### PR TITLE
Add execution of containerized UI E2E tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -116,7 +116,7 @@ deploy_ui: start_minikube
 	DEPLOY_TAG=$(DEPLOY_TAG) scripts/deploy_ui.sh
 
 test_ui: deploy_ui
-	DEPLOY_TAG=$(DEPLOY_TAG) scripts/test_ui.sh
+	DEPLOY_TAG=$(DEPLOY_TAG) PULL_SECRET=${PULL_SECRET} scripts/test_ui.sh
 
 kill_all_port_forwardings:
 	scripts/utils.sh kill_all_port_forwardings

--- a/Makefile
+++ b/Makefile
@@ -115,6 +115,9 @@ set_dns:
 deploy_ui: start_minikube
 	DEPLOY_TAG=$(DEPLOY_TAG) scripts/deploy_ui.sh
 
+test_ui: deploy_ui
+	DEPLOY_TAG=$(DEPLOY_TAG) scripts/test_ui.sh
+
 kill_all_port_forwardings:
 	scripts/utils.sh kill_all_port_forwardings
 

--- a/scripts/test_ui.sh
+++ b/scripts/test_ui.sh
@@ -34,6 +34,7 @@ mkdir -p ${SCREENSHOT_DIR}
 ${CONTAINER_COMMAND} run -it \
   -w /e2e \
   -e CYPRESS_BASE_URL="${CYPRESS_BASE_URL}" \
+  -e CYPRESS_PULL_SECRET="${PULL_SECRET}" \
   --security-opt label=disable \
   --mount type=bind,source=${VIDEO_DIR},target=/e2e/cypress/videos \
   --mount type=bind,source=${SCREENSHOT_DIR},target=/e2e/cypress/screenshots \

--- a/scripts/test_ui.sh
+++ b/scripts/test_ui.sh
@@ -1,0 +1,43 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+source scripts/utils.sh
+
+export NO_UI=${NO_UI:-n}
+if  [ "${NO_UI}" != "n" ];then
+    exit 0
+fi
+
+export NODE_IP=$(get_main_ip)
+export UI_PORT=${UI_PORT:-6008}
+export DEPLOY_TAG=${DEPLOY_TAG:-latest}
+export CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://${NODE_IP}:${UI_PORT}} # URL of running Metal3 Installer UI
+export TESTS_IMAGE=${TESTS_IMAGE:-"quay.io/ocpmetal/ocp-metal-ui-tests:${DEPLOY_TAG}"}
+export CONTAINER_COMMAND=${CONTAINER_COMMAND:-podman}
+export BASE_DIR=${BASE_DIR:-"`pwd`"/`date +%D_%T|sed 's/\//_/g'|sed 's/:/-/g'`} # where screenshots will be stored
+
+if [ "${CONTAINER_COMMAND}" = "podman" ]; then
+  export PODMAN_FLAGS="--pull=always"
+else
+  export PODMAN_FLAGS=""
+fi
+
+echo Connecting to UI at: ${CYPRESS_BASE_URL}
+echo Test image: ${TESTS_IMAGE}
+
+export VIDEO_DIR=${BASE_DIR}/videos
+export SCREENSHOT_DIR=${BASE_DIR}/screenshots
+
+mkdir -p ${VIDEO_DIR}
+mkdir -p ${SCREENSHOT_DIR}
+
+${CONTAINER_COMMAND} run -it \
+  -w /e2e \
+  -e CYPRESS_BASE_URL="${CYPRESS_BASE_URL}" \
+  --security-opt label=disable \
+  --mount type=bind,source=${VIDEO_DIR},target=/e2e/cypress/videos \
+  --mount type=bind,source=${SCREENSHOT_DIR},target=/e2e/cypress/screenshots \
+  "${TESTS_IMAGE}"
+
+echo Screenshots and videos can be found in ${BASE_DIR}
+


### PR DESCRIPTION
New `make test_ui` target is added.

Assuption prior executing the tests:
- clean environment produced by `make redeploy_all`, especially just a single `test-infra` cluster in the Ready state with 3 `Known` hosts.

Test execution needs to be fired manually so far. Once stabilized, they can be added as a mandatory target after UI deployment.

Optional parameters (env variables):
- `CYPRESS_BASE_URL` - URL of already running UI, default: `[NODE_IP]:[UI_PORT]`
- `PULL_SECRET` - content of the pull-secret file to enable installation test
- `BASE_DIR` - folder on local filesystem to store screenshots from test execution, default `./[date_time]`
- `DEPLOY_TAG` - usually either `latest` or `stable`, one from https://quay.io/repository/ocpmetal/ocp-metal-ui-tests?tab=tags

Additional info: 
- https://github.com/openshift-metal3/facet/pull/236
- https://issues.redhat.com/browse/MGMT-819