### PR TITLE
start_discovery: handle managed-dns-domains

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ ROUTE53_SECRET := $(or $(ROUTE53_SECRET), "")
 SHELL=/bin/sh
 CONTAINER_COMMAND = $(shell if [ -x "$(shell command -v docker)" ];then echo "docker" ; else echo "podman";fi)
 CLUSTER_NAME := $(or $(CLUSTER_NAME),test-infra-cluster)
+BASE_DNS_DOMAINS := $(or $(BASE_DNS_DOMAINS), ":")
 BASE_DOMAIN := $(or $(BASE_DOMAIN),redhat.com)
 NETWORK_CIDR := $(or $(NETWORK_CIDR),"192.168.126.0/24")
 CLUSTER_ID := $(or $(CLUSTER_ID), "")
@@ -135,7 +136,7 @@ install_cluster:
 #########
 
 _deploy_nodes:
-	discovery-infra/start_discovery.py -i $(ISO) -n $(NUM_MASTERS) -p $(STORAGE_POOL_PATH) -k '$(SSH_PUB_KEY)' -mm $(MASTER_MEMORY) -wm $(WORKER_MEMORY) -nw $(NUM_WORKERS) -ps '$(PULL_SECRET)' -bd $(BASE_DOMAIN) -cN $(CLUSTER_NAME) -vN $(NETWORK_CIDR) -nN $(NETWORK_NAME) -nB $(NETWORK_BRIDGE) -ov $(OPENSHIFT_VERSION) -rv $(RUN_WITH_VIPS) -iU $(REMOTE_INVENTORY_URL) -id $(CLUSTER_ID) $(ADDITIONAL_PARAMS)
+	discovery-infra/start_discovery.py -i $(ISO) -n $(NUM_MASTERS) -p $(STORAGE_POOL_PATH) -k '$(SSH_PUB_KEY)' -mm $(MASTER_MEMORY) -wm $(WORKER_MEMORY) -nw $(NUM_WORKERS) -ps '$(PULL_SECRET)' -bd $(BASE_DOMAIN) -cN $(CLUSTER_NAME) -vN $(NETWORK_CIDR) -nN $(NETWORK_NAME) -nB $(NETWORK_BRIDGE) -ov $(OPENSHIFT_VERSION) -rv $(RUN_WITH_VIPS) -iU $(REMOTE_INVENTORY_URL) -id $(CLUSTER_ID) -mD $(BASE_DNS_DOMAINS) $(ADDITIONAL_PARAMS)
 
 deploy_nodes_with_install:
 	skipper make _deploy_nodes ADDITIONAL_PARAMS=-in $(SKIPPER_PARAMS)
@@ -177,7 +178,7 @@ build_and_push_image:
 #######
 
 _download_iso:
-	discovery-infra/start_discovery.py -k '$(SSH_PUB_KEY)'  -ps '$(PULL_SECRET)' -bd $(BASE_DOMAIN) -cN $(CLUSTER_NAME) -ov $(OPENSHIFT_VERSION) -pU $(PROXY_URL) -iU $(REMOTE_INVENTORY_URL) -id $(CLUSTER_ID) -iO
+	discovery-infra/start_discovery.py -k '$(SSH_PUB_KEY)'  -ps '$(PULL_SECRET)' -bd $(BASE_DOMAIN) -cN $(CLUSTER_NAME) -ov $(OPENSHIFT_VERSION) -pU $(PROXY_URL) -iU $(REMOTE_INVENTORY_URL) -id $(CLUSTER_ID) -mD $(BASE_DNS_DOMAINS) -iO
 
 download_iso:
 	skipper make _download_iso $(SKIPPER_PARAMS)

--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -221,6 +221,9 @@ def nodes_flow(client, cluster_name, cluster):
 def main():
     client = None
     cluster = {}
+    if args.managed_dns_domains != ":":
+        args.cluster_name = ""
+        args.base_dns_domain = args.managed_dns_domains.split(':')[0]
     cluster_name = args.cluster_name or consts.CLUSTER_PREFIX + str(uuid.uuid4())[:8]
     # If image is passed, there is no need to create cluster and download image, need only to spawn vms with is image
     if not args.image:
@@ -310,6 +313,12 @@ if __name__ == "__main__":
         help="Base dns domain",
         type=str,
         default="redhat.com",
+    )
+    parser.add_argument(
+        "-mD", "--managed-dns-domains",
+        help="DNS domains that are managaed by bm-inventory, format: domain_name:domain_id/provider_type.",
+        type=str,
+        default=":"
     )
     parser.add_argument(
         "-cN", "--cluster-name", help="Cluster name", type=str, default=""

--- a/discovery-infra/update_bm_inventory_cm.py
+++ b/discovery-infra/update_bm_inventory_cm.py
@@ -21,7 +21,7 @@ ENVS = [
     ("INVENTORY_PORT", ""),
     ("AGENT_DOCKER_IMAGE", ""),
     ("KUBECONFIG_GENERATE_IMAGE", ""),
-    ("BASE_DNS_DOMAINS", ""),
+    ("BASE_DNS_DOMAINS", ":"),
 ]
 
 

--- a/scripts/assisted_deployment.sh
+++ b/scripts/assisted_deployment.sh
@@ -5,7 +5,7 @@ function destroy_all() {
 }
 
 function set_dns() {
-    if ! [ -z "$BASE_DNS_DOMAINS" ]; then
+    if [ $BASE_DNS_DOMAINS != ":" ]; then
         # DNS registration should be handled by inventory
         exit 0
     fi


### PR DESCRIPTION
In order to ensure registration of unique DNS records,
the cluster name should be randomly generated.
Hence, passed --managed-dns-domains to start_discovery.py
as an indication. Also, parsed the base domain from
args.managed_dns_domains map.