### PR TITLE
validate DNS authority using dnspython

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,7 @@
 
 bm-inventory-client==1.0.0
 boto3==1.13.11
+dnspython==1.16.0
 libvirt-python==4.5.0
 pre-commit==2.5.1
 pyyaml==5.3.1


### PR DESCRIPTION
Used dns.resolver (dnspython) to validate DNS authority and resolvability.

Note: added 'dnspython' package to requirements, so a new image of test-infra should be pushed to quay.