### PR TITLE
Check cluster state after install_cluster is called.

### DIFF
--- a/discovery-infra/consts.py
+++ b/discovery-infra/consts.py
@@ -8,6 +8,7 @@ IMAGE_PATH = "%s/installer-image.iso" % IMAGE_FOLDER
 STORAGE_PATH = "/var/lib/libvirt/openshift-images"
 SSH_KEY = "ssh_key/key.pub"
 NODES_REGISTERED_TIMEOUT = 180
+START_CLUSTER_INSTALLATION_TIMEOUT = 180
 TF_TEMPLATE = "terraform_files"
 STARTING_IP_ADDRESS = "192.168.126.10"
 NUMBER_OF_MASTERS = 3

--- a/discovery-infra/install_cluster.py
+++ b/discovery-infra/install_cluster.py
@@ -26,6 +26,12 @@ def verify_pull_secret(cluster, client, pull_secret):
 
 def _install_cluster(client, cluster):
     cluster = client.install_cluster(cluster_id=cluster.id)
+    utils.wait_till_cluster_is_in_status(
+        client=client,
+        cluster_id=cluster.id,
+        timeout=consts.START_CLUSTER_INSTALLATION_TIMEOUT,
+        statuses=[consts.ClusterStatus.INSTALLING],
+    )
     utils.wait_till_all_hosts_are_in_status(
         client=client,
         cluster_id=cluster.id,


### PR DESCRIPTION
To support asny install command first need to validate that cluster reached installing status