### PR TITLE
Update pre-commit plugins, enable shfmt, yaspeller and spellchecks fo…

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -4,7 +4,7 @@ repos:
     hooks:
       - id: check-useless-excludes
   - repo: https://github.com/prettier/prettier
-    rev: 2.0.2
+    rev: 2.0.5
     hooks:
       - id: prettier
         files: \.(css|js|md|markdown|json)
@@ -13,7 +13,7 @@ repos:
     hooks:
       - id: black
   - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+    rev: v3.2.0
     hooks:
       - id: check-added-large-files
       - id: check-ast
@@ -22,26 +22,39 @@ repos:
       - id: check-json
       - id: check-merge-conflict
       - id: check-symlinks
+      - id: check-vcs-permalinks
       - id: check-xml
       - id: check-yaml
         args: [--unsafe]
       - id: end-of-file-fixer
       - id: fix-encoding-pragma
       - id: forbid-new-submodules
+      - id: no-commit-to-branch
+        args: [--branch, master]
       - id: requirements-txt-fixer
       - id: sort-simple-yaml
       - id: trailing-whitespace
-  - repo: https://github.com/pre-commit/pre-commit-hooks
-    rev: v2.5.0
+  - repo: https://gitlab.com/pycqa/flake8
+    rev: 3.8.3
     hooks:
       - id: flake8
+  - repo: local
+    hooks:
+      - id: shfmt
+        name: shfmt
+        minimum_pre_commit_version: 2.4.0
+        language: golang
+        additional_dependencies: [mvdan.cc/sh/v3/cmd/shfmt@v3.1.1]
+        entry: shfmt
+        args: [-w, -i, "4"]
+        types: [shell]
   - repo: https://github.com/asottile/blacken-docs
-    rev:  v1.6.0
+    rev:  v1.7.0
     hooks:
       - id: blacken-docs
-# - repo: https://github.com/hcodes/yaspeller.git
-#   rev: v6.1.0
-#   hooks:
-#   - id: yaspeller
-#     files: ".md"
-#     types: [markdown]
+  - repo: https://github.com/hcodes/yaspeller.git
+    rev: v7.0.0
+    hooks:
+    - id: yaspeller
+      files: ".md"
+      types: [markdown]

--- a/.yaspeller.json
+++ b/.yaspeller.json
@@ -77,6 +77,15 @@
     "ipi",
     "versioned",
     "unversioned",
-    "devprev"
+    "devprev",
+    "CentOS",
+    "Dockerfile",
+    "UI",
+    "kubeconfig",
+    "libvirt",
+    "minikube",
+    "Parrilla",
+    "Parrilla's",
+    "ClusterId"
   ]
 }

--- a/GUIDE.md
+++ b/GUIDE.md
@@ -10,14 +10,14 @@
    - API VIP
    - Ingress VIP
      > NOTE: dnsmasq can be used to setup [DHCP](https://openshift-kni.github.io/baremetal-deploy/4.4/Deployment.html#creating-dhcp-reservations-using-dnsmasq-option2_ipi-install-prerequisites) and [DNS](https://openshift-kni.github.io/baremetal-deploy/4.4/Deployment.html#creating-dns-records-using-dnsmasq-option2_ipi-install-prerequisites). Out of scope for this document but I've included links on how to do it.
-1. Ensure these values are properly set via nslookup and dig commands from your assisted installer host
+1. Ensure these values are properly set via `nslookup` and dig commands from your assisted installer host
 1. Download your Pull Secret from https://cloud.redhat.com/openshift/install/metal/user-provisioned
 
 ## Deployment
 
 Procedure
 
-As `$USER` user with sudo privileges ,
+As `$USER` user with `sudo` privileges ,
 
 1.  Generate an SSH key if not already available (`ssh_key/key`)
 
@@ -46,7 +46,7 @@ As `$USER` user with sudo privileges ,
 
         [$USER@assisted_installer assisted-test-infra]# export OPENSHIFT_VERSION=4.6
 
-1.  Once complete, run the "run" using make that creates the bm-inventory and deploys the UI
+1.  Once complete, run the "run" using make that creates the `bm-inventory` and deploys the UI
 
         [$USER@assisted_installer assisted-test-infra]# make run
         .
@@ -72,15 +72,15 @@ As `$USER` user with sudo privileges ,
     - The **pull secret** would be the file contents you captured as a prerequisite.
     - The **SSH public key** would be the file contents of `~/.ssh/id_rsa.pub`
 
-    > NOTE: This screen also shows Available subnets, API Virtual IP and Ingress VIP VIP but these do not need to be set at this time of the install.
+    > NOTE: This screen also shows Available subnets, API Virtual IP and Ingress VIP but these do not need to be set at this time of the install.
 
     > NOTE: If you get `Value must be valid JSON` for your pull secret, make sure you are not surrounding your pull secret in tick marks `' '`
 
-    > NOTE: Make sure to delete any extra whitespaces when entering your pull secret and SSH key.
+    > NOTE: Make sure to delete any extra white spaces when entering your pull secret and SSH key.
 
 1. Once **Validate & Save Changes** has been clicked, click on the blue button labeled **Download discovery ISO** , and enter the HTTP Proxy URL (if required) and SSH public key using the host that is serving out the assisted installer UI. Click **Download Discovery ISO**. This will prepare the ISO and start the download
 
-   > NOTE: If you wish not to download the ISO on your current system but on a separate system, after you've initiated the download by clicking the button, you can cancel the download and run the following wget command.
+   > NOTE: If you wish not to download the ISO on your current system but on a separate system, after you've initiated the download by clicking the button, you can cancel the download and run the following `wget` command.
 
 
     > NOTE: This example installs ISO on the assisted installer host that will serve out the ISO via HTTP for the OpenShift cluster nodes.
@@ -96,7 +96,7 @@ As `$USER` user with sudo privileges ,
 
    > NOTE: Steps 14-18 only work on DELL hardware. A different method would need to be used if using a different vendor to mount your live ISO.
 
-1)  Create a webserver container labeled mywebserver that is to serve the `live.iso` from the `~/assisted-installer/images` directory serving out of port 8080 as follows
+1)  Create a web server container labeled `mywebserver` that is to serve the `live.iso` from the `~/assisted-installer/images` directory serving out of port 8080 as follows
 
         [$USER@assisted_installer ~]# firewall-cmd --add-port=8080/tcp --zone=public --permanent
         [$USER@assisted_installer ~]# firewall-cmd --reload

--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This project deploys the OpenShift Assisted Installer in Minikube and spawns lib
 - CentOS 8 or RHEL 8 host
 - File system that supports d_type
 - Ideally on a bare metal host with at least 64G of RAM.
-- Run as a user with passwordless sudo access or be ready to enter sudo password for prepare phase.
+- Run as a user with password-less `sudo` access or be ready to enter `sudo` password for prepare phase.
 - Get a valid pull secret (JSON string) from [redhat.com](https://cloud.redhat.com/openshift/install/pull-secret) if you want to test the installation (not needed for testing only the discovery flow). Export it as
 
 ```bash
@@ -48,16 +48,16 @@ The following is a list of stages that will be run:
 
 1. Start Minikube if not started yet
 1. Deploy services for assisted deployment on Minikube
-1. Create cluster in bm-inventory service
+1. Create cluster in `bm-inventory` service
 1. Download ISO image
-1. Spawn required number of VMs from downloaded ISO with parameters that can be configured by OS env (check makefile)
-1. Wait until nodes are up and registered in bm-inventory
-1. Set nodes roles in bm-inventory by matching VM names (worker/master)
+1. Spawn required number of VMs from downloaded ISO with parameters that can be configured by OS environment (check makefile)
+1. Wait until nodes are up and registered in `bm-inventory`
+1. Set nodes roles in `bm-inventory` by matching VM names (worker/master)
 1. Verify all nodes have required hardware to start installation
 1. Install nodes
-1. Download kubeconfig-noingress to build/kubeconfig
-1. Waiting till nodes are in "installed" state, while verifying that they don't move to "error" state
-1. Verifying cluster is in state "installed"
+1. Download `kubeconfig-noingress` to build/kubeconfig
+1. Waiting till nodes are in `installed` state, while verifying that they don't move to `error` state
+1. Verifying cluster is in state `installed`
 1. Download kubeconfig to build/kubeconfig
 
 **Note**: Please make sure no previous cluster is running before running a new one (it will rewrite its build files).
@@ -70,7 +70,7 @@ To run the full flow, including installation:
 make run_full_flow_with_install
 ```
 
-Or to run it together with create_full_environment (requires sudo password):
+Or to run it together with create_full_environment (requires `sudo` password):
 
 ```bash
 make all
@@ -104,7 +104,7 @@ make redeploy_all or make redeploy_all_with_install
 
 ## Cleaning
 
-Cleaning test-infra environment.
+Following sections show how to perform cleaning of test-infra environment.
 
 ### Clean all include minikube
 
@@ -118,7 +118,7 @@ make destroy
 make destroy_nodes
 ```
 
-### Delete all virsh resources
+### Delete all `virsh` resources
 
 Sometimes you may need to delete all libvirt resources
 
@@ -128,7 +128,7 @@ make delete_all_virsh_resources
 
 ### Install cluster
 
-Install cluster after nodes were deployed. Can take ClusterId as os env
+Install cluster after nodes were deployed. Can take ClusterId as OS environment
 
 ```bash
 make install_cluster
@@ -147,13 +147,13 @@ make run
 make deploy_monitoring
 ```
 
-### deploy_bm_inventory and Create cluster and download ISO
+### `deploy_bm_inventory` and Create cluster and download ISO
 
 ```bash
 make download_iso_for_remote_use
 ```
 
-### start_minikube and Deploy UI and and open port forwarding on port 6008, allows to connect to it from browser
+### start_minikube and Deploy UI and open port forwarding on port 6008, allows to connect to it from browser
 
 ```bash
 make deploy_ui
@@ -168,38 +168,37 @@ make kill_all_port_forwardings
 ## OS parameters used for configurations
 
 ```
-BMI_BRANCH                bm-inventory branch to use, default: master
-ISO                       path to ISO to spawn VM with, if set vms will be spawn with this iso without creating cluster. File must have the '.iso' suffix
-NUM_MASTERS               number of VMs to spawn as masters, default: 3
-WORKER_MEMORY             memory for worker VM, default: 8892MB
-MASTER_MEMORY             memory for master VM, default: 16984MB
-NUM_WORKERS               number of VMs to spawn as workers, default: 0
-SSH_PUB_KEY               SSH public key to use for image generation, gives option to SSH to VMs, default: ssh_key/key_pub
-PULL_SECRET               pull secret to use for cluster installation command, no option to install cluster without it.
-ROUTE53_SECRET            Amazon Route 53 secret to use for DNS domains registration.
-CLUSTER_NAME              cluster name, used as prefix for virsh resources, default: test-infra-cluster
-BASE_DOMAIN               base domain, needed for DNS name, default: redhat.com
-BASE_DNS_DOMAINS          base DNS domains that are managaed by bm-inventory, format: domain_name:domain_id/provider_type.
-NETWORK_CIDR              network cidr to use for virsh VM network, default: "192.168.126.0/24"
-CLUSTER_ID                cluster id , used for install_cluster command, default: the last spawned cluster
-NETWORK_NAME              virsh network name for VMs creation, default: test-infra-net
-NETWORK_MTU               virsh network MTU for VMs creation, default: 1500
-NETWORK_BRIDGE            network bridge to use while creating virsh network, default: tt0
-OPENSHIFT_VERSION         OpenShift version to install, default: "4.4"
-PROXY_URL:                proxy URL that will be pass to live cd image
-INVENTORY_URL:            update bm-inventory config map INVENTORY_URL param with given URL
-INVENTORY_PORT:           update bm-inventory config map INVENTORY_PORT with given port
-AGENT_DOCKER_IMAGE:       agent docker image to use, will update bm-inventory config map with given value
-INSTALLER_IMAGE:          assisted-installer image to use, will update bm-inventory config map with given value
-SERVICE:                  bm-inventory image to use
-DEPLOY_TAG:               the tag to be used for all images (bm-inventory, assisted-installer, agent, etc) this will override any other os params
+BMI_BRANCH          `bm-inventory` branch to use, default: master
+ISO                 path to ISO to spawn VM with, if set vms will be spawn with this iso without creating cluster. File must have the '.iso' suffix
+NUM_MASTERS         number of VMs to spawn as masters, default: 3
+WORKER_MEMORY       memory for worker VM, default: 8892MB
+MASTER_MEMORY       memory for master VM, default: 16984MB
+NUM_WORKERS         number of VMs to spawn as workers, default: 0
+SSH_PUB_KEY         SSH public key to use for image generation, gives option to SSH to VMs, default: ssh_key/key_pub
+PULL_SECRET         pull secret to use for cluster installation command, no option to install cluster without it.
+ROUTE53_SECRET      Amazon Route 53 secret to use for DNS domains registration.
+CLUSTER_NAME        cluster name, used as prefix for `virsh` resources, default: test-infra-cluster
+BASE_DOMAIN         base domain, needed for DNS name, default: `redhat.com`
+BASE_DNS_DOMAINS    base DNS domains that are managed by `bm-inventory`, format: domain_name:domain_id/provider_type.
+NETWORK_CIDR        network cidr to use for `virsh` VM network, default: "192.168.126.0/24"
+CLUSTER_ID          cluster id, used for install_cluster command, default: the last spawned cluster
+NETWORK_NAME        `virsh` network name for VMs creation, default: test-infra-net
+NETWORK_BRIDGE      network bridge to use while creating `virsh` network, default: tt0
+OPENSHIFT_VERSION   OpenShift version to install, default: "4.4"
+PROXY_URL:          proxy URL that will be pass to live cd image
+INVENTORY_URL:      update `bm-inventory` config map INVENTORY_URL param with given URL
+INVENTORY_PORT:     update `bm-inventory` config map INVENTORY_PORT with given port
+AGENT_DOCKER_IMAGE: agent docker image to use, will update `bm-inventory` config map with given value
+INSTALLER_IMAGE:    assisted-installer image to use, will update `bm-inventory` config map with given value
+SERVICE:            `bm-inventory` image to use
+DEPLOY_TAG:         the tag to be used for all images (`bm-inventory`, assisted-installer, agent, etc) this will override any other OS params
 IMAGE_BUILDER:            image-builder image to use, will update bm-inventory config map with given value
 CONNECTIVITY_CHECK_IMAGE  connectivity-check image to use, will update bm-inventory config map with given value
 HARDWARE_INFO_IMAGE       hardware-info image to use, will update bm-inventory config map with given value
 INVENTORY_IMAGE           bm-inventory image to be updated in bm-inventory config map with given value
 ```
 
-## Test bm-inventory image
+## Test `bm-inventory` image
 
 ```bash
 make redeploy_all SERVICE=<image to test>
@@ -223,7 +222,7 @@ or
 export PULL_SECRET='<pull secret JSON>'; make redeploy_all_with_install INSTALLER_IMAGE=<image to test> CONTROLLER_IMAGE=<image to test>
 ```
 
-## Test installer, controller, bm-inventory and agent images in the same flow
+## Test installer, controller, `bm-inventory` and agent images in the same flow
 
 ```bash
 make redeploy_all INSTALLER_IMAGE=<image to test> AGENT_DOCKER_IMAGE=<image to test> SERVICE=<image to test>
@@ -239,7 +238,7 @@ Assisted-test-infra builds an image including all the prerequisites to handle th
 make image_build
 ```
 
-# In case you would like to build the image with a different bm-inventory client
+# In case you would like to build the image with a different `bm-inventory` client
 
 ```bash
 make image_build SERVICE=<bm inventory image URL>

--- a/scripts/test_ui.sh
+++ b/scripts/test_ui.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 source scripts/utils.sh
 
 export NO_UI=${NO_UI:-n}
-if  [ "${NO_UI}" != "n" ];then
+if [ "${NO_UI}" != "n" ]; then
     exit 0
 fi
 
@@ -14,12 +14,12 @@ export DEPLOY_TAG=${DEPLOY_TAG:-latest}
 export CYPRESS_BASE_URL=${CYPRESS_BASE_URL:-http://${NODE_IP}:${UI_PORT}} # URL of running Metal3 Installer UI
 export TESTS_IMAGE=${TESTS_IMAGE:-"quay.io/ocpmetal/ocp-metal-ui-tests:${DEPLOY_TAG}"}
 export CONTAINER_COMMAND=${CONTAINER_COMMAND:-podman}
-export BASE_DIR=${BASE_DIR:-"`pwd`"/`date +%D_%T|sed 's/\//_/g'|sed 's/:/-/g'`} # where screenshots will be stored
+export BASE_DIR=${BASE_DIR:-"$(pwd)"/$(date +%D_%T | sed 's/\//_/g' | sed 's/:/-/g')} # where screenshots will be stored
 
 if [ "${CONTAINER_COMMAND}" = "podman" ]; then
-  export PODMAN_FLAGS="--pull=always"
+    export PODMAN_FLAGS="--pull=always"
 else
-  export PODMAN_FLAGS=""
+    export PODMAN_FLAGS=""
 fi
 
 echo Connecting to UI at: ${CYPRESS_BASE_URL}
@@ -32,12 +32,12 @@ mkdir -p ${VIDEO_DIR}
 mkdir -p ${SCREENSHOT_DIR}
 
 ${CONTAINER_COMMAND} run -it \
-  -w /e2e \
-  -e CYPRESS_BASE_URL="${CYPRESS_BASE_URL}" \
-  -e CYPRESS_PULL_SECRET="${PULL_SECRET}" \
-  --security-opt label=disable \
-  --mount type=bind,source=${VIDEO_DIR},target=/e2e/cypress/videos \
-  --mount type=bind,source=${SCREENSHOT_DIR},target=/e2e/cypress/screenshots \
-  "${TESTS_IMAGE}"
+    -w /e2e \
+    -e CYPRESS_BASE_URL="${CYPRESS_BASE_URL}" \
+    -e CYPRESS_PULL_SECRET="${PULL_SECRET}" \
+    --security-opt label=disable \
+    --mount type=bind,source=${VIDEO_DIR},target=/e2e/cypress/videos \
+    --mount type=bind,source=${SCREENSHOT_DIR},target=/e2e/cypress/screenshots \
+    "${TESTS_IMAGE}"
 
 echo Screenshots and videos can be found in ${BASE_DIR}


### PR DESCRIPTION
This commit will:
- update pre-commit plugins (`pre-commit autoupdate`)
- enable yaspeller in TODO (for spell checking MD files)
- add words to .yaspeller dictionary and fix typos, etc on markdown files
- enable shfmt for formatting 'shell' files
- commit the pre-commit recommendations to have pre-commit pass