### PR TITLE
Make /etc/passwd writable to allow SSH from a pod

### DIFF
--- a/Dockerfile.test-infra
+++ b/Dockerfile.test-infra
@@ -18,5 +18,8 @@ COPY --from=inventory /clients/bm-inventory-client-*.tar.gz /build/pip/
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
     find /build/pip/ -name 'setup.py' -exec dirname {} \; | xargs pip3 install
 
+# TODO: Remove once OpenShift CI will be upgraded to 4.2 (see https://access.redhat.com/articles/4859371)
+RUN chmod uga+w /etc/passwd
+
 # setting pre-commit env
 ENV PRE_COMMIT_HOME build


### PR DESCRIPTION
There’s a known issue [“scp / sftp / ssh from an OpenShift Pod gives an error "No user exists for uid $someUid"”](https://access.redhat.com/solutions/4665281).
To overcome it there are multiple approaches each project configuration solves differently.
* Make /etc/passwd writable
* Add the UID to /etc/passwd

Sources:
https://access.redhat.com/articles/4859371