### PR TITLE
Adding the deployment of monitoring used on bm-inventory repo

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -181,6 +181,9 @@ deploy_bm_inventory: start_minikube bring_bm_inventory
 bring_bm_inventory:
 	@if cd bm-inventory >/dev/null 2>&1; then git fetch --all && git reset --hard origin/$(BMI_BRANCH); else git clone --branch $(BMI_BRANCH) https://github.com/filanov/bm-inventory;fi
 
+deploy_monitoring: bring_bm_inventory
+	make -C bm-inventory/ deploy-monitoring
+
 clear_inventory:
 	make -C bm-inventory/ clear-deployment
 

--- a/README.md
+++ b/README.md
@@ -140,6 +140,13 @@ make install_cluster
 make download_iso
 ```
 
+### Deploy BM Inventory and Monitoring stack
+
+```bash
+make run
+make deploy_monitoring
+```
+
 ### deploy_bm_inventory and Create cluster and download ISO
 
 ```bash


### PR DESCRIPTION
- Added new target called `make deploy_monitoring` on the `Makefile` that involves the deployment of Grafana and Prometheus used on [bm-inventory repo](https://github.com/filanov/bm-inventory/#deploy-monitoring) directly from test-infra repo