### PR TITLE
MGMT-1668: Automatic port allocation per namespace

### DIFF
--- a/scripts/deploy_bm_inventory.sh
+++ b/scripts/deploy_bm_inventory.sh
@@ -18,7 +18,7 @@ skipper run "make -C bm-inventory/ deploy-all" ${SKIPPER_PARAMS} DEPLOY_TAG=${DE
 print_log "Wait till ${SERVICE_NAME} api is ready"
 wait_for_url_and_run "$(minikube service ${SERVICE_NAME} --url -n ${NAMESPACE})" "echo \"waiting for ${SERVICE_NAME}\""
 
-print_log "Starting port forwarding for deployment/${SERVICE_NAME}"
+print_log "Starting port forwarding for deployment/${SERVICE_NAME} port: $INVENTORY_PORT"
 wait_for_url_and_run "http://${INVENTORY_URL}:${INVENTORY_PORT}" "spawn_port_forwarding_command ${SERVICE_NAME} ${INVENTORY_PORT}"
 print_log "${SERVICE_NAME} can be reached at http://${INVENTORY_URL}:${INVENTORY_PORT} "
 print_log "Done"

--- a/scripts/deploy_ui.sh
+++ b/scripts/deploy_ui.sh
@@ -34,7 +34,7 @@ kubectl --kubeconfig=${KUBECONFIG} apply -f ${UI_DEPLOY_FILE}
 print_log "Wait till ui api is ready"
 wait_for_url_and_run "$(minikube service ${UI_SERVICE_NAME} -n ${NAMESPACE} --url)" "echo \"waiting for ${UI_SERVICE_NAME}\""
 
-print_log "Starting port forwarding for deployment/${UI_SERVICE_NAME}"
+print_log "Starting port forwarding for deployment/${UI_SERVICE_NAME} port: $UI_PORT"
 wait_for_url_and_run "http://${NODE_IP}:${UI_PORT}" "spawn_port_forwarding_command ${UI_SERVICE_NAME} ${UI_PORT}"
 print_log "OCP METAL UI can be reached at http://${NODE_IP}:${UI_PORT}"
 print_log "Done"


### PR DESCRIPTION
MGMT-1668: Automatic port allocation per namespace

We want to be able to run multiple namespaces on same hosts.
Currently it is possible, but the external ports of the uis
and inventories of each namespace overrides the connection
of each other (6000 for inventory, 6008 to ui).

In order to be able to expose all ports, added bash logic
that:
1. checks for the next free port for a service, by a given
start port.
2. xinetd files and services names will be unique also by
namespaces, so services from different namespaces won't
override each other.
3. deletes previews allocated port per namespace (if exist).
In case we deploy same namespace twice, we want to reuse the
same port.