### PR TITLE
Updating Ansible playbook to support SuperMicro

### DIFF
--- a/.yaspeller.json
+++ b/.yaspeller.json
@@ -86,6 +86,14 @@
     "minikube",
     "Parrilla",
     "Parrilla's",
-    "ClusterId"
+    "ClusterId",
+    "BMI",
+    "OPENSHIFT",
+    "virsh",
+    "iso",
+    "vms",
+    "ssh",
+    "cd",
+    "os"
   ]
 }

--- a/README.md
+++ b/README.md
@@ -66,22 +66,22 @@ Check the [Install Guide](GUIDE.md) for installation instructions.
 | ROUTE53_SECRET           | Amazon Route 53 secret to use for DNS domains registration.                                                                     |
 | CLUSTER_NAME             | cluster name, used as prefix for virsh resources, default: test-infra-cluster                                                   |
 | BASE_DOMAIN              | base domain, needed for DNS name, default: redhat.com                                                                           |
-| BASE_DNS_DOMAINS         | base DNS domains that are managaed by assisted-service, format: domain_name:domain_id/provider_type.                                |
-| NETWORK_CIDR             | network cidr to use for virsh VM network, default: "192.168.126.0/24"                                                           |
+| BASE_DNS_DOMAINS         | base DNS domains that are managed by assisted-service, format: domain_name:domain_id/provider_type.                             |
+| NETWORK_CIDR             | network CIDR to use for virsh VM network, default: "192.168.126.0/24"                                                           |
 | CLUSTER_ID               | cluster id , used for install_cluster command, default: the last spawned cluster                                                |
 | NETWORK_NAME             | virsh network name for VMs creation, default: test-infra-net                                                                    |
 | NETWORK_BRIDGE           | network bridge to use while creating virsh network, default: tt0                                                                |
 | OPENSHIFT_VERSION        | OpenShift version to install, default: "4.4"                                                                                    |
 | PROXY_URL                | proxy URL that will be pass to live cd image                                                                                    |
-| SERVICE_BASE_URL         | update assisted-service config map SERVICE_BASE_URL param with given URL, including port and protocol
-| AGENT_DOCKER_IMAGE       | agent docker image to use, will update assisted-service config map with given value                                                 |
-| INSTALLER_IMAGE          | assisted-installer image to use, will update assisted-service config map with given value                                           |
-| SERVICE                  | assisted-service image to use                                                                                                       |
-| DEPLOY_TAG               | the tag to be used for all images (assisted-service, assisted-installer, agent, etc) this will override any other os params         |
-| IMAGE_BUILDER            | image-builder image to use, will update assisted-service config map with given value                                                |
-| CONNECTIVITY_CHECK_IMAGE | connectivity-check image to use, will update assisted-service config map with given value                                           |
-| HARDWARE_INFO_IMAGE      | hardware-info image to use, will update assisted-service config map with given value                                                |
-| INVENTORY_IMAGE          | assisted-service image to be updated in assisted-service config map with given value                                                    |
+| SERVICE_BASE_URL         | update assisted-service config map SERVICE_BASE_URL parameter with given URL, including port and protocol                       |
+| AGENT_DOCKER_IMAGE       | agent docker image to use, will update assisted-service config map with given value                                             |
+| INSTALLER_IMAGE          | assisted-installer image to use, will update assisted-service config map with given value                                       |
+| SERVICE                  | assisted-service image to use                                                                                                   |
+| DEPLOY_TAG               | the tag to be used for all images (assisted-service, assisted-installer, agent, etc) this will override any other os parameters |
+| IMAGE_BUILDER            | image-builder image to use, will update assisted-service config map with given value                                            |
+| CONNECTIVITY_CHECK_IMAGE | connectivity-check image to use, will update assisted-service config map with given value                                       |
+| HARDWARE_INFO_IMAGE      | hardware-info image to use, will update assisted-service config map with given value                                            |
+| INVENTORY_IMAGE          | assisted-service image to be updated in assisted-service config map with given value                                            |
 
 ## Instructions
 

--- a/ansible-bm-install/README.adoc
+++ b/ansible-bm-install/README.adoc
@@ -242,6 +242,10 @@ cluster_name="openshift"
 # Contents of the pull-secret.txt file
 pull_secret="{{ lookup('file', './pull_secret.txt') }}"
 
+# Provide Remote Service URL and port
+#e.g. remote_service_url="http://example.com:6000
+remote_service_url=""
+
 # Version of the openshift-installer, undefined or empty results in the playbook failing.
 openshift_version="4.5"
 
@@ -295,6 +299,10 @@ cluster_name="openshift"
 
 # Contents of the pull-secret.txt file
 pull_secret="{{ lookup('file', './pull_secret.txt') }}"
+
+# Provide Remote Service URL and port
+#e.g. remote_service_url="http://example.com:6000
+remote_service_url=""
 
 # Version of the openshift-installer, undefined or empty results in the playbook failing.
 openshift_version="4.5"

--- a/ansible-bm-install/collections/ansible_collections/okd/assisted_installer/roles/boot_iso/tasks/boot_iso.yml
+++ b/ansible-bm-install/collections/ansible_collections/okd/assisted_installer/roles/boot_iso/tasks/boot_iso.yml
@@ -109,7 +109,22 @@
         body: {}
         body_format: json
         validate_certs: no
-        status_code: [200,202,204]
+        force_basic_auth: yes
+        return_content: yes
+
+    - name: Patching Host and Path for Mounting ISO
+      uri:
+        url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Managers/1/VM1/CfgCD"
+        user: "{{ hostvars[item]['bmc_user'] }}"
+        password: "{{ hostvars[item]['bmc_password'] }}"
+        method: PATCH
+        headers:
+          content-type: application/json
+          Accept: application/json
+        body: "{\"Host\": \"{{ groups['assisted_installer'][0] }}\", \"Path\": \"\\\\share\\\\installer-image.iso\"}"
+        body_format: json
+        force_basic_auth: yes
+        validate_certs: no
         return_content: yes
 
     - name: Mount SuperMicro ISO
@@ -117,13 +132,43 @@
         url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Managers/1/VM1/CfgCD/Actions/IsoConfig.Mount"
         user: "{{ hostvars[item]['bmc_user'] }}"
         password: "{{ hostvars[item]['bmc_password'] }}"
+        method: POST
+        headers:
+          content-type: application/json
+          Accept: application/json
+        body: {}
+        body_format: json
+        validate_certs: no
+        force_basic_auth: yes
+        return_content: yes
+
+    - name: Set Boot for the SuperMicro
+      uri:
+        url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Systems/1"
+        user: "{{ hostvars[item]['bmc_user'] }}"
+        password: "{{ hostvars[item]['bmc_password'] }}"
         method: PATCH
         headers:
           content-type: application/json
           Accept: application/json
-        body: {"Host": "{{ groups['assisted_installer'][0] }}:8080","Path": "\\ISO\\installer-image.iso"}
+        body: '{"Boot":{"BootSourceOverrideEnabled":"Once","BootSourceOverrideTarget":"UsbCd"}}'
         body_format: json
+        force_basic_auth: yes
         validate_certs: no
-        status_code: [200,202,204]
+        return_content: yes
+
+    - name: Restart the SuperMicro
+      uri:
+        url: "https://{{ hostvars[item]['bmc_address'] }}/redfish/v1/Systems/1/Actions/ComputerSystem.Reset"
+        user: "{{ hostvars[item]['bmc_user'] }}"
+        password: "{{ hostvars[item]['bmc_password'] }}"
+        method: POST
+        headers:
+          content-type: application/json
+          Accept: application/json
+        body: '{"ResetType": "ForceRestart"}'
+        body_format: json
+        force_basic_auth: yes
+        validate_certs: no
         return_content: yes
   when: hostvars[item]['vendor'] == 'SuperMicro'

--- a/ansible-bm-install/collections/ansible_collections/okd/assisted_installer/roles/create_iso/tasks/main.yml
+++ b/ansible-bm-install/collections/ansible_collections/okd/assisted_installer/roles/create_iso/tasks/main.yml
@@ -38,7 +38,7 @@
     PULL_SECRET: "{{ pull_secret|to_json }}"
     OPENSHIFT_VERSION: "{{ openshift_version|quote }}"
     CLUSTER_ID: "{{ cluster_id | quote }}"
-    REMOTE_SERVICE_URL: "http://{{ groups['assisted_installer'][0] }}:{{ remote_inventory_port }}"
+    REMOTE_SERVICE_URL: "{{ remote_service_url }}"
     SSH_PUB_KEY: "{{ key.content | b64decode|trim }}"
     PROXY_URL: "{{ proxy_url | quote }}"
     BASE_DNS_DOMAINS: "{{ domain | quote }}"

--- a/ansible-bm-install/collections/ansible_collections/okd/assisted_installer/roles/host_iso/tasks/main.yml
+++ b/ansible-bm-install/collections/ansible_collections/okd/assisted_installer/roles/host_iso/tasks/main.yml
@@ -15,6 +15,8 @@
     state: started
     enabled: yes
   become: yes
+  tags:
+  - host_iso
 
 - name: Open port {{ webserver_port }}/tcp, zone public, for podman container
   firewalld:
@@ -24,6 +26,22 @@
     zone: "public"
     immediate: yes
   become: yes
+  tags:
+  - host_iso
+
+- name: Enable samba and samba-client for podman container
+  firewalld:
+    service: "{{ item }}"
+    permanent: yes
+    state: enabled
+    zone: "public"
+    immediate: yes
+  loop:
+    - "samba"
+    - "samba-client"
+  become: yes
+  tags:
+  - host_iso
 
 - name: Start RHCOS image cache container
   containers.podman.podman_container:
@@ -34,5 +52,24 @@
     volumes:
       - "{{ iso_image_location }}:/var/www/html:z"
   become: yes
+  tags:
+  - host_iso
+
+- name: Start samba container
+  containers.podman.podman_container:
+    name: samba_share
+    image: dperson/samba
+    state: started
+    volumes:
+      - "{{ iso_image_location }}:/share:z"
+    env:
+      USERID: 1002
+      GROUPID: 64003
+    ports:
+      - "138:138/udp"
+      - "137:137/udp"
+      - "445:445"
+      - "139:139"
+    command: ['-n', '-s', 'share;/share;yes;yes;yes;all;none;none;Shared_files', '-p', '-g', 'usershare allow guests = yes', '-g', 'map to guest = bad user', '-g', 'load printers = no', '-g', 'printcap cache time = 0', '-g', 'printing = bsd', '-g', 'printcap name = /dev/null', '-g','disable spoolss = yes', '-g', 'server min protocol = NT1']
   tags:
   - host_iso

--- a/ansible-bm-install/collections/ansible_collections/okd/assisted_installer/roles/validations/tasks/main.yml
+++ b/ansible-bm-install/collections/ansible_collections/okd/assisted_installer/roles/validations/tasks/main.yml
@@ -26,3 +26,9 @@
   with_items:
   - "{{ groups['masters'] }}"
   - "{{ groups['workers'] | default([]) }}"
+
+- name: Fail if remote_service_url is empty
+  fail:
+    msg: |
+         The remote service URL is empty. Need a value similar to http://example.com:6000
+  when: remote_service_url|length == 0

--- a/ansible-bm-install/inventory/hosts_with_os.sample
+++ b/ansible-bm-install/inventory/hosts_with_os.sample
@@ -13,6 +13,10 @@ cluster_name="openshift"
 # Contents of the pull-secret.txt file
 pull_secret="{{ lookup('file', './pull_secret.txt') }}"
 
+# Provide Remote Service URL and port
+#e.g. remote_service_url: "http://example.com:6000
+remote_service_url=""
+
 # Version of the openshift-installer, undefined or empty results in the playbook failing.
 openshift_version="4.5"
 

--- a/ansible-bm-install/inventory/hosts_without_os.sample
+++ b/ansible-bm-install/inventory/hosts_without_os.sample
@@ -13,6 +13,10 @@ cluster_name="openshift"
 # Contents of the pull-secret.txt file
 pull_secret="{{ lookup('file', './pull_secret.txt') }}"
 
+# Provide Remote Service URL and port
+#e.g. remote_service_url: "http://example.com:6000
+remote_service_url=""
+
 # Version of the openshift-installer, undefined or empty results in the playbook failing.
 openshift_version="4.5"
 


### PR DESCRIPTION
Added samba share for mounting ISO for SuperMicro servers, added commands to properly mount and boot an ISO for supermicroservers, modified REMOTE_INVENTORY_URL to REMOTE_SERVICE_URL parameter for creating ISO, REMOTE_SERVICE_URL part of the inventory/hosts file for easy modification of your environment