### PR TITLE
Refresh token early to be resilient to time skew

### DIFF
--- a/discovery-infra/assisted_service_api.py
+++ b/discovery-infra/assisted_service_api.py
@@ -40,9 +40,9 @@ class InventoryClient(object):
 
                 expires_on = json.loads(base64.b64decode(segment))['exp']
 
-                # if this key doesn't expire or if it has more than 30 seconds left, don't refresh
+                # if this key doesn't expire or if it has more than 10 minutes left, don't refresh
                 remaining = expires_on - time.time()
-                if expires_on == 0 or remaining > 30:
+                if expires_on == 0 or remaining > 600:
                     return
 
             # fetch new key if expired or not set yet


### PR DESCRIPTION
When testing this, the jenkins worker node was 3-5 minutes behind
the correct time. This meant that we thought the token was still
valid when it was not.