### PR TITLE
MGMT-1883 - Update the install config before installing the cluster

### DIFF
--- a/discovery-infra/assisted_service_api.py
+++ b/discovery-infra/assisted_service_api.py
@@ -196,6 +196,10 @@ class InventoryClient(object):
         with open(output_file, "wb") as _file:
             _file.write(response.data)
 
+    def update_cluster_install_config(self, cluster_id, update_params):
+        log.info("Updating cluster install config with %s", update_params)
+        return self.client.update_cluster_install_config(cluster_id, json.dumps(update_params))
+
 
 def create_client(url, wait_for_api=True):
     log.info('Creating assisted-service client for url: %s', url)

--- a/discovery-infra/install_cluster.py
+++ b/discovery-infra/install_cluster.py
@@ -75,6 +75,7 @@ def wait_till_installed(client, cluster, timeout=60 * 60 * 2):
 def run_install_flow(client, cluster_id, kubeconfig_path, pull_secret):
     log.info("Verifying cluster exists")
     cluster = client.cluster_get(cluster_id)
+    client.update_cluster_install_config(cluster_id, {"networking": {"networkType": "OpenShiftSDN"}})
     log.info("Verifying pull secret")
     verify_pull_secret(client=client, cluster=cluster, pull_secret=pull_secret)
     log.info("Wait till cluster is ready")


### PR DESCRIPTION
This issues an update which should have no effect as it matches the
current default, but it will test the API and that the override logic
doesn't throw any errors.

@romfreiman is this what you had in mind?