### PR TITLE
MGMT-2044: Deploy nodes without ssl verification

### DIFF
--- a/discovery-infra/utils.py
+++ b/discovery-infra/utils.py
@@ -289,5 +289,5 @@ def get_local_assisted_service_url(namespace, service):
 
 
 def is_assisted_service_reachable(url):
-    r = requests.get(url + '/health', timeout=10)
+    r = requests.get(url + '/health', timeout=10, verify=False)
     return r.status_code == 200


### PR DESCRIPTION
Communication with assisted-service on PSI changed to use ssl.

This cause certificate errors in the nodes deployment against assisted-service on PSI.

 