### PR TITLE
fix pip3 install to support non root

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -69,7 +69,7 @@ function install_packages() {
     sudo systemctl enable --now xinetd
 
     echo "Installing pip packages"
-    pip3 install filelock
+    pip3 install --user filelock
 }
 
 function install_skipper() {


### PR DESCRIPTION
otherwise this fails with:
PermissionError: [Errno 13] Permission denied: '/usr/local/lib/python3.6'