### PR TITLE
Added deploy-target argument to deploy_nodes and install_cluster

### DIFF
--- a/discovery-infra/delete_nodes.py
+++ b/discovery-infra/delete_nodes.py
@@ -172,6 +172,12 @@ if __name__ == "__main__":
         type=str,
         default='assisted-installer'
     )
+    parser.add_argument(
+        '--deploy-target',
+        help='Where assisted-service is deployed',
+        type=str,
+        default='minikube'
+    )
     oc_utils.extend_parser_with_oc_arguments(parser)
     args = parser.parse_args()
     main()

--- a/discovery-infra/install_cluster.py
+++ b/discovery-infra/install_cluster.py
@@ -192,6 +192,12 @@ if __name__ == "__main__":
         type=str,
         default='assisted-installer'
     )
+    parser.add_argument(
+        '--deploy-target',
+        help='Where assisted-service is deployed',
+        type=str,
+        default='minikube'
+    )
     oc_utils.extend_parser_with_oc_arguments(parser)
     args = parser.parse_args()
     main()


### PR DESCRIPTION
Since it is required for creating the assisted-service client in local mode.

Traceback (most recent call last):
  File "/home/raz/go/src/assisted-test-infra/discovery-infra/utils.py", line 396, in wrapped
    return fn(*args, **kwargs)
  File "discovery-infra/delete_nodes.py", line 29, in try_to_delete_cluster
    url=utils.get_assisted_service_url_by_args(args=args, wait=False)
  File "/home/raz/go/src/assisted-test-infra/discovery-infra/utils.py", line 301, in get_assisted_service_url_by_args
    kwargs['deploy_target'] = args.deploy_target
AttributeError: 'Namespace' object has no attribute 'deploy_target'