### PR TITLE
MGMT-2462 AI on OCP cluster

### DIFF
--- a/discovery-infra/ocp.py
+++ b/discovery-infra/ocp.py
@@ -1,0 +1,85 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import argparse
+import day2
+import utils
+import oc_utils
+import assisted_service_api
+import consts
+import sys
+
+
+def get_ocp_cluster(args):
+    if not args.cluster_id:
+        cluster_name = f'{args.cluster_name or consts.CLUSTER_PREFIX}-{args.namespace}'
+        tf_folder = utils.get_tf_folder(cluster_name, args.namespace)
+        args.cluster_id = utils.get_tfvars(tf_folder)['cluster_inventory_id']
+    client = assisted_service_api.create_client(
+            url=utils.get_assisted_service_url_by_args(args=args)
+    )
+    return client.cluster_get(cluster_id=args.cluster_id)
+
+def main(args):
+    if args.config_etc_hosts:
+        ocp_cluster = get_ocp_cluster(args)
+        ocp_cluster_name = ocp_cluster.name
+        ocp_api_vip_dnsname = f"api.{ocp_cluster_name}.{ocp_cluster.base_dns_domain}"
+        day2.config_etc_hosts(ocp_cluster.api_vip, ocp_api_vip_dnsname)
+    if args.get_cluster_api_vip:
+        ocp_cluster = get_ocp_cluster(args)
+        sys.stdout.write(ocp_cluster.api_vip)
+
+
+if __name__ == "__main__":
+    parser = argparse.ArgumentParser(description="OCP")
+    parser.add_argument(
+        "-id", "--cluster-id",
+        help="Cluster id to install",
+        type=str,
+        default=None
+    )
+    parser.add_argument(
+        "-cn", "--cluster-name",
+        help="Cluster name",
+        type=str,
+        default=""
+    )
+    parser.add_argument(
+        "-ns",
+        "--namespace",
+        help="Namespace to use",
+        type=str,
+        default="assisted-installer",
+    )
+    parser.add_argument(
+        '--service-name',
+        help='Override assisted-service target service name',
+        type=str,
+        default='assisted-service'
+    )
+    parser.add_argument(
+        '--profile',
+        help='Minikube profile for assisted-installer deployment',
+        type=str,
+        default='assisted-installer'
+    )
+    parser.add_argument(
+        '--deploy-target',
+        help='Where assisted-service is deployed',
+        type=str,
+        default='ocp'
+    )
+    parser.add_argument(
+        "--config-etc-hosts",
+        help="Config /etc/hosts file",
+        action="store_true"
+    )
+    parser.add_argument(
+        "--get-cluster-api-vip",
+        help="Get OCP cluster API VIP",
+        action="store_true"
+    )
+    oc_utils.extend_parser_with_oc_arguments(parser)
+    args = parser.parse_args()
+    main(args)

--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -11,6 +11,8 @@ export SERVICE_PORT=$(( 6000 + $NAMESPACE_INDEX ))
 export SERVICE_BASE_URL=${SERVICE_BASE_URL:-"http://${SERVICE_URL}:${SERVICE_PORT}"}
 export EXTERNAL_PORT=${EXTERNAL_PORT:-y}
 export PROFILE=${PROFILE:-assisted-installer}
+export OCP_SERVICE_PORT=$(( 7000 + $NAMESPACE_INDEX ))
+export SERVICE_ONPREM=quay.io/ocpmetal/assisted-service-onprem:latest
 
 mkdir -p build
 
@@ -18,6 +20,16 @@ if [ "${DEPLOY_TARGET}" == "podman-localhost" ]; then
     sed -i "s/SERVICE_BASE_URL=http:\/\/127.0.0.1/SERVICE_BASE_URL=http:\/\/${ASSISTED_SERVICE_HOST}/" assisted-service/onprem-environment
     echo "HW_VALIDATOR_MIN_DISK_SIZE_GIB=20" >> assisted-service/onprem-environment
     make -C assisted-service/ deploy-onprem
+elif [ "${DEPLOY_TARGET}" == "ocp" ]; then
+    print_log "Starting port forwarding for deployment/$SERVICE_NAME on port $OCP_SERVICE_PORT"
+    add_firewalld_port $OCP_SERVICE_PORT
+
+    OCP_BASE_URL=http://$SERVICE_URL:$OCP_SERVICE_PORT
+	IP_NODEPORT=$(skipper run "scripts/ocp.sh deploy_service $OCP_KUBECONFIG $SERVICE_ONPREM $SERVICE_NAME $OCP_BASE_URL $NAMESPACE")
+    read -r CLUSTER_VIP SERVICE_NODEPORT <<< "$IP_NODEPORT"
+
+    wait_for_url_and_run "$OCP_BASE_URL" "spawn_port_forwarding_command $SERVICE_NAME $OCP_SERVICE_PORT $NAMESPACE $NAMESPACE_INDEX $PROFILE $OCP_KUBECONFIG ocp $CLUSTER_VIP $SERVICE_NODEPORT"
+    print_log "${SERVICE_NAME} can be reached at http://${SERVICE_URL}:${OCP_SERVICE_PORT}"
 else
     print_log "Updating assisted_service params"
     skipper run discovery-infra/update_assisted_service_cm.py ENABLE_AUTH=${ENABLE_AUTH}
@@ -29,7 +41,7 @@ else
     add_firewalld_port $SERVICE_PORT
 
     print_log "Starting port forwarding for deployment/${SERVICE_NAME} on port $SERVICE_PORT"
-    wait_for_url_and_run ${SERVICE_BASE_URL} "spawn_port_forwarding_command $SERVICE_NAME $SERVICE_PORT $NAMESPACE $NAMESPACE_INDEX $PROFILE"
+    wait_for_url_and_run ${SERVICE_BASE_URL} "spawn_port_forwarding_command $SERVICE_NAME $SERVICE_PORT $NAMESPACE $NAMESPACE_INDEX $PROFILE $KUBECONFIG minikube"
     print_log "${SERVICE_NAME} can be reached at ${SERVICE_BASE_URL} "
     print_log "Done"
 fi

--- a/scripts/deploy_ui.sh
+++ b/scripts/deploy_ui.sh
@@ -9,23 +9,36 @@ export NO_UI=${NO_UI:-n}
 export NAMESPACE=${NAMESPACE:-assisted-installer}
 export EXTERNAL_PORT=${EXTERNAL_PORT:-y}
 export UI_PORT=$(( 6008 + $NAMESPACE_INDEX ))
+export OCP_UI_PORT=$(( 7008 + $NAMESPACE_INDEX ))
 export PROFILE=${PROFILE:-assisted-installer}
 
-if [[ "${NO_UI}" != "n" || "${DEPLOY_TARGET}" != "minikube" ]]; then
+if [[ "${NO_UI}" != "n" || ("${DEPLOY_TARGET}" != "minikube" && "${DEPLOY_TARGET}" != "ocp") ]]; then
     exit 0
 fi
 
 mkdir -p build
 
 print_log "Starting ui"
-skipper run "make -C assisted-service/ deploy-ui" ${SKIPPER_PARAMS} DEPLOY_TAG=${DEPLOY_TAG} DEPLOY_MANIFEST_PATH=${DEPLOY_MANIFEST_PATH} DEPLOY_MANIFEST_TAG=${DEPLOY_MANIFEST_TAG} NAMESPACE=${NAMESPACE}
+if [ "${DEPLOY_TARGET}" == "minikube" ]; then
+    skipper run "make -C assisted-service/ deploy-ui" ${SKIPPER_PARAMS} DEPLOY_TAG=${DEPLOY_TAG} DEPLOY_MANIFEST_PATH=${DEPLOY_MANIFEST_PATH} DEPLOY_MANIFEST_TAG=${DEPLOY_MANIFEST_TAG} NAMESPACE=${NAMESPACE}
 
-print_log "Wait till ui api is ready"
-wait_for_url_and_run "$(minikube service ${UI_SERVICE_NAME} -p $PROFILE -n ${NAMESPACE} --url)" "echo \"waiting for ${UI_SERVICE_NAME}\""
+    print_log "Wait till ui api is ready"
+    wait_for_url_and_run "$(minikube service ${UI_SERVICE_NAME} -p $PROFILE -n ${NAMESPACE} --url)" "echo \"waiting for ${UI_SERVICE_NAME}\""
 
-add_firewalld_port $UI_PORT
+    add_firewalld_port $UI_PORT
 
-print_log "Starting port forwarding for deployment/${UI_SERVICE_NAME} on port $UI_PORT"
-wait_for_url_and_run "http://${NODE_IP}:${UI_PORT}" "spawn_port_forwarding_command $UI_SERVICE_NAME $UI_PORT $NAMESPACE $NAMESPACE_INDEX $PROFILE"
-print_log "OCP METAL UI can be reached at http://${NODE_IP}:${UI_PORT}"
+    print_log "Starting port forwarding for deployment/${UI_SERVICE_NAME} on port $UI_PORT"
+    wait_for_url_and_run "http://${NODE_IP}:${UI_PORT}" "spawn_port_forwarding_command $UI_SERVICE_NAME $UI_PORT $NAMESPACE $NAMESPACE_INDEX $PROFILE $KUBECONFIG minikube"
+    print_log "OCP METAL UI can be reached at http://${NODE_IP}:${UI_PORT}"
+elif [ "${DEPLOY_TARGET}" == "ocp" ]; then
+    IP_NODEPORT=$(skipper run "scripts/ocp.sh deploy_ui $OCP_KUBECONFIG $UI_SERVICE_NAME $NAMESPACE")
+    read -r CLUSTER_VIP SERVICE_NODEPORT <<< "$IP_NODEPORT"
+
+    add_firewalld_port $OCP_UI_PORT
+
+    CLUSTER_UI_URL=http://${NODE_IP}:${OCP_UI_PORT}
+    wait_for_url_and_run "${CLUSTER_UI_URL}" "spawn_port_forwarding_command $UI_SERVICE_NAME $OCP_UI_PORT $NAMESPACE $NAMESPACE_INDEX $PROFILE $OCP_KUBECONFIG ocp ${CLUSTER_VIP} ${SERVICE_NODEPORT}"
+    print_log "OCP METAL UI can be reached at ${CLUSTER_UI_URL}"
+fi
+
 print_log "Done"

--- a/scripts/ocp.sh
+++ b/scripts/ocp.sh
@@ -1,0 +1,42 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+function deploy_service() {
+    kubeconfig=$1
+    service_onprem=$2
+    service_name=$3
+    service_base_url=$4
+    namespace=$5
+    nodeport=""
+	{
+        SERVICE_BASE_URL=$service_base_url discovery-infra/update_assisted_service_cm.py
+        cp $kubeconfig assisted-service/build/kubeconfig
+        make config_etc_hosts_for_ocp_cluster
+        make -C assisted-service/ deploy-service-on-ocp-cluster OCP_KUBECONFIG=$kubeconfig SERVICE=$service_onprem
+        nodeport=$(kubectl --kubeconfig=$kubeconfig get svc/$service_name -n $namespace -o=jsonpath='{.spec.ports[0].nodePort}')
+    } &>/dev/null
+
+    read -ra def <<< "$(tail -1 /etc/hosts)"
+    read -r cluster_vip <<< "$def"
+
+    echo $cluster_vip $nodeport
+}
+
+function deploy_ui() {
+    kubeconfig=$1
+    service_name=$2
+    namespace=$3
+    nodeport=""
+	{
+        make config_etc_hosts_for_ocp_cluster
+        make -C assisted-service/ deploy-ui-on-ocp-cluster OCP_KUBECONFIG=$kubeconfig
+        nodeport=$(kubectl --kubeconfig=$kubeconfig get svc/$service_name -n $namespace -o=jsonpath='{.spec.ports[0].nodePort}')
+    } &> /dev/null
+
+    read -ra def <<< "$(tail -1 /etc/hosts)"
+    read -r cluster_vip <<< "$def"
+
+    echo $cluster_vip $nodeport
+}
+
+"$@"


### PR DESCRIPTION
- Added 'deploy-on-ocp-cluster' target: automates the deployemnt of
  service and UI on the test OCP cluster (using build/kubeconfig by default).
- Added 'ocp.py': for updating /etc/hosts.
- Added 'ocp.sh': for deploying service/ui using assited-service (invoked with 'skipper run').