### PR TITLE
Add disks_count to signature

### DIFF
--- a/discovery-infra/add_triage_signature.py
+++ b/discovery-infra/add_triage_signature.py
@@ -151,6 +151,7 @@ class HostsExtraDetailSignature(Signature):
                 installation_disk=host.get('installation_disk_path', ""),
                 product_name=inventory['system_vendor']['product_name'],
                 manufacturer=inventory['system_vendor']['manufacturer'],
+                disks_count=len(inventory['disks'])
             ))
 
         report = self._generate_table_for_report(hosts)


### PR DESCRIPTION
Example output:
`
h1. Host extra details:
|| id                                   || hostname   || requested_hostname   || last_contacted      || installation_disk   || product_name                                                  || manufacturer   ||   disks_count ||

| 86d3f0d0-271e-4dba-ac4f-1f19e45e9878 | master1    |                      | 2020-11-05 17:52:14 | /dev/vda            | KVM                                                           | Red Hat        |             1 |
| 51aed157-123f-4a11-8b64-ee10e06ce857 | master2    |                      | 2020-11-05 17:52:16 | /dev/vda            | KVM                                                           | Red Hat        |             1 |
| 1161fba5-f8af-cab3-f198-c64880a6bf96 | worker3    |                      | 2020-11-05 18:07:59 | /dev/sdb            | PowerEdge R640 (SKU=NotProvided;ModelName=PowerEdge R640)     | Dell Inc.      |             2 |
| eea20c93-641f-7588-ccb7-a3fd3c591307 | worker2    |                      | 2020-11-05 18:08:17 | /dev/sdb            | PowerEdge R640 (SKU=NotProvided;ModelName=PowerEdge R640)     | Dell Inc.      |             2 |
| 4342f0ae-1db7-9576-92a2-d5220fcbdec1 | worker4    |                      | 2020-11-05 19:11:59 | /dev/sda            | PowerEdge R640 (SKU=NotProvided;ModelName=PowerEdge R640)     | Dell Inc.      |             1 |
| b2e0c96f-4e89-6b9d-163d-2163d8ce315f | worker5    |                      | 2020-11-05 19:12:03 | /dev/sdm            | PowerEdge R740xd (SKU=NotProvided;ModelName=PowerEdge R740xd) | Dell Inc.      |            14 |
| b5e42bae-7b06-438a-d352-b0e547c120da | worker1    |                      | 2020-11-05 19:12:19 | /dev/sdb            | PowerEdge R640 (SKU=NotProvided;ModelName=PowerEdge R640)     | Dell Inc.      |             2 |
| 0037a7d0-ae7a-4e6c-b06a-9bee852131cb | master0    |                      | 2020-11-05 17:52:15 | /dev/vda            | KVM                                                           | Red Hat        |             1 |
`