### PR TITLE
MGMT-2881: e2e tests: added wrong boot order tests

### DIFF
--- a/discovery-infra/test_infra/consts.py
+++ b/discovery-infra/test_infra/consts.py
@@ -50,6 +50,7 @@ class ClusterStatus:
     ERROR = "error"
     PENDING_FOR_INPUT = "pending-for-input"
     CANCELLED = "cancelled"
+    INSTALLING_PENDING_USER_ACTION = "installing-pending-user-action"
 
 
 class HostsProgressStages:

--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -235,6 +235,21 @@ class Cluster:
             fall_on_error_status=fall_on_error_status,
         )
 
+    def wait_for_hosts_to_be_in_wrong_boot_order(
+            self,
+            nodes_count=env_variables['num_nodes'],
+            timeout=consts.CLUSTER_INSTALLATION_TIMEOUT,
+            fall_on_error_status=True
+    ):
+        utils.wait_till_all_hosts_are_in_status(
+            client=self.api_client,
+            cluster_id=self.id,
+            statuses=[consts.ClusterStatus.INSTALLING_PENDING_USER_ACTION],
+            nodes_count=nodes_count,
+            timeout=timeout,
+            fall_on_error_status=fall_on_error_status
+        )
+
     def wait_for_ready_to_install(self):
         utils.wait_till_cluster_is_in_status(
             client=self.api_client,
@@ -401,7 +416,7 @@ class Cluster:
                 self.api_client.cluster_get(self.id),
                 validation_section, validation_id) in statuses
         except:
-            log.exception("Failed to get cluster %s validation info", self.id)
+            logging.exception("Failed to get cluster %s validation info", self.id)
 
     def wait_for_host_validation(
         self, host_id, validation_section, validation_id, statuses,
@@ -436,3 +451,17 @@ class Cluster:
                 host_id, validation_section, validation_id) in statuses
         except:
             logging.exception("Failed to get cluster %s validation info", self.id)
+
+    def wait_for_cluster_to_be_in_installing_pending_user_action_status(self):
+        utils.wait_till_cluster_is_in_status(
+            client=self.api_client,
+            cluster_id=self.id,
+            statuses=[consts.ClusterStatus.INSTALLING_PENDING_USER_ACTION]
+        )
+
+    def wait_for_cluster_to_be_in_installing_status(self):
+        utils.wait_till_cluster_is_in_status(
+            client=self.api_client,
+            cluster_id=self.id,
+            statuses=[consts.ClusterStatus.INSTALLING]
+        )

--- a/discovery-infra/test_infra/helper_classes/nodes.py
+++ b/discovery-infra/test_infra/helper_classes/nodes.py
@@ -32,6 +32,10 @@ class Nodes(object):
     def __len__(self):
         return len(self.nodes)
 
+    def __iter__(self):
+        for n in self.nodes:
+            yield n
+
     def get_masters(self):
         return [node for node in self.nodes if node.is_master_in_name()]
 

--- a/discovery-infra/tests/pytest.ini
+++ b/discovery-infra/tests/pytest.ini
@@ -3,3 +3,5 @@ markers =
     sanity: mark test as part of sanity
     regression: mark test as part of regression
     proxy: mark test as proxy feature
+    wrong_boot_order: mark test as related to a wrong boot order case
+

--- a/discovery-infra/tests/test_wrong_boot_order.py
+++ b/discovery-infra/tests/test_wrong_boot_order.py
@@ -1,8 +1,14 @@
 import pytest
+import time
+import logging
 
 from tests.base_test import BaseTest
 
 
+logger = logging.getLogger(__name__)
+
+
+@pytest.mark.wrong_boot_order
 class TestWrongBootOrder(BaseTest):
     @pytest.mark.regression
     def test_wrong_boot_order_one_node(self, nodes, cluster):
@@ -20,12 +26,165 @@ class TestWrongBootOrder(BaseTest):
 
         # Wait until wrong boot order
         new_cluster.wait_for_one_host_to_be_in_wrong_boot_order()
+        new_cluster.wait_for_cluster_to_be_in_installing_pending_user_action_status()
 
-        # Reboot required nodes into ISO
+        # Reboot required nodes into HD
         node.shutdown()
         node.set_boot_order(cd_first=False)
         node.start()
 
         # wait until all nodes are in Installed status, will fail in case one host in error
+        new_cluster.wait_for_cluster_to_be_in_installing_status()
+        new_cluster.wait_for_hosts_to_install()
+        new_cluster.wait_for_install()
+
+    @pytest.mark.regression
+    def test_installation_succeeded_after_all_nodes_have_incorrect_boot_order(self,
+                                                                              nodes,
+                                                                              cluster):
+        # Define new cluster
+        new_cluster = cluster()
+
+        # Change boot order of all the nodes
+        for n in nodes:
+            n.set_boot_order(cd_first=True)
+
+        # Start cluster install
+        new_cluster.prepare_for_install(nodes)
+        new_cluster.start_install()
+        new_cluster.wait_for_installing_in_progress()
+
+        # Wait until wrong boot order - all hosts except bootstrap
+        new_cluster.wait_for_hosts_to_be_in_wrong_boot_order(len(nodes)-1)
+        new_cluster.wait_for_cluster_to_be_in_installing_pending_user_action_status()
+
+        # Reboot required nodes into HD
+        bootstrap = nodes.get_bootstrap_node(cluster=new_cluster)
+        for n in nodes:
+            if n.name == bootstrap.name:
+                continue
+            n.shutdown()
+            n.set_boot_order(cd_first=False)
+            n.start()
+
+        # Wait until installation continued.
+        new_cluster.wait_for_cluster_to_be_in_installing_status()
+
+        # Wait until bootstrap is in wrong boot order
+        new_cluster.wait_for_one_host_to_be_in_wrong_boot_order()
+        new_cluster.wait_for_cluster_to_be_in_installing_pending_user_action_status()
+
+        # Reboot bootstrap into HD
+        bootstrap.shutdown()
+        bootstrap.set_boot_order(cd_first=False)
+        bootstrap.start()
+
+        new_cluster.wait_for_cluster_to_be_in_installing_status()
+        new_cluster.wait_for_hosts_to_install()
+        new_cluster.wait_for_install()
+
+    @pytest.mark.regression
+    def test_reset_cancel_from_incorrect_boot_order(self, nodes, cluster):
+        # Define new cluster
+        new_cluster = cluster()
+
+        # Change boot order of all the nodes
+        for n in nodes:
+            n.set_boot_order(cd_first=True)
+
+        # Start cluster install
+        new_cluster.prepare_for_install(nodes)
+        new_cluster.start_install()
+        new_cluster.wait_for_installing_in_progress()
+
+        # Wait until wrong boot order - all hosts except bootstrap
+        new_cluster.wait_for_hosts_to_be_in_wrong_boot_order(len(nodes)-1)
+        new_cluster.wait_for_cluster_to_be_in_installing_pending_user_action_status()
+
+        # Cancel and reset installation
+        new_cluster.cancel_install()
+        assert new_cluster.is_in_cancelled_status(), \
+            f'cluster {new_cluster.id} failed to cancel installation'
+        new_cluster.reset_install()
+        assert new_cluster.is_in_insufficient_status(), \
+            f'cluster {new_cluster.id} failed to reset installation'
+
+        # Reboot required nodes into HD
+        bootstrap = nodes.get_bootstrap_node(cluster=new_cluster)
+        for n in nodes:
+            if n.name == bootstrap.name:
+                continue
+            n.shutdown()
+            n.set_boot_order(cd_first=False)
+
+        new_cluster.reboot_required_nodes_into_iso_after_reset(
+            nodes=nodes)
+
+        # Cancel and reset installation
+        new_cluster.wait_until_hosts_are_discovered()
+        new_cluster.wait_for_ready_to_install()
+        new_cluster.start_install()
+
+        # Wait until bootstrap is in wrong boot order
+        new_cluster.wait_for_one_host_to_be_in_wrong_boot_order()
+        new_cluster.wait_for_cluster_to_be_in_installing_pending_user_action_status()
+
+        # Reboot bootstrap into HD
+        bootstrap.shutdown()
+        bootstrap.set_boot_order(cd_first=False)
+        bootstrap.start()
+
+        new_cluster.wait_for_cluster_to_be_in_installing_status()
+        new_cluster.wait_for_hosts_to_install()
+        new_cluster.wait_for_install()
+
+    @pytest.mark.regression
+    def test_installation_succeeded_on_incorrect_boot_order_timeout_is_ignored(self,
+                                                                               nodes,
+                                                                               cluster):
+        # Define new cluster
+        new_cluster = cluster()
+
+        # Change boot order all the nodes
+        for n in nodes:
+            n.set_boot_order(cd_first=True)
+
+        # Start cluster install
+        new_cluster.prepare_for_install(nodes)
+        new_cluster.start_install()
+        new_cluster.wait_for_installing_in_progress()
+
+        # Wait until wrong boot order - all hosts except bootstrap
+        new_cluster.wait_for_hosts_to_be_in_wrong_boot_order(len(nodes)-1)
+        new_cluster.wait_for_cluster_to_be_in_installing_pending_user_action_status()
+
+        # Wait for an hour+, in normal cases we expect to get timeout error
+        # after an hour
+        logger.info('Waiting 65 minutes before fixing wrong boot order')
+        time.sleep(65 * 60)
+
+        # Reboot required nodes into HD
+        bootstrap = nodes.get_bootstrap_node(cluster=new_cluster)
+        for n in nodes:
+            if n.name == bootstrap.name:
+                continue
+            n.shutdown()
+            n.set_boot_order(cd_first=False)
+            n.start()
+
+        # Wait until installation continued.
+        new_cluster.wait_for_cluster_to_be_in_installing_status()
+        
+        # Wait until bootstrap is in wrong boot order
+        new_cluster.wait_for_one_host_to_be_in_wrong_boot_order()
+        new_cluster.wait_for_cluster_to_be_in_installing_pending_user_action_status()
+
+        # Reboot bootstrap into HD
+        bootstrap.shutdown()
+        bootstrap.set_boot_order(cd_first=False)
+        bootstrap.start()
+
+        # Wait until installation continued.
+        new_cluster.wait_for_cluster_to_be_in_installing_status()
         new_cluster.wait_for_hosts_to_install()
         new_cluster.wait_for_install()


### PR DESCRIPTION
These tests will include the new cluster status "installing-pending-user-action".

Update the existing test: "Installation succeeded after master node had incorrect boot order".
Create "Installation succeeded on incorrect boot order - timeout is ignored".
Create "Installation succeeded after all nodes have an incorrect boot order".
Create "Reset\Cancel from Incorrect boot order"