### PR TITLE
MGMT-2465: fetch ocp cluster id on deploy_controller

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -214,12 +214,6 @@ kill_all_port_forwardings:
 #########
 
 deploy_on_ocp_cluster: bring_assisted_installer
-	# controller
-	DEPLOY_TARGET=ocp NAMESPACE_INDEX=$(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE)) \
-		DEPLOY_TAG=$(DEPLOY_TAG) DEPLOY_MANIFEST_TAG=$(DEPLOY_MANIFEST_TAG) OCP_KUBECONFIG=$(OCP_KUBECONFIG) \
-		PROFILE=$(PROFILE) CONTROLLER_OCP=$(CONTROLLER_OCP) \
-		scripts/deploy_controller.sh
-
 	# service
 	DEPLOY_TARGET=ocp NAMESPACE_INDEX=$(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE)) \
 		DEPLOY_TAG=$(DEPLOY_TAG) DEPLOY_MANIFEST_TAG=$(DEPLOY_MANIFEST_TAG) OCP_KUBECONFIG=$(OCP_KUBECONFIG) \
@@ -231,8 +225,14 @@ deploy_on_ocp_cluster: bring_assisted_installer
 		DEPLOY_TAG=$(DEPLOY_TAG) DEPLOY_MANIFEST_TAG=$(DEPLOY_MANIFEST_TAG) OCP_KUBECONFIG=$(OCP_KUBECONFIG) PROFILE=$(PROFILE) \
 		scripts/deploy_ui.sh
 
+	# controller
+	DEPLOY_TARGET=ocp NAMESPACE_INDEX=$(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE)) \
+		DEPLOY_TAG=$(DEPLOY_TAG) DEPLOY_MANIFEST_TAG=$(DEPLOY_MANIFEST_TAG) OCP_KUBECONFIG=$(OCP_KUBECONFIG) \
+		PROFILE=$(PROFILE) CONTROLLER_OCP=$(CONTROLLER_OCP) \
+		scripts/deploy_controller.sh
+
 config_etc_hosts_for_ocp_cluster:
-	discovery-infra/ocp.py --config-etc-hosts -cn $(CLUSTER_NAME) -id $(CLUSTER_ID) -ns $(NAMESPACE) --service-name $(SERVICE_NAME) --profile $(PROFILE) $(ADDITIONAL_PARAMS)
+	discovery-infra/ocp.py --config-etc-hosts -cn $(CLUSTER_NAME) -ns $(NAMESPACE) --service-name $(SERVICE_NAME) --profile $(PROFILE) $(ADDITIONAL_PARAMS)
 
 bring_assisted_installer:
 	@if cd assisted-installer >/dev/null 2>&1; then git fetch --all && git reset --hard origin/$(INSTALLER_BRANCH); else git clone --branch $(INSTALLER_BRANCH) $(INSTALLER_REPO);fi

--- a/scripts/deploy_controller.sh
+++ b/scripts/deploy_controller.sh
@@ -11,5 +11,8 @@ export SERVICE_BASE_URL=${SERVICE_BASE_URL:-"http://${SERVICE_URL}:${SERVICE_POR
 mkdir -p build
 
 if [ "${DEPLOY_TARGET}" == "ocp" ]; then
-    skipper run "scripts/ocp.sh deploy_controller $OCP_KUBECONFIG $SERVICE_BASE_URL $NAMESPACE $CONTROLLER_OCP"
+    CLUSTER_ID=$(curl -s $SERVICE_BASE_URL/api/assisted-install/v1/clusters | jq -r '.[0] | .id')
+    print_log "OCP cluster ID is $CLUSTER_ID"
+
+    skipper run "scripts/ocp.sh deploy_controller $OCP_KUBECONFIG $SERVICE_BASE_URL $CLUSTER_ID $NAMESPACE $CONTROLLER_OCP"
 fi

--- a/scripts/ocp.sh
+++ b/scripts/ocp.sh
@@ -41,13 +41,14 @@ function deploy_ui() {
 function deploy_controller() {
     kubeconfig=$1
     service_base_url=$2
-    namespace=$3
-    controller_image=$4
+    cluster_id=$3
+    namespace=$4
+    controller_image=$5
 
     mkdir -p assisted-installer/build
     cp $kubeconfig assisted-installer/build/kubeconfig
     make -C assisted-installer/ deploy_controller_on_ocp_cluster OCP_KUBECONFIG=$kubeconfig \
-        SERVICE_BASE_URL=$service_base_url CONTROLLER_OCP=$controller_image
+        SERVICE_BASE_URL=$service_base_url CLUSTER_ID=$cluster_id CONTROLLER_OCP=$controller_image
 }
 
 "$@"


### PR DESCRIPTION
- As OCP cluster id is required for the controller, fetched the it form clusters list on deploy_controller.sh.
- Removed CLUSTER_ID from config_etc_hosts_for_ocp_cluster target (not required as build/kubeconfig is used).