### PR TITLE
fix e2e tests

### DIFF
--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -185,6 +185,15 @@ class InventoryClient(object):
             ]:
                 return host
 
+    def get_host_by_name(self, cluster_id, host_name):
+        hosts = self.get_cluster_hosts(cluster_id)
+
+        for host in hosts:
+            hostname = host.get('requested_hostname')
+            if hostname == host_name:
+                log.info(f"Requested host by name: {host_name}, host details: {host}")
+                return host
+
     def download_and_save_file(self, cluster_id, file_name, file_path):
         log.info("Downloading %s to %s", file_name, file_path)
         response = self.client.download_cluster_files(

--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -167,6 +167,15 @@ class Cluster:
             nodes_count=nodes_count
         )
 
+    def wait_for_specific_host_status(self, host, statuses, nodes_count=1):
+        utils.wait_till_specific_host_is_in_status(
+            client=self.api_client,
+            cluster_id=self.id,
+            host_name=host.get('requested_hostname'),
+            statuses=statuses,
+            nodes_count=nodes_count
+        )
+
     def wait_for_cluster_in_error_status(self):
         utils.wait_till_cluster_is_in_status(
             client=self.api_client,

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -279,6 +279,36 @@ def wait_till_at_least_one_host_is_in_status(
         raise
 
 
+def wait_till_specific_host_is_in_status(
+    client,
+    cluster_id,
+    host_name,
+    nodes_count,
+    statuses,
+    timeout=consts.NODES_REGISTERED_TIMEOUT,
+    fall_on_error_status=True,
+    interval=5,
+):
+    log.info(f"Wait till {nodes_count} host is in one of the statuses: {statuses}")
+
+    try:
+        waiting.wait(
+            lambda: are_hosts_in_status(
+                [client.get_host_by_name(cluster_id, host_name)],
+                nodes_count,
+                statuses,
+                fall_on_error_status,
+            ),
+            timeout_seconds=timeout,
+            sleep_seconds=interval,
+            waiting_for="Node to be in of the statuses %s" % statuses,
+        )
+    except:
+        hosts = client.get_cluster_hosts(cluster_id)
+        log.info("All nodes: %s", hosts)
+        raise
+
+
 def wait_till_at_least_one_host_is_in_stage(
     client,
     cluster_id,


### PR DESCRIPTION
- Change test_wrong_boot_order.test_reset_cancel_from_incorrect_boot_order: to reduce execution time (now 15 min).

- Fix flaky test_cancel_and_reset.test_cancel_reset_after_installation_failure_and_wrong_boot: to check specific host state before kill its installer