### PR TITLE
Set default expiration time for images in s3 to 10m when running e2e tests

### DIFF
--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -9,6 +9,7 @@ pipeline {
         SKIPPER_PARAMS = " "
         PROFILE = "minikube"
         NAMESPACE = "assisted-installer"
+        IMAGE_EXPIRATION_TIME="10m"
 
         /* Credentials */
         PULL_SECRET = credentials('assisted-test-infra-pull-secret')


### PR DESCRIPTION
This in order to avoid storage overflow which causes the pods to crash and tests to fail.