### PR TITLE
MGMT-3269 IPv6 fixes

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -128,7 +128,7 @@ function config_firewalld() {
 function config_squid() {
     echo "Config squid"
     sudo dnf install -y squid
-    sudo sed -i  -e '/^.*allowed_ips.*$/d' -e '/^acl CONNECT.*/a acl allowed_ips src 2001:db8::/120' -e '/^http_access deny all/i http_access allow allowed_ips'  /etc/squid/squid.conf
+    sudo sed -i  -e '/^.*allowed_ips.*$/d' -e '/^acl CONNECT.*/a acl allowed_ips src 1001:db8::/120' -e '/^http_access deny all/i http_access allow allowed_ips'  /etc/squid/squid.conf
     sudo systemctl restart squid
     sudo firewall-cmd --zone=libvirt --add-port=3128/tcp
 }
@@ -137,8 +137,8 @@ function fix_ipv6_routing() {
   sudo sed -i '/^net[.]ipv6[.]conf[.][^.]*[.]accept_ra = 2$/d' /etc/sysctl.conf
   for intf in `ls -l /sys/class/net/ | grep root | grep -v virtual | awk '{print $9}'` ; do
       if sudo test ! -f "/proc/sys/net/ipv6/conf/${intf}/accept_ra"; then
-          echo "WARNING: It looks like IPv6 is disabled on this host and might not work"
-          return
+          echo "WARNING: It looks like IPv6 is disabled for this interface and might not work"
+          continue
       fi
       echo "net.ipv6.conf.${intf}.accept_ra = 2" | sudo tee --append /etc/sysctl.conf
   done


### PR DESCRIPTION
- Change default subnets and prefixes
- During cluster installation, query cluster for host statuses, and do not query libvirt for DHCP leases
/cc @YuviGold 
/cc @tsorya 