### PR TITLE
MGMT-3292 - Added test infrastructure for attaching disks

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/node.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/node.py
@@ -2,8 +2,8 @@ import logging
 from test_infra.controllers.node_controllers import ssh
 from test_infra import consts
 
-class Node(object):
 
+class Node:
     def __init__(self, name, node_controller, private_ssh_key_path=None, username="core"):
         self.name = name
         self.private_ssh_key_path = private_ssh_key_path
@@ -136,3 +136,9 @@ class Node(object):
 
     def reset_ram_kib(self):
         self.set_ram_kib(self.original_ram_kib)
+
+    def attach_test_disk(self, disk_size):
+        return self.node_controller.attach_test_disk(self.name, disk_size)
+
+    def detach_all_test_disks(self):
+        self.node_controller.detach_all_test_disks(self.name)

--- a/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
@@ -1,73 +1,114 @@
-from typing import Dict, List, Any
-from test_infra.controllers.node_controllers import node
+from typing import Dict, List, Any, Tuple
+from test_infra.controllers.node_controllers.node import Node
+from abc import ABC, abstractmethod
 
 
-class NodeController:
-    def list_nodes(self) -> Dict[str, node.Node]:
-        raise NotImplementedError
+class NodeController(ABC):
+    @abstractmethod
+    def list_nodes(self) -> Dict[str, Node]:
+        pass
 
+    @abstractmethod
     def list_networks(self) -> List[Any]:
-        return NotImplementedError
+        pass
 
+    @abstractmethod
     def list_leases(self, network_name: str) -> List[Any]:
-        return NotImplementedError
+        pass
 
+    @abstractmethod
     def shutdown_node(self, node_name: str) -> None:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def shutdown_all_nodes(self) -> None:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def start_node(self, node_name: str) -> None:
-        raise NotImplementedError
+        pass
 
-    def start_all_nodes(self) -> List[node.Node]:
-        raise NotImplementedError
+    @abstractmethod
+    def start_all_nodes(self) -> List[Node]:
+        pass
 
+    @abstractmethod
     def restart_node(self, node_name: str) -> None:
-        raise NotImplementedError
-    
+        pass
+
+    @abstractmethod
     def format_node_disk(self, node_name: str) -> None:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def format_all_node_disks(self) -> None:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
+    def attach_test_disk(self, node_name: str, disk_size: int):
+        """
+        Attaches a test disk. That disk can later be detached with `detach_all_test_disks`
+        :param node_name: Node to attach disk to
+        :param disk_size: Size of disk to attach
+        """
+        pass
+
+    @abstractmethod
+    def detach_all_test_disks(self, node_name: str):
+        """
+        Detaches all test disks created by `attach_test_disk`
+        :param node_name: Node to detach disk from
+        """
+        pass
+
+    @abstractmethod
     def get_ingress_and_api_vips(self) -> dict:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def destroy_all_nodes(self) -> None:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def get_cluster_network(self) -> str:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def setup_time(self) -> str:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def prepare_nodes(self):
         pass
 
+    @abstractmethod
     def is_active(self, node_name) -> bool:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def set_boot_order(self, node_name, cd_first=False) -> None:
-        raise NotImplementedError
+        pass
 
-    def set_correct_boot_order_to_all_nodes(self) -> None:
-        raise NotImplementedError
+    @abstractmethod
+    def get_node_ips_and_macs(self, node_name) -> Tuple[List[str], List[str]]:
+        pass
 
+    @abstractmethod
     def get_host_id(self, node_name: str) -> str:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def get_cpu_cores(self, node_name: str) -> int:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def set_cpu_cores(self, node_name: str, core_count: int) -> None:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def get_ram_kib(self, node_name: str) -> int:
-        raise NotImplementedError
+        pass
 
+    @abstractmethod
     def set_ram_kib(self, node_name: str, ram_kib: int) -> None:
-        raise NotImplementedError
+        pass

--- a/discovery-infra/test_infra/helper_classes/nodes.py
+++ b/discovery-infra/test_infra/helper_classes/nodes.py
@@ -1,30 +1,31 @@
 import logging
 import json
-from typing import Dict
+from typing import Dict, Iterator, List
 import random
+
+import waiting
 from munch import Munch
+from test_infra.controllers.node_controllers.node_controller import NodeController
 from test_infra.controllers.node_controllers.node import Node
 from test_infra.tools.concurrently import run_concurrently
 
 
-class NodeMapping(object):
-
+class NodeMapping:
     def __init__(self, node, cluster_host):
         self.name = node.name
         self.node = node
         self.cluster_host = cluster_host
 
 
-class Nodes(object):
-
-    def __init__(self, node_controller, private_ssh_key_path):
+class Nodes:
+    def __init__(self, node_controller: NodeController, private_ssh_key_path):
         self.controller = node_controller
         self.private_ssh_key_path = private_ssh_key_path
         self._nodes = None
         self._nodes_as_dict = None
 
     @property
-    def nodes(self):
+    def nodes(self) -> List[Node]:
         if not self._nodes:
             self._nodes = self._list()
         return self._nodes
@@ -35,7 +36,7 @@ class Nodes(object):
     def __len__(self):
         return len(self.nodes)
 
-    def __iter__(self):
+    def __iter__(self) -> Iterator[Node]:
         for n in self.nodes:
             yield n
 


### PR DESCRIPTION
(Ignore the branch name, it's a mistake and can't be changed in GitHub after a PR is created)

Adds ability to attach disks to hosts. This in order to allow writing tests for the "Show all disks" epic (where we show all disks, and why they aren't eligible for installation, rather than just disks that are eligible for installation).