### PR TITLE
Adding libvirt logs

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -15,10 +15,15 @@ class LibvirtController(NodeController):
     def __init__(self, **kwargs):
         self.libvirt_connection = libvirt.open('qemu:///system')
         self.private_ssh_key_path = kwargs.get("private_ssh_key_path")
+        self._setup_timestamp = utils.run_command("date +\"%Y-%m-%d %T\"")[0]
 
     def __del__(self):
         with suppress(Exception):
             self.libvirt_connection.close()
+
+    @property
+    def setup_time(self):
+        return self._setup_timestamp
 
     def list_nodes(self):
         return self.list_nodes_with_name_filter(None)

--- a/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
@@ -39,6 +39,12 @@ class NodeController:
     def destroy_all_nodes(self) -> None:
         raise NotImplementedError
 
+    def get_cluster_network(self) -> str:
+        raise NotImplementedError
+
+    def setup_time(self) -> str:
+        raise NotImplementedError
+
     def prepare_nodes(self):
         pass
 

--- a/discovery-infra/test_infra/controllers/node_controllers/qe_vm_controler.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/qe_vm_controler.py
@@ -19,3 +19,6 @@ class QeVmController(LibvirtController):
         self.destroy_all_nodes()
         for node in self.list_nodes():
             self.set_boot_order(node.name(), False)
+
+    def get_cluster_network(self):
+        return "baremetal-0"

--- a/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -177,6 +177,7 @@ class TerraformController(LibvirtController):
         """ Runs terraform destroy and then cleans it with virsh cleanup to delete
             everything relevant.
         """
+
         logging.info("Deleting all nodes")
         if os.path.exists(self.tf_folder):
             self._try_to_delete_nodes()
@@ -208,3 +209,8 @@ class TerraformController(LibvirtController):
             utils.touch(self.image_path)
         self.params.running = False
         self._create_nodes()
+
+    def get_cluster_network(self):
+        logging.info(f'Cluster network name: {self.network_name}')
+        return self.network_name
+

--- a/discovery-infra/test_infra/helper_classes/nodes.py
+++ b/discovery-infra/test_infra/helper_classes/nodes.py
@@ -49,6 +49,10 @@ class Nodes(object):
         nodes = self.controller.list_nodes()
         return [Node(node.name(), self.controller, self.private_ssh_key_path) for node in nodes]
 
+    @property
+    def setup_time(self):
+        return self.controller.setup_time
+
     def get_random_node(self):
         return random.choice(self.nodes)
 
@@ -75,6 +79,9 @@ class Nodes(object):
 
     def reboot_given(self, nodes):
         self.run_for_given_nodes(nodes, "restart")
+
+    def get_cluster_network(self):
+        return self.controller.get_cluster_network()
 
     def set_correct_boot_order(self, nodes=None, start_nodes=False):
         nodes = nodes or self.nodes

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -13,6 +13,8 @@ volumes:
   - $HOME/.cache/libvirt/:$HOME/.cache/libvirt/
   - $HOME/.ssh/:$HOME/.ssh/
   - /usr/local/bin/oc:/usr/local/bin/oc
+  - /var/log:/var/log
+  - /run/log/journal:/run/log/journal
 env:
   PULL_SECRET: $PULL_SECRET
   SECOND_PULL_SECRET: $SECOND_PULL_SECRET


### PR DESCRIPTION
In some cases the nodes fails to get IPs when booting. Not yet sure if its ISO issue or libvirt or lack of machine resources.

This PR collect more logs (mainly libvirt logs) on test failure, in order to properly understand the root cause when reproduces.