### PR TITLE
fix-flaky-ci-failure-due-numeric-runid

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -28,9 +28,9 @@ pipeline {
         SLACK_TOKEN = credentials('slack-token')
         BASE_DNS_DOMAINS = credentials('route53_dns_domain')
         ROUTE53_SECRET = credentials('route53_secret')
-        RUN_ID = UUID.randomUUID().toString().take(8)
-        PROFILE = "${RUN_ID}"
-        NAMESPACE = "${RUN_ID}"
+        RUN_ID    = UUID.randomUUID().toString().take(8)
+        PROFILE   = "profile-${RUN_ID}"
+        NAMESPACE = "ns-${RUN_ID}"
     }
     options {
       timeout(time: 2, unit: 'HOURS')


### PR DESCRIPTION
Added string prefix to PROFILE and NAMESPACE variables in Jenkinesfile in order to eliminate the possibility that it will be interpreted as an integer (which can't be used as namespace or profile names).