### PR TITLE
NO-ISSUE - Prevent rare CI failure due to YAML quirks

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -29,8 +29,8 @@ pipeline {
         BASE_DNS_DOMAINS = credentials('route53_dns_domain')
         ROUTE53_SECRET = credentials('route53_secret')
         RUN_ID = UUID.randomUUID().toString().take(8)
-        PROFILE = "${RUN_ID}"
-        NAMESPACE = "${RUN_ID}"
+        PROFILE = "test-infra-${RUN_ID}"
+        NAMESPACE = "test-infra-${RUN_ID}"
     }
     options {
       timeout(time: 2, unit: 'HOURS')


### PR DESCRIPTION
tl;dr Prevent rare kubectl apply error due to problematic random namespace form 
_____

This bug is rather interesting:

1. Groovy Jenkinsfile sometimes generates a RUN_ID that looks something like `18371e12`

2. NAMESPACE env var gets set to "18371e12"

```groovy
RUN_ID = UUID.randomUUID().toString().take(8)
PROFILE = "${RUN_ID}"
NAMESPACE = "${RUN_ID}"
```

3. `assisted-service/tools/deploy_postgres.py` generates a `postgres-secret.yaml` file that contains:

```yaml
apiVersion: v1
kind: Secret
metadata:
  labels:
    app: postgres
  name: assisted-installer-rds
  namespace: 18371e12
stringData:
  db.host: postgres
  db.name: installer
  db.password: admin
  db.port: '5432'
  db.user: admin
type: Opaque
```

Most importantly, notice the namespace line - and specifically, the lack of quotes around the namespace value. pyyaml, when dumping our dictionary, detects that the namespace string has an `e` in it, so, no reason to put quotes around it. Right? If a string has letters, it will be parsed as a string regardless of quotes, so might as well get rid of them!

Well GoLang's `gopkg.in/yaml.v2` has a different idea. To the GoLang library, this value actually *doesn't* look like a string. It looks like a float! Written in scientific notation! It's the value 18371 times 10 to the power of 12 or 18371000000000000.0, and that's definitely not a valid k8s namespace, so `kubectl apply` fails. 

So to sum it up, if the randomly generates number looks like `<digit><digit><digit><digit><digit><the letter e><digit><digit>`, our CI randomly fails.

Here is a distilled example that reproduces this unexpected behavior:

```go
package main
import (
	"fmt"
	"gopkg.in/yaml.v2"
	"os/exec"
)
func main() {
	dumper := []string{"-c", `
import yaml
print(yaml.dump({'a': '12312e32'}))
`,
	}
	cmd := exec.Command("python3", dumper...)
	stdout, _ := cmd.CombinedOutput()
	m := make(map[interface{}]interface{})
	_ = yaml.Unmarshal([]byte(stdout), &m)
	fmt.Printf("\n%v\n\n", m)
}
```

Outputs: `map[a:1.2312e+36]`

This is caused by YAML allowing such horribly flexible interpretations of values, but mostly because Python's dump function carelessly removes quotes around values that might be interpreted as floats by other ~correct~ (actually, turns out GoLang is wrong for interpreting it as a float. The spec requires a plus or minus sign after the `e` for it to be considered a float, which it doesn't have) implementations of the YAML spec. 
	