### PR TITLE
MGMT-3468 Remove hard coded network type from install flow

### DIFF
--- a/discovery-infra/install_cluster.py
+++ b/discovery-infra/install_cluster.py
@@ -76,7 +76,6 @@ def wait_till_installed(client, cluster, timeout=60 * 60 * 2):
 def run_install_flow(client, cluster_id, kubeconfig_path, pull_secret, tf=None):
     log.info("Verifying cluster exists")
     cluster = client.cluster_get(cluster_id)
-    client.update_cluster_install_config(cluster_id, {"networking": {"networkType": "OpenShiftSDN"}})
     log.info("Verifying pull secret")
     verify_pull_secret(client=client, cluster=cluster, pull_secret=pull_secret)
     log.info("Wait till cluster is ready")

--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -289,10 +289,6 @@ class InventoryClient(object):
         with open(output_file, "wb") as _file:
             _file.write(response.data)
 
-    def update_cluster_install_config(self, cluster_id, update_params):
-        log.info("Updating cluster install config with %s", update_params)
-        return self.client.update_cluster_install_config(cluster_id, json.dumps(update_params))
-
     def cancel_cluster_install(self, cluster_id):
         log.info("Canceling installation of cluster %s", cluster_id)
         return self.client.cancel_installation(cluster_id=cluster_id)


### PR DESCRIPTION
- Making hard coded network type prevents IPv6 installation flow
- This reverts https://github.com/openshift/assisted-test-infra/pull/107
/cc @YuviGold 