### PR TITLE
Add nss_wrapper to Dockerfile.test-infra

### DIFF
--- a/Dockerfile.test-infra
+++ b/Dockerfile.test-infra
@@ -2,7 +2,7 @@ FROM quay.io/ocpmetal/assisted-service:latest AS service
 
 FROM quay.io/centos/centos:8.3.2011
 
-RUN yum -y install make gcc unzip wget curl git podman httpd-tools jq \
+RUN yum -y install make gcc unzip wget curl git podman httpd-tools jq nss_wrapper \
   python3 python3-devel \
   libvirt-client libvirt-devel libguestfs-tools && \
   yum clean all


### PR DESCRIPTION
Adding nss_wrapper provides for a local, unprivileged passwd file to be specified,
allowing the container to map the required user information to a random UID without 
having to modify the containers /etc/passwd file directly.

Full explanation on https://access.redhat.com/articles/4859371