### PR TITLE
pulling squid container image from quay

### DIFF
--- a/discovery-infra/test_infra/controllers/proxy_controller/proxy_controller.py
+++ b/discovery-infra/test_infra/controllers/proxy_controller/proxy_controller.py
@@ -18,7 +18,7 @@ class ProxyController:
             self.name = name
             self.port = port
             self.authenticated = authenticated
-            self.image = 'docker.io/sameersbn/squid'
+            self.image = 'quay.io/sameersbn/squid'
             self.dir = dir
             self._set_server_address()
             self._create_conf_from_template(denied_port=denied_port)


### PR DESCRIPTION
Pulling the container image for proxy server from quay instead of dockerhub, in order to avoid pull rate limits 