### PR TITLE
MGMT-3603 Changes for single node IPv6

### DIFF
--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -161,25 +161,25 @@ resource "libvirt_domain" "worker" {
 # the count directive to include/exclude elements
 
 data "libvirt_network_dns_host_template" "api" {
-  count    = 1
+  count    = !var.bootstrap_in_place || length(var.libvirt_master_ips[0]) > 0 ? 1 : 0
   ip       = var.bootstrap_in_place ? var.libvirt_master_ips[count.index][0] : var.api_vip
   hostname = "api.${var.cluster_name}.${var.cluster_domain}"
 }
 
 data "libvirt_network_dns_host_template" "api-int" {
-  count    = var.bootstrap_in_place ? 1 : 0
+  count    = var.bootstrap_in_place && length(var.libvirt_master_ips[0]) > 0 ? 1 : 0
   ip       = var.libvirt_master_ips[count.index][0]
   hostname = "api-int.${var.cluster_name}.${var.cluster_domain}"
 }
 
 data "libvirt_network_dns_host_template" "oauth" {
-  count    = var.bootstrap_in_place ? 1 : 0
+  count    = var.bootstrap_in_place && length(var.libvirt_master_ips[0]) > 0 ? 1 : 0
   ip       = var.libvirt_master_ips[count.index][0]
   hostname = "oauth-openshift.apps.${var.cluster_name}.${var.cluster_domain}"
 }
 
 data "libvirt_network_dns_host_template" "console" {
-  count    = var.bootstrap_in_place ? 1 : 0
+  count    = var.bootstrap_in_place && length(var.libvirt_master_ips[0]) > 0 ? 1 : 0
   ip       = var.libvirt_master_ips[count.index][0]
   hostname = "console-openshift-console.apps.${var.cluster_name}.${var.cluster_domain}"
 }


### PR DESCRIPTION
- Send machine CIDR to assisted-service in user-managed-networking single with IPv6
- Set all dns names to point to the node IP address
/cc @empovit 
/cc @tsorya 