### PR TITLE
Add managed domains to assisted_service_api

### DIFF
--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -26,6 +26,7 @@ class InventoryClient(object):
         self.client = api.InstallerApi(api_client=self.api)
         self.events = api.EventsApi(api_client=self.api)
         self.versions = api.VersionsApi(api_client=self.api)
+        self.domains = api.ManagedDomainsApi(api_client=self.api)
 
     def set_config_auth(self, c, offline_token):
         if not offline_token:
@@ -392,6 +393,8 @@ class InventoryClient(object):
     def get_host_requirements(self):
         return self.client.get_host_requirements()
 
+    def get_managed_domains(self):
+        return self.domains.list_managed_domains()
 
 def create_client(
     url,


### PR DESCRIPTION
Includes ManagedDomainsApi so we can validate domain and provider used by the api_client. 