### PR TITLE
Add bootable option for newly attached disks

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/node.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/node.py
@@ -140,8 +140,8 @@ class Node:
     def reset_ram_kib(self):
         self.set_ram_kib(self.original_ram_kib)
 
-    def attach_test_disk(self, disk_size):
-        return self.node_controller.attach_test_disk(self.name, disk_size)
+    def attach_test_disk(self, disk_size, bootable=False):
+        return self.node_controller.attach_test_disk(self.name, disk_size, bootable)
 
     def detach_all_test_disks(self):
         self.node_controller.detach_all_test_disks(self.name)

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -32,13 +32,14 @@ from distutils.dir_util import copy_tree
 conn = libvirt.open("qemu:///system")
 
 
-def run_command(command, shell=False, raise_errors=True):
+def run_command(command, shell=False, raise_errors=True, env=None):
     command = command if shell else shlex.split(command)
     process = subprocess.run(
         command,
         shell=shell,
         stdout=subprocess.PIPE,
         stderr=subprocess.PIPE,
+        env=env,
         universal_newlines=True
     )
 

--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -122,9 +122,9 @@ class BaseTest:
     def attach_disk(self):
         modified_nodes = []
 
-        def attach(node, disk_size):
+        def attach(node, disk_size, bootable=False):
             nonlocal modified_nodes
-            node.attach_test_disk(disk_size)
+            node.attach_test_disk(disk_size, bootable)
             modified_nodes.append(node)
 
         yield attach


### PR DESCRIPTION
Modifies `attach_test_disk` node method and dependencies to allow for attaching bootable disks. This is useful for test cases that require a disk with the `(bootable)` flag to be set