### PR TITLE
MGMT-3065 Set hostnames via API in IPv6 setups

### DIFF
--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -560,10 +560,11 @@ def main():
     if is_none_platform_mode():
         return
 
+    has_ipv4 = args.ipv4 and args.ipv4.lower() in MachineNetwork.YES_VALUES
     if args.day2_cloud_cluster:
-        day2.execute_day2_cloud_flow(cluster_id, args)
+        day2.execute_day2_cloud_flow(cluster_id, args, has_ipv4)
     if args.day2_ocp_cluster:
-        day2.execute_day2_ocp_flow(cluster_id, args)
+        day2.execute_day2_ocp_flow(cluster_id, args, has_ipv4)
     if args.bootstrap_in_place:
         ibip.execute_ibip_flow(args)
 

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -773,10 +773,21 @@ def extract_installer(release_image, dest):
     run_command(f"oc adm release extract --command=openshift-install --to={dest} {release_image}")
 
 
-# Set nodes roles by vm name
-# If master in name -> role will be master, same for worker
-# Optionally, update hostanames
 def update_hosts(client, cluster_id, libvirt_nodes, update_hostnames=False, update_roles=True):
+
+    """
+    Update names and/or roles of the hosts in a cluster from a dictionary of libvirt nodes.
+
+    An entry from the dictionary is matched to a host by the host's MAC address (of any NIC).
+    Entries that do not match any host in the cluster are ignored.
+
+    Arguments:
+        client -- An assisted service client
+        cluster_id -- ID of the cluster to update
+        libvirt_nodes -- A dictionary that may contain data about cluster hosts
+        update_hostnames -- Whether hostnames must be set (default False)
+        update_roles -- Whether host roles must be set (default True)
+    """
 
     if not update_hostnames and not update_roles:
         logging.info("Skipping update roles and hostnames")


### PR DESCRIPTION
Setting hostnames via Terraform doesn't work with IPv6. Work that around by setting the hostnames of a cluster via assisted service API. Day 2 scenario similar to how it's done in day 1.