### PR TITLE
unset KUBECONFIG note

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,6 +44,7 @@ This project deploys the OpenShift Assisted Installer in Minikube and spawns lib
 - Ideally on a bare metal host with at least 64G of RAM.
 - Run as a user with password-less `sudo` access or be ready to enter `sudo` password for prepare phase.
 - Get a valid pull secret (JSON string) from [redhat.com](https://cloud.redhat.com/openshift/install/pull-secret) if you want to test the installation (not needed for testing only the discovery flow). Export it as
+- Make sure to unset the KUBECONFIG variable in the same shell where you run make
 
 ```bash
 export PULL_SECRET='<pull secret JSON>'


### PR DESCRIPTION
Adding a note to unset the KUBECONFIG variable.
Otherwise the deployment may get stuck.

Signed-off-by: Alexander Chuzhoy <achuzhoy@redhat.com>