### PR TITLE
NO-ISSUE - Upgrade pip before installing requirements

### DIFF
--- a/Dockerfile.test-infra
+++ b/Dockerfile.test-infra
@@ -19,6 +19,7 @@ RUN curl -SL https://github.com/dmacvicar/terraform-provider-libvirt/releases/do
 
 COPY requirements.txt /tmp/
 COPY --from=service /clients/assisted-service-client-*.tar.gz /build/pip/
+RUN pip3 install --no-cache-dir --upgrade pip
 RUN pip3 install --no-cache-dir -r /tmp/requirements.txt && \
   pip3 install --upgrade /build/pip/*
 


### PR DESCRIPTION
Fixes an issue with the installation of the `paramiko` requirement:
```
Collecting cryptography>=2.5 (from paramiko==2.7.2->-r /tmp/requirements.txt (line 21))
  Downloading https://files.pythonhosted.org/packages/ea/d8/2afd2890fe451a3c109d2bdb6bc4ded55ec43059e524344d5e0004e36412/cryptography-3.4.tar.gz (544kB)
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/tmp/pip-build-2p7vcr4l/cryptography/setup.py", line 13, in <module>
        from setuptools_rust import RustExtension
    ModuleNotFoundError: No module named 'setuptools_rust'
```