### PR TITLE
NO-ISSUE Pin cryptography Python dependency to 3.3.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,3 @@
-
 boto3==1.16.63
 dnspython==2.1.0
 ipython==7.11.1
@@ -23,3 +22,4 @@ scp==0.13.3
 openshift-client==1.0.12
 Jinja2===2.11.3
 pytest-xdist==2.2.0
+cryptography==3.3.2


### PR DESCRIPTION
Pin the cryptography dependency to the latest version before 3.4 to fix
ModuleNotFoundError: No module named 'setuptools_rust'