### PR TITLE
MGMT-3370: Allow running in kube api mode

### DIFF
--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -14,7 +14,10 @@ export PROFILE=${PROFILE:-assisted-installer}
 export OCP_SERVICE_PORT=$(( 7000 + $NAMESPACE_INDEX ))
 export OPENSHIFT_INSTALL_RELEASE_IMAGE=${OPENSHIFT_INSTALL_RELEASE_IMAGE:-}
 export PUBLIC_CONTAINER_REGISTRIES=${PUBLIC_CONTAINER_REGISTRIES:-}
-
+export ENABLE_KUBE_API_CMD=""
+if [ ! -z ${ENABLE_KUBE_API:-} ]; then
+ENABLE_KUBE_API_CMD="ENABLE_KUBE_API=true"
+fi
 mkdir -p build
 
 if [ "${DEPLOY_TARGET}" == "onprem" ]; then
@@ -50,7 +53,7 @@ elif [ "${DEPLOY_TARGET}" == "ocp" ]; then
 else
     print_log "Updating assisted_service params"
     skipper run discovery-infra/update_assisted_service_cm.py ENABLE_AUTH=${ENABLE_AUTH}
-    skipper run "make -C assisted-service/ deploy-all" ${SKIPPER_PARAMS} DEPLOY_TAG=${DEPLOY_TAG} DEPLOY_MANIFEST_PATH=${DEPLOY_MANIFEST_PATH} DEPLOY_MANIFEST_TAG=${DEPLOY_MANIFEST_TAG} NAMESPACE=${NAMESPACE} ENABLE_AUTH=${ENABLE_AUTH} PROFILE=${PROFILE}
+    cd assisted-service/ && skipper run "make deploy-all" ${SKIPPER_PARAMS} $ENABLE_KUBE_API_CMD DEPLOY_TAG=${DEPLOY_TAG} DEPLOY_MANIFEST_PATH=${DEPLOY_MANIFEST_PATH} DEPLOY_MANIFEST_TAG=${DEPLOY_MANIFEST_TAG} NAMESPACE=${NAMESPACE} ENABLE_AUTH=${ENABLE_AUTH} PROFILE=${PROFILE}
 
     print_log "Wait till ${SERVICE_NAME} api is ready"
     wait_for_url_and_run "$(minikube service ${SERVICE_NAME} --url -p $PROFILE -n ${NAMESPACE})" "echo \"waiting for ${SERVICE_NAME}\""


### PR DESCRIPTION
By passing ENABLE_KUBE_API env.
Use the skipper image of assisted-service which has all
the relevant dependencies required to generate and deploy
relevant definitions and deploy the service with the kube
controller enabled.