### PR TITLE
MGMT-3420 Make test infra work with none platform and IPv6

### DIFF
--- a/Dockerfile.test-infra
+++ b/Dockerfile.test-infra
@@ -16,6 +16,7 @@ RUN curl -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v
 RUN mkdir -p /root/.terraform.d/plugins
 RUN curl -SL https://github.com/dmacvicar/terraform-provider-libvirt/releases/download/v0.6.2/terraform-provider-libvirt-0.6.2+git.1585292411.8cbe9ad0.Fedora_28.x86_64.tar.gz | \
   tar -xz -C /root/.terraform.d/plugins
+RUN curl -SL https://releases.hashicorp.com/terraform-provider-local/2.0.0/terraform-provider-local_2.0.0_linux_amd64.zip > /tmp/tpl.zip && unzip -d /root/.terraform.d/plugins /tmp/tpl.zip && rm -f /tmp/tpl.zip
 
 COPY requirements.txt /tmp/
 COPY --from=service /clients/assisted-service-client-*.tar.gz /build/pip/

--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -21,6 +21,7 @@ import day2
 import install_cluster
 import oc_utils
 from logger import log
+from test_infra.controllers.load_balancer_controller import LoadBalancerController
 
 
 class MachineNetwork(object):
@@ -394,9 +395,15 @@ def nodes_flow(client, cluster_name, cluster):
         tf=tf
     )
 
+    is_ipv4 =  machine_net.has_ip_v4 or not machine_net.has_ip_v6
+    main_cidr = args.vm_network_cidr if is_ipv4 else args.vm_network_cidr6
+    secondary_cidr = machine_net.provisioning_cidr_v4 if is_ipv4 else machine_net.provisioning_cidr_v6
+
     if client:
         cluster_info = client.cluster_get(cluster.id)
         macs = utils.get_libvirt_nodes_macs(nodes_details["libvirt_network_name"])
+        if is_none_platform_mode():
+            macs += utils.get_libvirt_nodes_macs(nodes_details["libvirt_secondary_network_name"])
 
         if not (cluster_info.api_vip and cluster_info.ingress_vip):
             utils.wait_till_hosts_with_macs_are_in_status(
@@ -411,11 +418,11 @@ def nodes_flow(client, cluster_name, cluster):
             )
 
             if args.master_count == 1:
-                is_ip4 = machine_net.has_ip_v4 or not machine_net.has_ip_v6
-                cidr = args.vm_network_cidr if is_ip4 else args.vm_network_cidr6
                 tf.change_variables({"single_node_ip": helper_cluster.Cluster.get_ip_for_single_node(
-                    client, cluster.id, cidr, ipv4_first=is_ip4)})
+                    client, cluster.id, main_cidr, ipv4_first=is_ipv4)})
                 set_cluster_machine_cidr(client, cluster.id, machine_net, set_vip_dhcp_allocation=False)
+            elif is_none_platform_mode():
+                set_cluster_vips(client, cluster.id, machine_net)
             elif args.vip_dhcp_allocation:
                 set_cluster_machine_cidr(client, cluster.id, machine_net)
             else:
@@ -424,6 +431,12 @@ def nodes_flow(client, cluster_name, cluster):
             log.info("VIPs already configured")
 
         set_hosts_roles(client, cluster, nodes_details, machine_net, tf, args.master_count, args.with_static_ips)
+
+        if is_none_platform_mode() and args.master_count > 1:
+            master_ips = helper_cluster.Cluster.get_master_ips(client, cluster.id, main_cidr) + helper_cluster.Cluster.get_master_ips(client, cluster.id, secondary_cidr)
+            load_balancer_ip = _get_host_ip_from_cidr(machine_net.cidr_v6 if machine_net.has_ip_v6 and not machine_net.has_ip_v4 else machine_net.cidr_v4)
+            lb_controller = LoadBalancerController(tf)
+            lb_controller.set_load_balancing_config(load_balancer_ip, master_ips)
 
         utils.wait_till_hosts_with_macs_are_in_status(
             client=client,

--- a/discovery-infra/test_infra/controllers/load_balancer_controller.py
+++ b/discovery-infra/test_infra/controllers/load_balancer_controller.py
@@ -1,0 +1,51 @@
+import re
+import waiting
+import socket
+from logger import log
+
+
+class LoadBalancerController:
+
+    def __init__(self, tf):
+        self._tf = tf
+
+    def _render_socket_endpoint(self, ip, port):
+        return f'{ip}:{port}' if '.' in ip else f'[{ip}]:{port}'
+
+    def _render_upstream_server(self, ip, port):
+        return f'\t\tserver {self._render_socket_endpoint(ip, port)};'
+
+    def _render_upstream_servers(self, master_ips, port):
+        return '\n'.join([self._render_upstream_server(ip, port) for ip in master_ips]) + '\n'
+
+    def _render_upstream_block(self, master_ips, port, upstream_name):
+        return f'\tupstream {upstream_name} {{\n{self._render_upstream_servers(master_ips, port)}\t}}\n'
+
+    def _render_server_block(self, load_balancer_ip, port, upstream_name):
+        return f'\tserver {{\n\t\tlisten {self._render_socket_endpoint(load_balancer_ip, port)};\n\t\tproxy_pass {upstream_name};\n\t}}\n'
+
+    def _render_port_entities(self, load_balancer_ip, master_ips, port):
+        upstream_name = f'upstream_{re.sub(r"[.:]", r"_", load_balancer_ip)}_{port}'
+        return self._render_upstream_block(master_ips, port, upstream_name) + self._render_server_block(load_balancer_ip, port, upstream_name)
+
+    def _render_load_balancer_config_file(self, load_balancer_ip, master_ips):
+        return '\n'.join([self._render_port_entities(load_balancer_ip, master_ips, port) for port in [443, 6443, 22623]])
+
+    def _connect_to_load_balancer(self, load_balancer_ip):
+        family = socket.AF_INET6 if ':' in load_balancer_ip else socket.AF_INET
+        try:
+            with socket.socket(family, socket.SOCK_STREAM) as s:
+                s.connect((load_balancer_ip, 6443))
+                return True
+        except Exception as e:
+            log.warning("Could not connect to load balancer endpoint %s: %s", self._render_socket_endpoint(load_balancer_ip, 6443), e)
+            return False
+
+    def _wait_for_load_balancer(self, load_balancer_ip):
+        log.info("Waiting for load balancer %s to be up", load_balancer_ip)
+        waiting.wait(lambda : self._connect_to_load_balancer(load_balancer_ip), timeout_seconds=120, sleep_seconds=5, waiting_for="Waiting for load balancer to be active")
+
+    def set_load_balancing_config(self, load_balancer_ip, master_ips):
+        load_balancer_config_file = self._render_load_balancer_config_file(load_balancer_ip, master_ips)
+        self._tf.change_variables({"load_balancer_ip": load_balancer_ip, "load_balancer_config_file": load_balancer_config_file})
+        self._wait_for_load_balancer(load_balancer_ip)

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -4,6 +4,7 @@ import ipaddress
 import itertools
 import json
 import logging
+import re
 import os
 import random
 import shlex
@@ -669,15 +670,15 @@ def get_libvirt_nodes_from_tf_state(network_names, tf_state):
 
 
 def extract_nodes_from_tf_state(tf_state, network_names, role):
-    domains = next(r["instances"] for r in tf_state.resources if r["type"] == "libvirt_domain" and r["name"] == role)
     data = {}
-    for d in domains:
-        for nic in d["attributes"]["network_interface"]:
+    for domains in [r["instances"] for r in tf_state.resources if r["type"] == "libvirt_domain" and role in r["name"]]:
+        for d in domains:
+            for nic in d["attributes"]["network_interface"]:
 
-            if nic["network_name"] not in network_names:
-                continue
+                if nic["network_name"] not in network_names:
+                    continue
 
-            data[nic["mac"]] = {"ip": nic["addresses"], "name": d["attributes"]["name"], "role": role}
+                data[nic["mac"]] = {"ip": nic["addresses"], "name": d["attributes"]["name"], "role": role}
 
     return data
 

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -18,6 +18,7 @@ volumes:
   - /dev/:/dev
   - /run/udev:/run/udev
   - /var/ai-logs:/var/ai-logs
+  - $HOME/.test-infra/etc/nginx/stream.d:/etc/nginx/stream.d
 env:
   PULL_SECRET: $PULL_SECRET
   SECOND_PULL_SECRET: $SECOND_PULL_SECRET

--- a/terraform_files/none/variables-libvirt.tf
+++ b/terraform_files/none/variables-libvirt.tf
@@ -144,3 +144,15 @@ variable "running" {
 variable "cluster_inventory_id" {
   type      = string
 }
+
+variable "load_balancer_ip" {
+  type = string
+  description = "IP address for load balancer"
+  default = ""
+}
+
+variable "load_balancer_config_file" {
+  type = string
+  description = "Contents of load balancer configuration file"
+  default = ""
+}


### PR DESCRIPTION
Add load balancer
The load balancer runs in its own container.  The setup of the container is in install_environment.sh.
It runs nginx as load balancer.
The nginx in the container is refreshed every 60 seconds.  It looks at directory /etc/nginx/stream.d/ , where load balancing definitions can be added or removed.
The load balancing definitions are managed by terraform (using local_file resource) which is driver by python code.  They are generated currently only for none platform.

/cc @tsorya 
/cc @empovit 