### PR TITLE
MGMT-4182 - Use new pull secret without the svc registry

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -32,7 +32,7 @@ pipeline {
         LOGS_DEST = "${WORKSPACE}/cluster_logs"
 
         // Credentials
-        PULL_SECRET = credentials('assisted-test-infra-pull-secret')
+        PULL_SECRET = credentials('assisted-test-infra-pull-secret-no-svc')
         OCPMETAL_CREDS = credentials('docker_ocpmetal_cred')
         SLACK_TOKEN = credentials('slack-token')
     }

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -12,7 +12,7 @@ pipeline {
         E2E_TESTS_MODE="true"
 
         /* Credentials */
-        PULL_SECRET = credentials('assisted-test-infra-pull-secret')
+        PULL_SECRET = credentials('assisted-test-infra-pull-secret-no-svc')
         OCPMETAL_CREDS = credentials('docker_ocpmetal_cred')
         BASE_DNS_DOMAINS = credentials('route53_dns_domain')
         ROUTE53_SECRET = credentials('route53_secret')


### PR DESCRIPTION
Using this new pull secret: http://assisted-jenkins.usersys.redhat.com/credentials/store/system/domain/_/credential/assisted-test-infra-pull-secret-no-svc/ This is an alternative pull secret to the previous test infra pull secret "assisted-test-infra-pull-secret" that doesn't contain an entry for the "registry.svc.ci.openshift.org" registry. The previous secret seems to have an invalid entry for that registry and it was causing CI issues.