### PR TITLE
MGMT-3370: Jenkinsfile.test - enabled kube-api

### DIFF
--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -10,6 +10,7 @@ pipeline {
         PROFILE = "minikube"
         NAMESPACE = "assisted-installer"
         E2E_TESTS_MODE="true"
+        ENABLE_KUBE_API="true"
 
         /* Credentials */
         PULL_SECRET = credentials('assisted-test-infra-pull-secret')


### PR DESCRIPTION
In order to make the kube-api e2e test to work we need to enable
kube-api when deploying the environment.