### PR TITLE
Remove --must-gather flag on Jenkinsfile.download_logs

### DIFF
--- a/Jenkinsfile.download_logs
+++ b/Jenkinsfile.download_logs
@@ -11,7 +11,6 @@ pipeline {
         SKIPPER_PARAMS = " "
 
         LOGS_DEST = "/var/ai-logs/triage_logs"
-        ADDITIONAL_PARAMS = "--must-gather"
 
         // Credentials
         OFFLINE_TOKEN = credentials('admin_offline_token')


### PR DESCRIPTION
The collector is unable to reach the cluster to get the must-gather
logs from the outside.
Hence, we would have to rely on assisted-service to collect the
must-gather logs.
No reason to keep executing that command from test-infra.