### PR TITLE
not prepending 'http://' to URLs that already include a scheme

### DIFF
--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -269,7 +269,7 @@ class InventoryClient(object):
         log.info("Downloading metrics to %s", dest)
 
         url = self.inventory_url
-        if not url.startswith('http://'):
+        if not (url.startswith('http://') or url.startswith('https://')):
             url = f'http://{url}'
         response = requests.get(f"{url}/metrics")
         assert response.status_code == 200


### PR DESCRIPTION
Fixing the case the URL already contains an ``https`` scheme:
```
urllib3.exceptions.MaxRetryError: HTTPConnectionPool(host='https', port=80): Max retries exceeded with url: //api.openshift.com/metrics (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7fc59b05ca90>: Failed to establish a new connection: [Errno -2] Name or service not known',))
```