### PR TITLE
OCPBUGSM-25057 add image type to event const

### DIFF
--- a/discovery-infra/test_infra/consts.py
+++ b/discovery-infra/test_infra/consts.py
@@ -103,6 +103,7 @@ class Events:
     GENERATED_IMAGE_FULL = "Generated image (Image type is \"full-iso\", SSH public key is set)"
     GENERATED_IMAGE_MINIMAL = "Generated image (Image type is \"minimal-iso\", SSH public key is set)"
     DOWNLOAD_IMAGE = "Started image download"
+    STARTED_DOWNLOAD_IMAGE = "Started image download (image type is \"full-iso\")"
     HOST_REGISTERED_TO_CLUSTER = ": registered to cluster"
     INSUFFICIENT = "insufficient"
     KNOWN = "to \"known\""


### PR DESCRIPTION
Added STARTED_DOWNLOAD_IMAGE to consts - contains image type
as updated in: https://github.com/openshift/assisted-service/pull/1258