### PR TITLE
NO-ISSUE: Added KubeAPIContext

### DIFF
--- a/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
@@ -2,15 +2,18 @@
 kube_helpers package provides infra to deploy, manage and install cluster using
 CRDs instead of restful API calls.
 
-Simplest use of this infra is performed by calling cluster_deployment_context
-fixture, must be called with a kube_api_client which is provided as a fixture
-as well. With this context manager you will be able to manage a cluster
-without need to handle registration and deregistration.
+Use this package as part of pytest infra with the fixture kube_api_context.
+It provides a KubeAPIContext object which holds information about the resources
+created as well as the kubernetes ApiClient.
 
 Example of usage:
 
-with cluster_deployment_context(kube_api_client) as cluster_deployment:
-    print(cluster_deployment.status())
+def test_kube_api_wait_for_install(kube_api_context):
+    kube_api_client = kube_api_context.api_client
+    cluster_deployment = deploy_default_cluster_deployment(
+        kube_api_client, 'test-cluster', **installation_params
+    )
+    cluster_deployment.wait_for_state('installing')
 
 An Agent CRD will be created for each registered host. In order to start the
 installation all agents must be approved.
@@ -18,27 +21,31 @@ When a ClusterDeployment has sufficient data and the assigned agents are
 approved, installation will be started automatically.
 """
 
-from .cluster_deployment import \
-    cluster_deployment_context, \
-    deploy_default_cluster_deployment, \
-    delete_cluster_deployment, \
-    Platform,\
-    InstallStrategy, \
+from .cluster_deployment import (
+    deploy_default_cluster_deployment,
+    Platform,
+    InstallStrategy,
     ClusterDeployment
+)
 from .secret import deploy_default_secret, Secret
 from .agent import Agent
-from .common import create_kube_api_client, ObjectReference
+from .common import (
+    create_kube_api_client,
+    delete_all_resources,
+    KubeAPIContext,
+    ObjectReference
+)
 
 __all__ = (
-    'cluster_deployment_context',
     'deploy_default_cluster_deployment',
-    'delete_cluster_deployment',
     'deploy_default_secret',
     'create_kube_api_client',
+    'delete_all_resources',
     'Platform',
     'InstallStrategy',
     'ClusterDeployment',
     'Secret',
     'Agent',
+    'KubeAPIContext',
     'ObjectReference'
 )

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/agent.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/agent.py
@@ -26,7 +26,7 @@ class Agent(BaseCustomResource):
             name: str,
             namespace: str = env_variables['namespace']
     ):
-        BaseCustomResource.__init__(self, name, namespace)
+        super().__init__(name, namespace)
         self.crd_api = CustomObjectsApi(kube_api_client)
 
     @classmethod

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/base_resource.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/base_resource.py
@@ -1,20 +1,34 @@
 import abc
 
-from .common import ObjectReference
+from .common import KubeAPIContext, ObjectReference
 
 
-class BaseCustomResource(abc.ABC):
+class BaseResource(abc.ABC):
     """
-    Base class for all CRDs, enforces basic methods that every resource must
-    have e.g create, path, get, delete and status.
+    A base object of both custom resources and kubernetes resources that holds
+    a shared KubeAPIContext. Any sub instance of this class will be added to the
+    shared context.
     """
+    context = KubeAPIContext()
 
     def __init__(self, name: str, namespace: str):
+        self.context.resources.add(self)
         self._reference = ObjectReference(name=name, namespace=namespace)
 
     @property
     def ref(self) -> ObjectReference:
         return self._reference
+
+    @abc.abstractmethod
+    def delete(self) -> None:
+        pass
+
+
+class BaseCustomResource(BaseResource):
+    """
+    Base class for all CRDs, enforces basic methods that every resource must
+    have e.g create, path, get, delete and status.
+    """
 
     @abc.abstractmethod
     def create(self, **kwargs) -> None:
@@ -26,10 +40,6 @@ class BaseCustomResource(abc.ABC):
 
     @abc.abstractmethod
     def get(self) -> dict:
-        pass
-
-    @abc.abstractmethod
-    def delete(self) -> None:
         pass
 
     @abc.abstractmethod

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/secret.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/secret.py
@@ -9,9 +9,10 @@ from kubernetes.client.rest import ApiException
 from tests.conftest import env_variables
 
 from .common import logger, ObjectReference
+from .base_resource import BaseResource
 
 
-class Secret:
+class Secret(BaseResource):
     """
     A Kube API secret resource that consists of the pull secret data, used
     by a ClusterDeployment CRD.
@@ -25,12 +26,8 @@ class Secret:
             name: str,
             namespace: str = env_variables['namespace']
     ):
+        super().__init__(name, namespace)
         self.v1_api = CoreV1Api(kube_api_client)
-        self._reference = ObjectReference(name=name, namespace=namespace)
-
-    @property
-    def ref(self) -> ObjectReference:
-        return self._reference
 
     def create(self, pull_secret: str = env_variables['pull_secret']) -> None:
         self.v1_api.create_namespaced_secret(

--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -16,7 +16,7 @@ from paramiko import SSHException
 from test_infra import consts
 from test_infra.controllers.proxy_controller.proxy_controller import ProxyController
 from test_infra.helper_classes.cluster import Cluster
-from test_infra.helper_classes.kube_helpers import create_kube_api_client, cluster_deployment_context
+from test_infra.helper_classes.kube_helpers import create_kube_api_client, KubeAPIContext
 from test_infra.helper_classes.nodes import Nodes
 from test_infra.tools.assets import NetworkAssets
 from tests.conftest import env_variables, qe_env
@@ -303,5 +303,8 @@ class BaseTest:
         yield create_kube_api_client()
 
     @pytest.fixture()
-    def cluster_deployment_context(self):
-        yield cluster_deployment_context
+    def kube_api_context(self, kube_api_client):
+        kube_api_context = KubeAPIContext(kube_api_client)
+
+        with kube_api_context:
+            yield kube_api_context


### PR DESCRIPTION
KubeAPIContext is an object which holds information about the resources
created during a test. It will be used in a fixture
called kube_api_context and provides the kube_api_client. By doing that,
there will be no need to worry about cleanup of any resource that will be
created in the test (i.e no need to run the test within contextmanager).
