### PR TITLE
MGMT-4604 Fix scality ephemeral storage error

### DIFF
--- a/scripts/run_minikube.sh
+++ b/scripts/run_minikube.sh
@@ -20,7 +20,7 @@ function init_minikube() {
         fi
     done
 
-    minikube start --driver=kvm2 --memory=8192 --cpus=4 --profile=${PROFILE} --force --wait-timeout=15m0s
+    minikube start --driver=kvm2 --memory=8192 --cpus=4 --profile=${PROFILE} --force --wait-timeout=15m0s --disk-size=50g
 }
 
 if [ "${DEPLOY_TARGET}" != "minikube" ]; then


### PR DESCRIPTION
Increase minikube disk allocation so that the VM
has enough space for minikube components and ephemeral storage.