### PR TITLE
MGMT-3334 Wait for operators to finish

### DIFF
--- a/discovery-infra/install_cluster.py
+++ b/discovery-infra/install_cluster.py
@@ -59,6 +59,14 @@ def wait_till_installed(client, cluster, timeout=60 * 60 * 2):
             timeout=timeout,
             interval=60,
         )
+        utils.wait_till_all_operators_are_in_status(
+            client=client,
+            cluster_id=cluster.id,
+            operators_count=len(cluster.monitored_operators),
+            statuses=[consts.OperatorStatus.AVAILABLE, consts.OperatorStatus.FAILED],
+            timeout=consts.CLUSTER_INSTALLATION_TIMEOUT,
+            fall_on_error_status=False,
+        )
         utils.wait_till_cluster_is_in_status(
             client=client,
             cluster_id=cluster.id,

--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -467,12 +467,6 @@ def nodes_flow(client, cluster_name, cluster):
             )
             # Validate DNS domains resolvability
             validate_dns(client, cluster.id)
-            if args.wait_for_cvo:
-                cluster_info = client.cluster_get(cluster.id)
-                log.info("Start waiting till CVO status is available")
-                api_vip = helper_cluster.get_api_vip_from_cluster(client, cluster_info)
-                config_etc_hosts(cluster_info.name, cluster_info.base_dns_domain, api_vip)
-                utils.wait_for_cvo_available()
 
 
 def set_hosts_roles(client, cluster, nodes_details, machine_net, tf, master_count, static_network_mode):
@@ -736,12 +730,6 @@ if __name__ == "__main__":
         "-in",
         "--install-cluster",
         help="Install cluster, will take latest id",
-        action="store_true",
-    )
-    parser.add_argument(
-        "-cvo",
-        "--wait-for-cvo",
-        help="Wait for CVO available after cluster installation",
         action="store_true",
     )
     parser.add_argument(

--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -105,6 +105,10 @@ class InventoryClient(object):
         log.info("Getting registered nodes for cluster %s", cluster_id)
         return self.client.list_hosts(cluster_id=cluster_id)
 
+    def get_cluster_operators(self, cluster_id):
+        log.info("Getting monitored operators for cluster %s", cluster_id)
+        return self.client.list_of_cluster_operators(cluster_id=cluster_id)
+
     def get_hosts_in_statuses(self, cluster_id, statuses):
         hosts = self.get_cluster_hosts(cluster_id)
         return [host for host in hosts if host["status"] in statuses]

--- a/discovery-infra/test_infra/consts.py
+++ b/discovery-infra/test_infra/consts.py
@@ -90,6 +90,12 @@ class HostsProgressStages:
     DONE = "Done"
 
 
+class OperatorStatus:
+    FAILED = "failed"
+    PROGRESSING = "progressing"
+    AVAILABLE = "available"
+
+
 all_host_stages = [HostsProgressStages.START_INSTALLATION, HostsProgressStages.INSTALLING,
                    HostsProgressStages.WRITE_IMAGE_TO_DISK, HostsProgressStages.WAIT_FOR_CONTROL_PLANE,
                    HostsProgressStages.REBOOTING, HostsProgressStages.WAIT_FOR_IGNITION,

--- a/discovery-infra/tests/conftest.py
+++ b/discovery-infra/tests/conftest.py
@@ -63,7 +63,7 @@ env_variables = {"ssh_public_key": utils.get_env('SSH_PUB_KEY'),
                  "master_vcpu": utils.get_env('MASTER_CPU', consts.MASTER_CPU),
                  "test_teardown": bool(util.strtobool(utils.get_env('TEST_TEARDOWN', 'true'))),
                  "namespace": utils.get_env('NAMESPACE', consts.DEFAULT_NAMESPACE),
-                 "olm_operators": utils.get_env('OLM_OPERATORS', '').lower().split(),
+                 "olm_operators": list(map(lambda name: {'name': name}, utils.get_env('OLM_OPERATORS', '').lower().split())),
                  "platform": utils.get_env("PLATFORM", consts.Platforms.BARE_METAL)
                  }
 cluster_mid_name = infra_utils.get_random_name()


### PR DESCRIPTION
As part of waiting for installation to complete - we look for hosts and cluster to be "installed". Now we watch for operators to be "Available" or "Failed" as well.
    
Remove "-cvo" flag to inspect cvo status since it's being done by the service.


```
2021-03-25 14:10:23,067 INFO       - 139877912267648 - Asked operators to be in one of the statuses from ['available', 'failed'] and currently operators statuses are [('console', 'available', 'All is well')]    (/home/assisted-test-infra/discovery-infra/test_infra/utils.py:232)
```