### PR TITLE
Run minikube tunnel when starting minikube

### DIFF
--- a/scripts/run_minikube.sh
+++ b/scripts/run_minikube.sh
@@ -21,6 +21,7 @@ function init_minikube() {
     done
 
     minikube start --driver=kvm2 --memory=8192 --cpus=4 --profile=${PROFILE} --force --wait-timeout=15m0s --disk-size=50g
+    minikube tunnel --cleanup &> /dev/null &
 }
 
 if [ "${DEPLOY_TARGET}" != "minikube" ]; then


### PR DESCRIPTION
In order for k8s services to have external IPs accessible from kubectl
 - minikube have to be started with a LoadBalancer.
By default minikube isn't starting with a LoadBalancer and for that we
have to run `minikube tunnel` on a separate process, since it is running
in the foreground.