### PR TITLE
NO-ISSUE Quote the command input to `skipper run`

### DIFF
--- a/Jenkinsfile.download_logs
+++ b/Jenkinsfile.download_logs
@@ -37,14 +37,14 @@ pipeline {
                     sh "git clone 'https://github.com/openshift-assisted/assisted-installer-deployment'"
 
                     dir ('assisted-installer-deployment') {
-                        sh "skipper run ./tools/create_triage_tickets.py -up ${JIRA_CREDS} -v"
+                        sh "skipper run \"./tools/create_triage_tickets.py -up ${JIRA_CREDS} -v\""
                     }
                 }
             }
         }
         stage('Testgrid failures') {
             steps {
-                sh "skipper run deploymentRepo/assisted-installer-deployment/tools/create_testgrid_tickets.py -up ${JIRA_CREDS} -v"
+                sh "skipper run \"deploymentRepo/assisted-installer-deployment/tools/create_testgrid_tickets.py -up ${JIRA_CREDS} -v\""
             }
         }
     }


### PR DESCRIPTION
This will make a clear separation between the flags
meant for skipper and those meant for the internal command

Specifically this will fix skipper trying to interpret the
user pass as a port input as of this change:
https://github.com/Stratoscale/skipper/pull/142

This is currently breaking the `download_logs` job with:
```
13:54:10  + skipper run ./tools/create_triage_tickets.py -up **** -v
13:54:10  Usage: skipper run [OPTIONS] COMMAND...
13:54:10  
13:54:10  Error: Invalid value for "-p" / "--publish": Publish need to be in format port:port or port-port:port-port
```