### PR TITLE
Support SHAs for SERVICE_BRANCH and INSTALLER_BRANCH

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -280,7 +280,11 @@ config_etc_hosts_for_ocp_cluster:
 	discovery-infra/ocp.py --config-etc-hosts -cn $(CLUSTER_NAME) -ns $(NAMESPACE) --service-name $(SERVICE_NAME) --profile $(PROFILE) $(ADDITIONAL_PARAMS)
 
 bring_assisted_installer:
-	@if cd assisted-installer >/dev/null 2>&1; then git fetch --all && git reset --hard origin/$(INSTALLER_BRANCH); else git clone --branch $(INSTALLER_BRANCH) $(INSTALLER_REPO);fi
+	@if ! cd assisted-installer >/dev/null 2>&1; then \
+		git clone $(INSTALLER_REPO); \
+	fi
+
+	@cd assisted-installer && git fetch origin $(INSTALLER_BRANCH) && git reset --hard $(INSTALLER_BRANCH)
 
 ###########
 # Cluster #
@@ -362,7 +366,11 @@ deploy_assisted_service: start_minikube bring_assisted_service
 	DEPLOY_TAG=$(DEPLOY_TAG) NAMESPACE_INDEX=$(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE) $(OC_FLAG)) DEPLOY_MANIFEST_PATH=$(DEPLOY_MANIFEST_PATH) DEPLOY_MANIFEST_TAG=$(DEPLOY_MANIFEST_TAG) scripts/deploy_assisted_service.sh
 
 bring_assisted_service:
-	@if cd assisted-service >/dev/null 2>&1; then git fetch --all && git reset --hard origin/$(SERVICE_BRANCH); else git clone --branch $(SERVICE_BRANCH) $(SERVICE_REPO);fi
+	@if ! cd assisted-service >/dev/null 2>&1; then \
+		git clone $(SERVICE_REPO); \
+	fi
+
+	@cd assisted-service && git fetch origin $(SERVICE_BRANCH) && git reset --hard $(SERVICE_BRANCH)
 
 deploy_monitoring: bring_assisted_service
 	make -C assisted-service/ deploy-monitoring NAMESPACE=$(NAMESPACE) PROFILE=$(PROFILE)


### PR DESCRIPTION
Before
```bash
➜  assisted-test-infra git:(master) make bring_assisted_service SERVICE_BRANCH=1639cf2c9b3ddaa34525757a2caaa5884bb0e997
Fetching origin
fatal: ambiguous argument 'origin/1639cf2c9b3ddaa34525757a2caaa5884bb0e997': unknown revision or path not in the working tree.
Use '--' to separate paths from revisions, like this:
'git <command> [<revision>...] -- [<file>...]'
make: *** [Makefile:365: bring_assisted_service] Error 128
```

After

```bash
➜  assisted-test-infra git:(get-assisted-service-by-sha) make bring_assisted_service SERVICE_BRANCH=1639cf2c9b3ddaa34525757a2caaa5884bb0e997
Cloning into 'assisted-service'...
remote: Enumerating objects: 76, done.
remote: Counting objects: 100% (76/76), done.
remote: Compressing objects: 100% (67/67), done.
remote: Total 19909 (delta 23), reused 26 (delta 8), pack-reused 19833
Receiving objects: 100% (19909/19909), 31.91 MiB | 15.98 MiB/s, done.
Resolving deltas: 100% (14850/14850), done.
remote: Enumerating objects: 3, done.
remote: Counting objects: 100% (3/3), done.
remote: Total 5 (delta 3), reused 3 (delta 3), pack-reused 2
Unpacking objects: 100% (5/5), 746 bytes | 746.00 KiB/s, done.
From https://github.com/openshift/assisted-service
 * branch              1639cf2c9b3ddaa34525757a2caaa5884bb0e997 -> FETCH_HEAD
HEAD is now at 1639cf2c NO-ISSUE Add skipper.env file
```