### PR TITLE
Bugfix get cluster operators to avoid agentAuth

### DIFF
--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -107,7 +107,7 @@ class InventoryClient(object):
 
     def get_cluster_operators(self, cluster_id):
         log.info("Getting monitored operators for cluster %s", cluster_id)
-        return self.client.list_of_cluster_operators(cluster_id=cluster_id)
+        return self.cluster_get(cluster_id=cluster_id).monitored_operators
 
     def get_hosts_in_statuses(self, cluster_id, statuses):
         hosts = self.get_cluster_hosts(cluster_id)

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -18,15 +18,17 @@ from functools import wraps
 from pathlib import Path
 from pprint import pformat
 from string import ascii_lowercase
-from typing import List, Dict
+from typing import Dict, List
 
 import filelock
 import libvirt
 import oc_utils
 import requests
 import waiting
+from assisted_service_client.models.monitored_operator import MonitoredOperator
 from logger import log
 from retry import retry
+
 from test_infra import consts
 
 conn = libvirt.open("qemu:///system")
@@ -200,20 +202,20 @@ def are_hosts_in_status(
     return False
 
 
-def are_operators_in_status(operators: List[Dict], operators_count: int, statuses: List[str], fall_on_error_status: bool) -> bool:
+def are_operators_in_status(operators: List[MonitoredOperator], operators_count: int, statuses: List[str], fall_on_error_status: bool) -> bool:
     log.info(
         "Asked operators to be in one of the statuses from %s and currently operators statuses are %s",
         statuses,
-        [(operator["name"], operator.get("status"), operator.get("status_info")) for operator in operators],
+        [(operator.name, operator.status, operator.status_info) for operator in operators],
     )
 
-    if len([operator for operator in operators if operator.get("status") in statuses]) >= operators_count:
+    if len([operator for operator in operators if operator.status in statuses]) >= operators_count:
         return True
 
     if fall_on_error_status:
         for operator in operators:
-            if operator.get("status") == consts.OperatorStatus.FAILED:
-                raise ValueError(f"Operator {operator['name']} status is {consts.OperatorStatus.FAILED} with info {operator.get('status_info')}")
+            if operator.status == consts.OperatorStatus.FAILED:
+                raise ValueError(f"Operator {operator.name} status is {consts.OperatorStatus.FAILED} with info {operator.status_info}")
 
     return False
 


### PR DESCRIPTION
get_cluster_operators is an agent operation.
We weren't notified about this usage because test-infra by default isn't
running with auth but staging is
