### PR TITLE
NO-ISSUE implement a 'kubectl apply' like interface

### DIFF
--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -3,7 +3,6 @@
 
 import pathlib
 import argparse
-import contextlib
 import distutils.util
 import ipaddress
 import json
@@ -11,7 +10,6 @@ import os
 
 import dns.resolver
 from kubernetes.client import CustomObjectsApi
-from kubernetes.client.exceptions import ApiException
 from netaddr import IPNetwork
 from test_infra import assisted_service_api, consts, utils
 from test_infra.helper_classes import cluster as helper_cluster
@@ -551,19 +549,13 @@ def execute_day1_flow(cluster_name):
                 name=cluster_name,
                 namespace=args.namespace,
             )
-            with contextlib.suppress(ApiException):
-                secret.delete()
-
-            secret.create(pull_secret=args.pull_secret)
+            secret.apply(pull_secret=args.pull_secret)
 
             ipv4 = args.ipv4 and args.ipv4.lower() in MachineNetwork.YES_VALUES
             ipv6 = args.ipv6 and args.ipv6.lower() in MachineNetwork.YES_VALUES
             api_vip, ingress_vip = "", ""
 
-            with contextlib.suppress(ApiException):
-                cluster_deployment.delete()
-
-            cluster_deployment.create(
+            cluster_deployment.apply(
                 platform=Platform(
                     api_vip=api_vip,
                     ingress_vip=ingress_vip,
@@ -588,10 +580,7 @@ def execute_day1_flow(cluster_name):
                 name=f"{cluster_name}-install-env",
                 namespace=args.namespace
             )
-            with contextlib.suppress(ApiException):
-                install_env.delete()
-
-            install_env.create(
+            install_env.apply(
                 cluster_deployment=cluster_deployment,
                 secret=secret,
                 proxy=Proxy(

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/base_resource.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/base_resource.py
@@ -1,4 +1,7 @@
 import abc
+import contextlib
+
+from kubernetes.client.rest import ApiException
 
 from .common import KubeAPIContext, ObjectReference
 
@@ -20,8 +23,22 @@ class BaseResource(abc.ABC):
         return self._reference
 
     @abc.abstractmethod
+    def create(self, **kwargs) -> None:
+        pass
+
+    @abc.abstractmethod
     def delete(self) -> None:
         pass
+
+    @abc.abstractmethod
+    def get(self) -> dict:
+        pass
+
+    def apply(self, **kwargs):
+        with contextlib.suppress(ApiException):
+            self.delete()
+
+        self.create(**kwargs)
 
 
 class BaseCustomResource(BaseResource):
@@ -31,15 +48,7 @@ class BaseCustomResource(BaseResource):
     """
 
     @abc.abstractmethod
-    def create(self, **kwargs) -> None:
-        pass
-
-    @abc.abstractmethod
     def patch(self, **kwargs) -> None:
-        pass
-
-    @abc.abstractmethod
-    def get(self) -> dict:
         pass
 
     @abc.abstractmethod

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/cluster_deployment.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/cluster_deployment.py
@@ -159,7 +159,7 @@ class ClusterDeployment(BaseCustomResource):
             secret: Secret,
             base_domain: str = env_variables['base_domain'],
             **kwargs
-    ) -> None:
+    ):
         body = {
             'apiVersion': f'{self._api_group}/{self._api_version}',
             'kind': 'ClusterDeployment',

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/secret.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/secret.py
@@ -1,6 +1,5 @@
 import os
 import json
-
 from typing import Optional
 
 from kubernetes.client import ApiClient, CoreV1Api
@@ -8,7 +7,7 @@ from kubernetes.client.rest import ApiException
 
 from tests.conftest import env_variables
 
-from .common import logger, ObjectReference
+from .common import logger
 from .base_resource import BaseResource
 
 
@@ -29,7 +28,7 @@ class Secret(BaseResource):
         super().__init__(name, namespace)
         self.v1_api = CoreV1Api(kube_api_client)
 
-    def create(self, pull_secret: str = env_variables['pull_secret']) -> None:
+    def create(self, pull_secret: str = env_variables['pull_secret']):
         self.v1_api.create_namespaced_secret(
             body={
                 'type': self._secret_type,


### PR DESCRIPTION
Current code is just too long, and the behavior we want is a simple 'kubectl apply'.
So I replaced deletion and creation with the new methods.
Kubernetes python client doesn't support apply right now, so it will be a simple substitution for now (until we'll mimic the 3-way patch of apply).

/test e2e-metal-assisted-kube-api
/hold
/cc @RazRegev 