### PR TITLE
MGMT-3335 teardown iptables in nodes

### DIFF
--- a/discovery-infra/test_infra/controllers/nat_controller.py
+++ b/discovery-infra/test_infra/controllers/nat_controller.py
@@ -1,83 +1,98 @@
 import logging
 from test_infra.utils import run_command
 
-#
-# Create NAT rules networks that are nat using libvirt "nat" forwarding - which is currently none platform
-# The logic behind it is to mark packets that are coming from libvirt bridges (i.e input_interfaces), and
-# reference this mark in order to perform NAT operation on these packets.
-#
+
 class NatController:
-    # Build iptables mark
-    def _build_mark(self, ns_index):
+    """
+    Create NAT rules networks that are nat using libvirt "nat" forwarding - which is currently none platform
+    The logic behind it is to mark packets that are coming from libvirt bridges (i.e input_interfaces), and
+    reference this mark in order to perform NAT operation on these packets.
+    """
+
+    @staticmethod
+    def _build_mark(ns_index):
+        """ Build iptables mark """
         return 555 + int(ns_index)
 
-    # Find all interfaces that have default route on them.  Usually it is a single interface.
-    def _get_default_interfaces(self):
+    @staticmethod
+    def _get_default_interfaces():
+        """ Find all interfaces that have default route on them.  Usually it is a single interface. """
         interfaces, _, _ = run_command(r"ip -4 route | egrep '^default ' | awk '{print $5}'", shell=True)
         return set(interfaces.strip().split())
 
-    # Mark all packets coming from the input_interface with "555".  Marking is needed because input interface
-    # query is not available in POSTROUTING chain
-    def _build_mark_string(self, input_interface, mark):
+    @staticmethod
+    def _build_mark_string(input_interface, mark):
+        """ Mark all packets coming from the input_interface with "555".  Marking is needed because input interface
+        query is not available in POSTROUTING chain """
         rule_template = ["PREROUTING", "-i", input_interface, "-j", "MARK", "--set-mark", f"{mark}"]
 
         return " ".join(rule_template)
 
-    # Perform MASQUERADE nat operation  on all marked packets with "555" and their output interface is "output_interface"
-    def _build_nat_string(self, output_interface, mark):
+    @staticmethod
+    def _build_nat_string(output_interface, mark):
+        """ Perform MASQUERADE nat operation  on all marked packets with "555" and their output interface
+        is 'output_interface' """
         rule_template = ["POSTROUTING", "-m", "mark", "--mark", f"{mark}", "-o", output_interface, "-j", "MASQUERADE"]
 
         return " ".join(rule_template)
 
-    # Build iptables command
-    def _build_rule_string(self, option, rule_suffix):
-        rule_template = ["iptables", "-t", "nat",  f"--{option}", rule_suffix]
+    @staticmethod
+    def _build_rule_string(option, rule_suffix):
+        """ Build iptables command """
+        rule_template = ["iptables", "-t", "nat", f"--{option}", rule_suffix]
 
         return " ".join(rule_template)
 
-    # Check if rule exists
-    def _does_rule_exist(self, rule_suffix):
-        check_rule = self._build_rule_string('check', rule_suffix)
+    @classmethod
+    def _does_rule_exist(cls, rule_suffix):
+        """ Check if rule exists """
+        check_rule = cls._build_rule_string('check', rule_suffix)
         _, _, exit_code = run_command(check_rule, shell=True, raise_errors=False)
 
         return exit_code == 0
 
-    # Insert a new rule
-    def _insert_rule(self, rule_suffix):
-        insert_rule = self._build_rule_string('insert', rule_suffix)
+    @classmethod
+    def _insert_rule(cls, rule_suffix):
+        """ Insert a new rule """
+        insert_rule = cls._build_rule_string('insert', rule_suffix)
         logging.info("Adding rule \"%s\"", insert_rule)
         run_command(insert_rule, shell=True)
 
-    # Insert a new rule
-    def _delete_rule(self, rule_suffix):
-        delete_rule = self._build_rule_string('delete', rule_suffix)
+    @classmethod
+    def _delete_rule(cls, rule_suffix):
+        """ Insert a new rule """
+        delete_rule = cls._build_rule_string('delete', rule_suffix)
         logging.info("Delete rule \"%s\"", delete_rule)
         run_command(delete_rule, shell=True)
 
-    # Add a new rule if it doesn't already exist
-    def _add_rule(self, rule_suffix):
-        if not self._does_rule_exist(rule_suffix):
-            self._insert_rule(rule_suffix)
+    @classmethod
+    def _add_rule(cls, rule_suffix):
+        """ Add a new rule if it doesn't already exist """
+        if not cls._does_rule_exist(rule_suffix):
+            cls._insert_rule(rule_suffix)
 
-    # Add a new rule if it doesn't already exist
-    def _remove_rule(self, rule_suffix):
-        if self._does_rule_exist(rule_suffix):
-            self._delete_rule(rule_suffix)
+    @classmethod
+    def _remove_rule(cls, rule_suffix):
+        """ Add a new rule if it doesn't already exist """
+        if cls._does_rule_exist(rule_suffix):
+            cls._delete_rule(rule_suffix)
 
-    # Add rules for the input interfaces and output interfaces
-    def add_nat_rules(self, input_interfaces, ns_index):
+    @classmethod
+    def add_nat_rules(cls, input_interfaces, ns_index):
+        """" Add rules for the input interfaces and output interfaces """
         logging.info("Adding nat rules for interfaces %s", input_interfaces)
-        mark = self._build_mark(ns_index)
-        for output_interface in self._get_default_interfaces():
-            self._add_rule(self._build_nat_string(output_interface, mark))
+        mark = cls._build_mark(ns_index)
+        for output_interface in cls._get_default_interfaces():
+            cls._add_rule(cls._build_nat_string(output_interface, mark))
         for input_interface in input_interfaces:
-            self._add_rule(self._build_mark_string(input_interface, mark))
+            cls._add_rule(cls._build_mark_string(input_interface, mark))
 
-    # Delete nat rules
-    def remove_nat_rules(self, input_interfaces, ns_index):
+    @classmethod
+    def remove_nat_rules(cls, input_interfaces, ns_index):
+        """  Delete nat rules """
         logging.info("Deleting nat rules for interfaces %s", input_interfaces)
-        mark = self._build_mark(ns_index)
+        mark = cls._build_mark(ns_index)
         for input_interface in input_interfaces:
-            self._remove_rule(self._build_mark_string(input_interface, mark))
-        for output_interface in self._get_default_interfaces():
-            self._remove_rule(self._build_nat_string(output_interface, mark))
+            cls._remove_rule(cls._build_mark_string(input_interface, mark))
+        for output_interface in cls._get_default_interfaces():
+            cls._remove_rule(cls._build_nat_string(output_interface, mark))

--- a/discovery-infra/test_infra/helper_classes/nodes.py
+++ b/discovery-infra/test_infra/helper_classes/nodes.py
@@ -24,7 +24,6 @@ class Nodes:
     def __init__(self, node_controller: NodeController, private_ssh_key_path):
         self.controller = node_controller
         self.private_ssh_key_path = private_ssh_key_path
-        self._nat_controller = NatController()
         self._nodes = None
         self._nodes_as_dict = None
 
@@ -57,11 +56,11 @@ class Nodes:
 
     def configure_nat(self):
         nat_interfaces = self.nat_interfaces
-        self._nat_controller.add_nat_rules(nat_interfaces, self._get_namespace_index(nat_interfaces[0]))
+        NatController.add_nat_rules(nat_interfaces, self._get_namespace_index(nat_interfaces[0]))
 
     def unconfigure_nat(self):
         nat_interfaces = self.nat_interfaces
-        self._nat_controller.remove_nat_rules(nat_interfaces, self._get_namespace_index(nat_interfaces[0]))
+        NatController.remove_nat_rules(nat_interfaces, self._get_namespace_index(nat_interfaces[0]))
 
     def drop_cache(self):
         self._nodes = None

--- a/discovery-infra/test_infra/helper_classes/nodes.py
+++ b/discovery-infra/test_infra/helper_classes/nodes.py
@@ -44,23 +44,24 @@ class Nodes:
         for n in self.nodes:
             yield n
 
-    @classmethod
-    def _get_namespace_index(cls, libvirt_network_if):
-        # Hack to retrieve namespace index - does not exist in tests
+    @property
+    def nat_interfaces(self):
+        return (self.controller.network_conf.libvirt_network_if,
+                self.controller.network_conf.libvirt_secondary_network_if)
+
+    @staticmethod
+    def _get_namespace_index(libvirt_network_if):
+        """ Hack to retrieve namespace index - does not exist in tests """
         matcher = re.match(r'^tt(\d+)$', libvirt_network_if)
         return int(matcher.groups()[0]) if matcher is not None else 0
 
     def configure_nat(self):
-        libvirt_network_if = self.controller.network_conf.libvirt_network_if
-        libvirt_secondary_network_if = self.controller.network_conf.libvirt_secondary_network_if
-        input_interfaces = [libvirt_network_if, libvirt_secondary_network_if]
-        self._nat_controller.add_nat_rules(input_interfaces, self._get_namespace_index(libvirt_network_if))
+        nat_interfaces = self.nat_interfaces
+        self._nat_controller.add_nat_rules(nat_interfaces, self._get_namespace_index(nat_interfaces[0]))
 
     def unconfigure_nat(self):
-        libvirt_network_if = self.controller.network_conf.libvirt_network_if
-        libvirt_secondary_network_if = self.controller.network_conf.libvirt_secondary_network_if
-        input_interfaces = [libvirt_network_if, libvirt_secondary_network_if]
-        self._nat_controller.remove_nat_rules(input_interfaces, self._get_namespace_index(libvirt_network_if))
+        nat_interfaces = self.nat_interfaces
+        self._nat_controller.remove_nat_rules(nat_interfaces, self._get_namespace_index(nat_interfaces[0]))
 
     def drop_cache(self):
         self._nodes = None

--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -40,6 +40,7 @@ class BaseTest:
         else:
             node_vars = env_variables
         net_asset = None
+        needs_nat = "platform" in node_vars and node_vars["platform"] == consts.Platforms.NONE
         try:
             if not qe_env:
                 net_asset = NetworkAssets()
@@ -47,10 +48,14 @@ class BaseTest:
             controller = setup_node_controller(**node_vars)
             nodes = Nodes(controller, node_vars["private_ssh_key_path"])
             nodes.prepare_nodes()
+            if needs_nat:
+                nodes.configure_nat()
             yield nodes
             if env_variables['test_teardown']:
                 logging.info('--- TEARDOWN --- node controller\n')
                 nodes.destroy_all_nodes()
+            if needs_nat:
+                nodes.unconfigure_nat()
         finally:
             if not qe_env:
                 net_asset.release_all()

--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -40,7 +40,7 @@ class BaseTest:
         else:
             node_vars = env_variables
         net_asset = None
-        needs_nat = "platform" in node_vars and node_vars["platform"] == consts.Platforms.NONE
+        needs_nat = node_vars.get("platform") == consts.Platforms.NONE
         try:
             if not qe_env:
                 net_asset = NetworkAssets()


### PR DESCRIPTION
Put `configure_nat` and `unconfigure_nat` methods in nodes.py and tear them down if needed in the nodes fixture. Also, make NatController a static class, no `self` is needed.