### PR TITLE
Add xtrace for run_minikube script

### DIFF
--- a/scripts/run_minikube.sh
+++ b/scripts/run_minikube.sh
@@ -2,6 +2,11 @@
 
 source scripts/utils.sh
 
+set -o nounset
+set -o pipefail
+set -o errexit
+set -o xtrace
+
 export PROFILE=${PROFILE:-assisted-installer}
 
 function configure_minikube() {


### PR DESCRIPTION
Instead of 
```bash
[root@f13-h20-b08-5039ms assisted-test-infra]# make start_minikube 
scripts/run_minikube.sh
Configuring minikube...
eval 
```
Now we will know if it runs a new instance of minikube or not

```bash
[root@f13-h20-b08-5039ms assisted-test-infra]# make start_minikube 
scripts/run_minikube.sh
+ export PROFILE=minikube
+ PROFILE=minikube
+ '[' minikube '!=' minikube ']'
+ configure_minikube
+ echo 'Configuring minikube...'
Configuring minikube...
+ minikube config set ShowBootstrapperDeprecationNotification false
+ minikube config set WantUpdateNotification false
+ minikube config set WantReportErrorPrompt false
+ minikube config set WantKubectlDownloadMsg false
+ as_singleton init_minikube
+ func=init_minikube
+ interval=15s
+ lockfile=/tmp/init_minikube.lock
+ '[' -e /tmp/init_minikube.lock ']'
+ trap 'rm "$lockfile"; exit' EXIT INT TERM HUP
+ touch /tmp/init_minikube.lock
+ init_minikube
++ virsh -c qemu:///system list --name
+ minikube start --driver=kvm2 --memory=8192 --cpus=4 --profile=minikube --force --wait-timeout=15m0s --disk-size=50g
😄  minikube v1.10.1 on Redhat 8.2
    ▪ KUBECONFIG=/root/.kube/config
✨  Using the kvm2 driver based on user configuration
🛑  The "kvm2" driver should not be used with root privileges.
💡  If you are running minikube within a VM, consider using --driver=none:
📘    https://minikube.sigs.k8s.io/docs/reference/drivers/none/
👍  Starting control plane node minikube in cluster minikube
🔥  Creating kvm2 VM (CPUs=4, Memory=8192MB, Disk=51200MB) ...
🐳  Preparing Kubernetes v1.18.2 on Docker 19.03.8 ...
🔎  Verifying Kubernetes components...
🌟  Enabled addons: default-storageclass, storage-provisioner
🏄  Done! kubectl is now configured to use "minikube"
+ minikube tunnel --cleanup
+ rm /tmp/init_minikube.lock
+ exit
eval 
```