### PR TITLE
Install minikube and kubectl using arkade

### DIFF
--- a/scripts/install_minikube.sh
+++ b/scripts/install_minikube.sh
@@ -9,9 +9,8 @@ function install_minikube() {
 
     if ! [ -x "$(command -v minikube)" ]; then
         echo "Installing minikube..."
-        curl --retry 3 -Lo minikube https://storage.googleapis.com/minikube/releases/v1.8.2/minikube-linux-amd64
-        chmod +x minikube
-        ${SUDO} cp minikube /usr/bin/
+        arkade get minikube --version=v1.18.1
+        ${SUDO} mv ${HOME}/.arkade/bin/minikube /usr/local/bin/
     else
         echo "minikube is already installed"
     fi
@@ -20,9 +19,8 @@ function install_minikube() {
 function install_kubectl() {
     if ! [ -x "$(command -v kubectl)" ]; then
         echo "Installing kubectl..."
-        curl --retry 3 -Lo kubectl https://storage.googleapis.com/kubernetes-release/release/v1.17.0/bin/linux/amd64/kubectl
-        chmod +x kubectl
-        ${SUDO} mv kubectl /usr/bin/
+        arkade get kubectl --version=v1.20.0
+        ${SUDO} mv ${HOME}/.arkade/bin/kubectl /usr/local/bin/
     else
         echo "kubectl is already installed"
     fi
@@ -41,6 +39,16 @@ function install_oc() {
     fi
 }
 
+function install_arkade() {
+    if ! [ -x "$(command -v arkade)" ]; then
+        echo "Installing arkade..."
+        curl -sLS https://dl.get-arkade.dev | ${SUDO} sh
+    else
+        echo "arkade is already installed"
+    fi
+}
+
+install_arkade
 install_minikube
 install_kubectl
 install_oc


### PR DESCRIPTION
Instead of maintaining different URLS for tools installations,
arkade provides a portable marketplace for downloading devops CLIs.

- Bumping minikube to v1.18.1
- Bumping kubectl to v1.20.0

stdout:
```bash
Installing minikube and oc
Installing arkade...
x86_64
Downloading package https://github.com/alexellis/arkade/releases/download/0.7.10/arkade as /tmp/arkade
Download complete.

Running with sufficient permissions to attempt to move arkade to /usr/local/bin
New version of arkade installed to /usr/local/bin
which: no ark in (/sbin:/bin:/usr/sbin:/usr/bin)
Creating alias 'ark' for 'arkade'.
main: line 176: arkade: command not found
Installing minikube...
Downloading minikube
https://github.com/kubernetes/minikube/releases/download/v1.18.1/minikube-linux-amd64
9.20 MiB / 57.02 MiB [----------->__________________________________________________________] 16.14%21.71 MiB / 57.02 MiB [-------------------------->__________________________________________] 38.07%34.01 MiB / 57.02 MiB [----------------------------------------->___________________________] 59.65%46.61 MiB / 57.02 MiB [-------------------------------------------------------->____________] 81.73%57.02 MiB / 57.02 MiB [--------------------------------------------------------------------] 100.00%Tool written to: /root/.arkade/bin/minikube

# Add (minikube) to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/root/.arkade/bin/minikube

# Or install with:
sudo mv /root/.arkade/bin/minikube /usr/local/bin/

Installing kubectl...
Downloading kubectl
https://storage.googleapis.com/kubernetes-release/release/v1.20.0/bin/linux/amd64/kubectl
20.00 MiB / 38.37 MiB [----------------------------------->_________________________________] 52.13%38.37 MiB / 38.37 MiB [--------------------------------------------------------------------] 100.00%Tool written to: /root/.arkade/bin/kubectl

# Add (kubectl) to your PATH variable
export PATH=$PATH:$HOME/.arkade/bin/

# Test the binary:
/root/.arkade/bin/kubectl

# Or install with:
sudo mv /root/.arkade/bin/kubectl /usr/local/bin/
```