### PR TITLE
NO-ISSUE update minikube version if stale

### DIFF
--- a/scripts/install_minikube.sh
+++ b/scripts/install_minikube.sh
@@ -7,9 +7,11 @@ function install_minikube() {
         return
     fi
 
-    if ! [ -x "$(command -v minikube)" ]; then
+    minikube_version=v1.18.1
+    minikube_path=$(command -v minikube)
+    if ! [ -x "$minikube_path" ] || [ $(minikube version -o json | jq -r '.minikubeVersion') != $minikube_version ]; then
         echo "Installing minikube..."
-        arkade get minikube --version=v1.18.1
+        arkade get minikube --version=$minikube_version
         ${SUDO} mv ${HOME}/.arkade/bin/minikube /usr/local/bin/
     else
         echo "minikube is already installed"


### PR DESCRIPTION
Currently, 'install_minikube' checks only whether minikube is installed.
To avoid a stale version, updating minikube when necessary.
This seems to prevent issues like "Wait for http://<pending>:8090/ready",
when using 'tunnel --cleanup':
https://github.com/openshift/assisted-test-infra/blob/1132db6444569f074efa62b27bc646f33a5a420b/scripts/run_minikube.sh#L29