### PR TITLE
Revert "NO-ISSUE pull latest code on origin remote"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -12,13 +12,13 @@ REPORTS = $(ROOT_DIR)/reports
 SKIPPER_PARAMS ?= -i
 
 # assisted-service
-SERVICE_BRANCH := $(or $(SERVICE_BRANCH), "origin/master")
+SERVICE_BRANCH := $(or $(SERVICE_BRANCH), "master")
 SERVICE_REPO := $(or $(SERVICE_REPO), "https://github.com/openshift/assisted-service")
 SERVICE := $(or $(SERVICE), quay.io/ocpmetal/assisted-service:latest)
 SERVICE_NAME := $(or $(SERVICE_NAME),assisted-service)
 
 # assisted-installer
-INSTALLER_BRANCH := $(or $(INSTALLER_BRANCH), "origin/master")
+INSTALLER_BRANCH := $(or $(INSTALLER_BRANCH), "master")
 INSTALLER_REPO := $(or $(INSTALLER_REPO), "https://github.com/openshift/assisted-installer")
 
 # ui service
@@ -281,7 +281,7 @@ bring_assisted_installer:
 		git clone $(INSTALLER_REPO); \
 	fi
 
-	@cd assisted-installer && git fetch origin && git reset --hard $(INSTALLER_BRANCH)
+	@cd assisted-installer && git fetch origin $(INSTALLER_BRANCH) && git reset --hard $(INSTALLER_BRANCH)
 
 ###########
 # Cluster #
@@ -367,7 +367,7 @@ bring_assisted_service:
 		git clone $(SERVICE_REPO); \
 	fi
 
-	@cd assisted-service && git fetch origin && git reset --hard $(SERVICE_BRANCH)
+	@cd assisted-service && git fetch origin $(SERVICE_BRANCH) && git reset --hard $(SERVICE_BRANCH)
 
 deploy_monitoring: bring_assisted_service
 	make -C assisted-service/ deploy-monitoring NAMESPACE=$(NAMESPACE) PROFILE=$(PROFILE)

--- a/README.md
+++ b/README.md
@@ -75,9 +75,7 @@ Check the [Install Guide](GUIDE.md) for installation instructions.
 | HTTPS_PROXY_URL             | A proxy URL to use for creating HTTPS connections outside the cluster                                                                       |
 | HTTP_PROXY_URL              | A proxy URL to use for creating HTTP connections outside the cluster                                                                        |
 | IMAGE_BUILDER               | image-builder image to use, will update assisted-service config map with given value                                                        |
-| INSTALLER_BRANCH            | assisted-installer branch to use, default: origin/master                                                                                    |
 | INSTALLER_IMAGE             | assisted-installer image to use, will update assisted-service config map with given value                                                   |
-| INSTALLER_REPO              | assisted-installer repository to use, default: https://github.com/openshift/assisted-installer                                              |
 | IPv4                        | Boolean value indicating if IPv4 is enabled. Default is yes                                                                                 |
 | IPv6                        | Boolean value indicating if IPv6 is enabled. Default is no                                                                                  |
 | ISO                         | path to ISO to spawn VM with, if set vms will be spawn with this iso without creating cluster. File must have the '.iso' suffix             |
@@ -88,7 +86,7 @@ Check the [Install Guide](GUIDE.md) for installation instructions.
 | NO_PROXY_VALUES             | A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying                       |
 | NUM_MASTERS                 | number of VMs to spawn as masters, default: 3                                                                                               |
 | NUM_WORKERS                 | number of VMs to spawn as workers, default: 0                                                                                               |
-| OCM_BASE_URL                | OCM API URL used to communicate with OCM and AMS, default: https://api.integration.openshift.com/                                           |
+| OCM_BASE_URL                | OCM API URL used to communicate with OCM and AMS, default: https://api.integration.openshift.com/                  |
 | OCM_CLIENT_ID               | ID of Service Account used to communicate with OCM and AMS for Agent Auth and Authz                                                         |
 | OCM_CLIENT_SECRET           | Password of Service Account used to communicate with OCM and AMS for Agent Auth and Authz                                                   |
 | OC_MODE                     | if set, use oc instead of minikube                                                                                                          |
@@ -104,7 +102,7 @@ Check the [Install Guide](GUIDE.md) for installation instructions.
 | ROUTE53_SECRET              | Amazon Route 53 secret to use for DNS domains registration.                                                                                 |
 | SERVICE                     | assisted-service image to use                                                                                                               |
 | SERVICE_BASE_URL            | update assisted-service config map SERVICE_BASE_URL parameter with given URL, including port and protocol                                   |
-| SERVICE_BRANCH              | assisted-service branch to use, default: origin/master                                                                                      |
+| SERVICE_BRANCH              | assisted-service branch to use, default: master                                                                                             |
 | SERVICE_NAME                | assisted-service target service name, default: assisted-service                                                                             |
 | SERVICE_REPO                | assisted-service repository to use, default: https://github.com/openshift/assisted-service                                                  |
 | SSH_PUB_KEY                 | SSH public key to use for image generation, gives option to SSH to VMs, default: ssh_key/key_pub                                            |
@@ -113,7 +111,7 @@ Check the [Install Guide](GUIDE.md) for installation instructions.
 | WORKER_MEMORY               | memory for worker VM, default: 8892MB                                                                                                       |
 | PUBLIC_CONTAINER_REGISTRIES | comma-separated list of registries that do not require authentication for pulling assisted installer images                                 |
 | CHECK_CLUSTER_VERSION       | If "True", the controller will wait for CVO to finish                                                                                       |
-| ENABLE_KUBE_API             | If set, deploy assisted-service with Kube API controllers (minikube only)                                                                   |
+| ENABLE_KUBE_API             | If set, deploy assisted-service with Kube API controllers (minikube only)                                                                                     |
 
 ## Instructions
 


### PR DESCRIPTION
Reverts openshift/assisted-test-infra#673
It breaks the CI, not supporting SHAs
```bash
➜  assisted-test-infra git:(master) SERVICE_BRANCH=200a658589c6986a3888ac29fc4247b7e21f716c make bring_assisted_service 
Cloning into 'assisted-service'...
remote: Enumerating objects: 828, done.
remote: Counting objects: 100% (828/828), done.
remote: Compressing objects: 100% (439/439), done.
remote: Total 20358 (delta 482), reused 616 (delta 377), pack-reused 19530
Receiving objects: 100% (20358/20358), 32.34 MiB | 7.57 MiB/s, done.
Resolving deltas: 100% (15070/15070), done.
fatal: Could not parse object '200a658589c6986a3888ac29fc4247b7e21f716c'.
make: *** [Makefile:367: bring_assisted_service] Error 128
```