### PR TITLE
Adding cluster methods for e2e

### DIFF
--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -536,6 +536,11 @@ class Cluster:
             fall_on_error_status=False,
         )
 
+    def is_operator_in_status(self, operator_name, status):
+        return utils.is_operator_in_status(operators=self.get_operators(),
+                                           operator_name=operator_name,
+                                           status=status)
+
     def wait_for_install(
             self,
             timeout=consts.CLUSTER_INSTALLATION_TIMEOUT
@@ -723,6 +728,15 @@ class Cluster:
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.INSTALLING],
             timeout=consts.START_CLUSTER_INSTALLATION_TIMEOUT
+        )
+
+    def wait_for_cluster_to_be_in_finalizing_status(self):
+        utils.wait_till_cluster_is_in_status(
+            client=self.api_client,
+            cluster_id=self.id,
+            statuses=[consts.ClusterStatus.FINALIZING, consts.ClusterStatus.INSTALLED],
+            timeout=consts.CLUSTER_INSTALLATION_TIMEOUT,
+            break_statuses=[consts.ClusterStatus.ERROR]
         )
 
     @classmethod

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -220,6 +220,17 @@ def are_operators_in_status(operators: List[MonitoredOperator], operators_count:
     return False
 
 
+def is_operator_in_status(operators: List[MonitoredOperator], operator_name: str, status: str) -> bool:
+    log.info(
+        f"Asked operator %s to be in status: %s, and currently operators statuses are %s",
+        operator_name,
+        status,
+        [(operator.name, operator.status, operator.status_info) for operator in operators],
+    )
+    return any(operator.status == status for operator in operators
+               if operator.name == operator_name)
+
+
 def wait_till_hosts_with_macs_are_in_status(
         client,
         cluster_id,


### PR DESCRIPTION
Adding wait_for_cluster_to_be_in_finalizing_status and is_operator_in_status methods for e2e that simulate operator failure
