### PR TITLE
NOISSUE: raise error if ClusterDeployment status changed to error

### DIFF
--- a/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
@@ -34,6 +34,7 @@ from .installenv import deploy_default_installenv, InstallEnv, Proxy
 from .common import (
     create_kube_api_client,
     delete_all_resources,
+    UnexpectedStateError,
     KubeAPIContext,
     ObjectReference
 )
@@ -54,4 +55,5 @@ __all__ = (
     'InstallEnv',
     'Proxy',
     'NMStateConfig',
+    'UnexpectedStateError',
 )

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/common.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/common.py
@@ -15,6 +15,10 @@ logging.getLogger('kubernetes').setLevel(logging.INFO)
 logger = logging.getLogger(__name__)
 
 
+class UnexpectedStateError(Exception):
+    pass
+
+
 class KubeAPIContext:
     """
     This class is used to hold information shared between both kubernetes and

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/global_vars.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/global_vars.py
@@ -14,6 +14,8 @@ DEFAULT_MACHINE_CIDR = env_variables.get('machine_cidr', '')
 DEFAULT_CLUSTER_CIDR = env_variables.get('cluster_cidr', '172.30.0.0/16')
 DEFAULT_SERVICE_CIDR = env_variables.get('service_cidr', '10.128.0.0/14')
 
+FAILURE_STATES = ('error', 'cancelled')
+
 _MINUTE = 60
 _HOUR = 60 * _MINUTE
 


### PR DESCRIPTION
Instead of waiting 2 hours to find out the installation has failed,
raise error immediately if the status changes to error.