### PR TITLE
NOISSUE centralized kube api group and version vars

### DIFF
--- a/discovery-infra/test_infra/helper_classes/kube_helpers/agent.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/agent.py
@@ -9,7 +9,11 @@ from tests.conftest import env_variables
 
 from .common import logger, ObjectReference
 from .base_resource import BaseCustomResource
-from .global_vars import DEFAULT_WAIT_FOR_CRD_STATUS_TIMEOUT
+from .global_vars import (
+    CRD_API_GROUP,
+    CRD_API_VERSION,
+    DEFAULT_WAIT_FOR_CRD_STATUS_TIMEOUT,
+)
 
 
 class Agent(BaseCustomResource):
@@ -19,8 +23,6 @@ class Agent(BaseCustomResource):
     resource and assign it to the relevant cluster.
     In oder to start the installation, all assigned agents must be approved.
     """
-    _api_group = 'adi.io.my.domain'
-    _version = 'v1alpha1'
     _plural = 'agents'
 
     def __init__(
@@ -39,8 +41,8 @@ class Agent(BaseCustomResource):
             cluster_deployment: 'ClusterDeployment',
     ) -> List['Agent']:
         resources = crd_api.list_namespaced_custom_object(
-            group=cls._api_group,
-            version=cls._version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=cls._plural,
             namespace=cluster_deployment.ref.namespace,
         )
@@ -68,8 +70,8 @@ class Agent(BaseCustomResource):
 
     def get(self) -> dict:
         return self.crd_api.get_namespaced_custom_object(
-            group=self._api_group,
-            version=self._version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,
@@ -79,8 +81,8 @@ class Agent(BaseCustomResource):
         body = {'spec': kwargs}
 
         self.crd_api.patch_namespaced_custom_object(
-            group=self._api_group,
-            version=self._version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,
@@ -93,8 +95,8 @@ class Agent(BaseCustomResource):
 
     def delete(self) -> None:
         self.crd_api.delete_namespaced_custom_object(
-            group=self._api_group,
-            version=self._version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/cluster_deployment.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/cluster_deployment.py
@@ -11,6 +11,9 @@ from kubernetes.client.rest import ApiException
 from tests.conftest import env_variables
 
 from .global_vars import (
+    CRD_API_GROUP,
+    HIVE_API_GROUP,
+    HIVE_API_VERSION,
     DEFAULT_API_VIP,
     DEFAULT_API_VIP_DNS_NAME,
     DEFAULT_INGRESS_VIP,
@@ -130,9 +133,6 @@ class ClusterDeployment(BaseCustomResource):
     On deletion it will be unregistered from the service.
     When has sufficient data installation will start automatically.
     """
-
-    _api_group = 'hive.openshift.io'
-    _api_version = 'v1'
     _plural = 'clusterdeployments'
 
     def __init__(
@@ -146,8 +146,8 @@ class ClusterDeployment(BaseCustomResource):
 
     def create_from_yaml(self, yaml_data: dict) -> None:
         self.crd_api.create_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=HIVE_API_GROUP,
+            version=HIVE_API_VERSION,
             plural=self._plural,
             body=yaml_data,
             namespace=self.ref.namespace,
@@ -166,7 +166,7 @@ class ClusterDeployment(BaseCustomResource):
             **kwargs,
     ):
         body = {
-            'apiVersion': f'{self._api_group}/{self._api_version}',
+            'apiVersion': f'{HIVE_API_GROUP}/{HIVE_API_VERSION}',
             'kind': 'ClusterDeployment',
             'metadata': self.ref.as_dict(),
             'spec': {
@@ -179,8 +179,8 @@ class ClusterDeployment(BaseCustomResource):
         }
         body['spec'].update(kwargs)
         self.crd_api.create_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=HIVE_API_GROUP,
+            version=HIVE_API_VERSION,
             plural=self._plural,
             body=body,
             namespace=self.ref.namespace,
@@ -212,8 +212,8 @@ class ClusterDeployment(BaseCustomResource):
             spec['pullSecretRef'] = secret.ref.as_dict()
 
         self.crd_api.patch_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=HIVE_API_GROUP,
+            version=HIVE_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,
@@ -228,14 +228,14 @@ class ClusterDeployment(BaseCustomResource):
         body = {
             'metadata': {
                 'annotations': {
-                    'adi.io.my.domain/install-config-overrides': install_config
+                    f'{CRD_API_GROUP}/install-config-overrides': install_config
                 }
             }
         }
 
         self.crd_api.patch_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=HIVE_API_GROUP,
+            version=HIVE_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,
@@ -248,8 +248,8 @@ class ClusterDeployment(BaseCustomResource):
 
     def get(self) -> dict:
         return self.crd_api.get_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=HIVE_API_GROUP,
+            version=HIVE_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,
@@ -257,8 +257,8 @@ class ClusterDeployment(BaseCustomResource):
 
     def delete(self) -> None:
         self.crd_api.delete_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=HIVE_API_GROUP,
+            version=HIVE_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/global_vars.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/global_vars.py
@@ -1,6 +1,11 @@
 from tests.conftest import env_variables
 
 
+CRD_API_GROUP = 'adi.io.my.domain'
+CRD_API_VERSION = 'v1alpha1'
+HIVE_API_GROUP = 'hive.openshift.io'
+HIVE_API_VERSION = 'v1'
+
 DEFAULT_API_VIP = env_variables.get('api_vip', '')
 DEFAULT_API_VIP_DNS_NAME = env_variables.get('api_vip_dns_name', '')
 DEFAULT_INGRESS_VIP = env_variables.get('ingress_vip', '')

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/installenv.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/installenv.py
@@ -15,6 +15,8 @@ from .base_resource import BaseCustomResource
 from .cluster_deployment import ClusterDeployment
 from .secret import deploy_default_secret, Secret
 from .global_vars import (
+    CRD_API_GROUP,
+    CRD_API_VERSION,
     DEFAULT_WAIT_FOR_CRD_STATUS_TIMEOUT,
     DEFAULT_WAIT_FOR_ISO_URL_TIMEOUT,
 )
@@ -66,8 +68,6 @@ class InstallEnv(BaseCustomResource):
     Image is automatically generated on CRD deployment, after InstallEnv is
     reconciled. Image download url will be exposed in the status.
     """
-    _api_group = 'adi.io.my.domain'
-    _api_version = 'v1alpha1'
     _plural = 'installenvs'
 
     def __init__(
@@ -81,8 +81,8 @@ class InstallEnv(BaseCustomResource):
 
     def create_from_yaml(self, yaml_data: dict) -> None:
         self.crd_api.create_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             body=yaml_data,
             namespace=self.ref.namespace,
@@ -103,7 +103,7 @@ class InstallEnv(BaseCustomResource):
             **kwargs,
     ) -> None:
         body = {
-            'apiVersion': f'{self._api_group}/{self._api_version}',
+            'apiVersion': f'{CRD_API_GROUP}/{CRD_API_VERSION}',
             'kind': 'InstallEnv',
             'metadata': self.ref.as_dict(),
             'spec': {
@@ -111,7 +111,7 @@ class InstallEnv(BaseCustomResource):
                 'pullSecretRef': secret.ref.as_dict(),
                 'nmStateConfigLabelSelector': {
                     'matchLabels': {
-                        f'{self._api_group}/selector-nmstate-config-name':
+                        f'{CRD_API_GROUP}/selector-nmstate-config-name':
                             nmstate_label or ''
                     }
                 },
@@ -124,8 +124,8 @@ class InstallEnv(BaseCustomResource):
             spec['proxy'] = proxy.as_dict()
         spec.update(kwargs)
         self.crd_api.create_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             body=body,
             namespace=self.ref.namespace,
@@ -163,7 +163,7 @@ class InstallEnv(BaseCustomResource):
         if nmstate_label:
             spec['nmStateConfigLabelSelector'] = {
                 'matchLabels': {
-                    f'{self._api_group}/selector-nmstate-config-name': nmstate_label,
+                    f'{CRD_API_GROUP}/selector-nmstate-config-name': nmstate_label,
                 }
             }
 
@@ -171,8 +171,8 @@ class InstallEnv(BaseCustomResource):
             spec['ignitionConfigOverride'] = ignition_config_override
 
         self.crd_api.patch_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,
@@ -185,8 +185,8 @@ class InstallEnv(BaseCustomResource):
 
     def get(self) -> dict:
         return self.crd_api.get_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,
@@ -194,8 +194,8 @@ class InstallEnv(BaseCustomResource):
 
     def delete(self) -> None:
         self.crd_api.delete_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/nmstate_config.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/nmstate_config.py
@@ -7,34 +7,35 @@ from kubernetes.client import ApiClient, CustomObjectsApi
 
 from tests.conftest import env_variables
 from .base_resource import BaseCustomResource
-from .global_vars import DEFAULT_WAIT_FOR_CRD_STATUS_TIMEOUT
-
+from .global_vars import (
+    CRD_API_GROUP,
+    CRD_API_VERSION,
+    DEFAULT_WAIT_FOR_CRD_STATUS_TIMEOUT,
+)
 
 logger = logging.getLogger(__name__)
 
 
 class NMStateConfig(BaseCustomResource):
     """Configure nmstate (static IP) related settings for agents."""
-    _api_group = 'adi.io.my.domain'
-    _api_version = 'v1alpha1'
     _plural = 'nmstateconfigs'
 
     def __init__(
             self,
             kube_api_client: ApiClient,
             name: str,
-            namespace: str = env_variables['namespace']
+            namespace: str = env_variables['namespace'],
     ):
         super().__init__(name, namespace)
         self.crd_api = CustomObjectsApi(kube_api_client)
 
     def create_from_yaml(self, yaml_data: dict) -> None:
         self.crd_api.create_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             body=yaml_data,
-            namespace=self.ref.namespace
+            namespace=self.ref.namespace,
         )
 
         logger.info(
@@ -46,14 +47,14 @@ class NMStateConfig(BaseCustomResource):
             config: dict,
             interfaces: list,
             label: Optional[str] = None,
-            **kwargs
+            **kwargs,
     ) -> None:
         body = {
-            'apiVersion': f'{self._api_group}/{self._api_version}',
+            'apiVersion': f'{CRD_API_GROUP}/{CRD_API_VERSION}',
             'kind': 'NMStateConfig',
             'metadata': {
                 'labels': {
-                    f'{self._api_group}/selector-nmstate-config-name': label,
+                    f'{CRD_API_GROUP}/selector-nmstate-config-name': label,
                 },
                 **self.ref.as_dict()
             },
@@ -64,11 +65,11 @@ class NMStateConfig(BaseCustomResource):
         }
         body['spec'].update(kwargs)
         self.crd_api.create_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             body=body,
-            namespace=self.ref.namespace
+            namespace=self.ref.namespace,
         )
 
         logger.info(
@@ -79,7 +80,7 @@ class NMStateConfig(BaseCustomResource):
             self,
             config: dict,
             interfaces: list,
-            **kwargs
+            **kwargs,
     ) -> None:
         body = {'spec': kwargs}
 
@@ -91,12 +92,12 @@ class NMStateConfig(BaseCustomResource):
             spec['interfaces'] = interfaces
 
         self.crd_api.patch_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
             namespace=self.ref.namespace,
-            body=body
+            body=body,
         )
 
         logger.info(
@@ -105,20 +106,20 @@ class NMStateConfig(BaseCustomResource):
 
     def get(self) -> dict:
         return self.crd_api.get_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
-            namespace=self.ref.namespace
+            namespace=self.ref.namespace,
         )
 
     def delete(self) -> None:
         self.crd_api.delete_namespaced_custom_object(
-            group=self._api_group,
-            version=self._api_version,
+            group=CRD_API_GROUP,
+            version=CRD_API_VERSION,
             plural=self._plural,
             name=self.ref.name,
-            namespace=self.ref.namespace
+            namespace=self.ref.namespace,
         )
 
         logger.info('deleted nmstate config %s', self.ref)


### PR DESCRIPTION
To reduce future work in case of any change, use
global variables for api group and version instead
of duplicated values in every object.