### PR TITLE
MGMT-4640 Using HW_VALIDATOR_REQUIREMENTS

### DIFF
--- a/discovery-infra/update_assisted_service_cm.py
+++ b/discovery-infra/update_assisted_service_cm.py
@@ -11,9 +11,8 @@
 #   MY_VAR: ""
 #
 # Hence, in order to support unset env vars, avoid override in Makefile.
-
+import json
 import os
-
 import yaml
 
 CM_PATH = "assisted-service/deploy/assisted-service-configmap.yaml"
@@ -33,8 +32,26 @@ ENVS = [
     ("IMAGE_BUILDER", ""),
     ("OCM_BASE_URL", ""),
     ("PUBLIC_CONTAINER_REGISTRIES", ""),
-    ("CHECK_CLUSTER_VERSION", "")
+    ("CHECK_CLUSTER_VERSION", ""),
+    ("HW_VALIDATOR_REQUIREMENTS", "")
 ]
+DEFAULT_MASTER_REQUIREMENTS = {
+    "cpu_cores": 4,
+    "ram_mib": 8192,
+    "disk_size_gb": 10,
+    "installation_disk_speed_threshold_ms": 10
+}
+DEFAULT_WORKER_REQUIREMENTS = {
+    "cpu_cores": 2,
+    "ram_mib": 3072,
+    "disk_size_gb": 10,
+    "installation_disk_speed_threshold_ms": 10
+}
+DEFAULT_REQUIREMENTS = [{
+    "version": "default",
+    "master": DEFAULT_MASTER_REQUIREMENTS,
+    "worker": DEFAULT_WORKER_REQUIREMENTS
+}]
 
 
 def _read_yaml():
@@ -56,11 +73,26 @@ def _get_relevant_envs():
     return data
 
 
+def update_requirements(requirements_json):
+    if requirements_json == "" or requirements_json == "REPLACE_HW_VALIDATOR_REQUIREMENTS":
+        return json.dumps(DEFAULT_REQUIREMENTS)
+    requirements = json.loads(requirements_json)
+    for version_requirements in requirements:
+        if version_requirements["version"] == "default":
+            version_requirements["master"] = DEFAULT_MASTER_REQUIREMENTS
+            version_requirements["worker"] = DEFAULT_WORKER_REQUIREMENTS
+
+    return json.dumps(requirements)
+
+
 def set_envs_to_service_cm():
     cm_data = _read_yaml()
     if not cm_data:
         raise Exception("%s must exists before setting envs to it" % CM_PATH)
     cm_data["data"].update(_get_relevant_envs())
+    existing_requirements = cm_data["data"].get("HW_VALIDATOR_REQUIREMENTS", "")
+    requirements = update_requirements(existing_requirements)
+    cm_data["data"].update({"HW_VALIDATOR_REQUIREMENTS": requirements})
     with open(CM_PATH, "w") as cm_file:
         yaml.dump(cm_data, cm_file)
 


### PR DESCRIPTION
This PR adds `HW_VALIDATOR_REQUIREMENTS` env variable handling in update_assisted_service_cm.py

The purpose of this change is to make sure assisted-service is always configured with expected default host requirements after legacy, separate env variable values (`HW_VALIDATOR_MIN_*` at https://github.com/openshift/assisted-service/blob/0ec56929f077cd512e4ef91e3a242ad20d3a7bd4/internal/hardware/validator.go#L41-L46)  are removed from the assisted-service and `HW_VALIDATOR_REQUIREMENTS` takes the full responsibility for setting the host requirements.