### PR TITLE
MGMT-4921 Rename InstallEnv --> InfraEnv

### DIFF
--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -17,7 +17,7 @@ from test_infra.helper_classes import cluster as helper_cluster
 from test_infra.tools import static_network, terraform_utils
 from test_infra.helper_classes.kube_helpers import (
     create_kube_api_client, ClusterDeployment, Platform,
-    InstallStrategy, Secret, InstallEnv, Proxy, NMStateConfig,
+    InstallStrategy, Secret, InfraEnv, Proxy, NMStateConfig,
 )
 
 import bootstrap_in_place as ibip
@@ -703,7 +703,7 @@ def execute_day1_flow(cluster_name):
 
         if args.kube_api:
             http_proxy, https_proxy, no_proxy = _get_http_proxy_params(ipv4=ipv4, ipv6=ipv6)
-            install_env = InstallEnv(
+            install_env = InfraEnv(
                 kube_api_client=kube_client,
                 name=f"{cluster_name}-install-env",
                 namespace=args.namespace

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
@@ -30,7 +30,7 @@ from .cluster_deployment import (
 from .agent import Agent
 from .nmstate_config import NMStateConfig
 from .secret import deploy_default_secret, Secret
-from .installenv import deploy_default_installenv, InstallEnv, Proxy
+from .infraenv import deploy_default_infraenv, InfraEnv, Proxy
 from .common import (
     create_kube_api_client,
     delete_all_resources,
@@ -43,7 +43,7 @@ from .common import (
 __all__ = (
     'deploy_default_cluster_deployment',
     'deploy_default_secret',
-    'deploy_default_installenv',
+    'deploy_default_infraenv',
     'create_kube_api_client',
     'delete_all_resources',
     'suppress_not_found_error',
@@ -54,7 +54,7 @@ __all__ = (
     'Agent',
     'KubeAPIContext',
     'ObjectReference',
-    'InstallEnv',
+    'InfraEnv',
     'Proxy',
     'NMStateConfig',
     'UnexpectedStateError',

--- a/discovery-infra/test_infra/kubeapi_utils.py
+++ b/discovery-infra/test_infra/kubeapi_utils.py
@@ -10,7 +10,7 @@ from test_infra import utils
 from test_infra.helper_classes.kube_helpers import (
     suppress_not_found_error,
     Secret,
-    InstallEnv,
+    InfraEnv,
     ClusterDeployment,
     NMStateConfig,
 )
@@ -105,7 +105,7 @@ def delete_kube_api_resources_for_namespace(
         namespace,
         *,
         secret_name=None,
-        installenv_name=None,
+        infraenv_name=None,
         nmstate_name=None,
 ):
     CoreV1Api.delete_namespaced_secret = suppress_not_found_error(
@@ -132,9 +132,9 @@ def delete_kube_api_resources_for_namespace(
         namespace=namespace,
     ).delete()
 
-    InstallEnv(
+    InfraEnv(
         kube_api_client=kube_api_client,
-        name=installenv_name or f'{name}-install-env',
+        name=infraenv_name or f'{name}-infra-env',
         namespace=namespace,
     ).delete()
 


### PR DESCRIPTION
As the assisted-service KubeAPI approaches a point in which it starts to integrate
with other projects, we make final changes to the API naming.

This PR renames InstallEnv to InfraEnv in our tests.
It follows the footsteps of:  https://github.com/openshift/assisted-service/pull/1485