### PR TITLE
MGMT-4050 	E2E tests for disk ID

### DIFF
--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -175,12 +175,12 @@ class InventoryClient(object):
     def select_installation_disk(self, cluster_id, hosts_with_diskpaths):
         log.info("Setting installation disk for hosts %s in cluster %s", hosts_with_diskpaths, cluster_id)
 
-        def role_to_selected_disk_config(host_id, path, role):
-            disk_config_params = models.DiskConfigParams(id=path, role=role)
+        def role_to_selected_disk_config(host_id, disk_id, role):
+            disk_config_params = models.DiskConfigParams(id=disk_id, role=role)
             return models.ClusterupdateparamsDisksSelectedConfig(id=host_id, disks_config=[disk_config_params])
 
-        disks_selected_config = [role_to_selected_disk_config(h["id"], h["path"], h["role"]) for h in
-                                 hosts_with_diskpaths]
+        disks_selected_config = [role_to_selected_disk_config(h["id"], h["disk_id"] if "disk_id" in h else h["path"],
+                                                              h["role"]) for h in hosts_with_diskpaths]
         params = models.ClusterUpdateParams(disks_selected_config=disks_selected_config)
         return self.client.update_cluster(
             cluster_id=cluster_id, cluster_update_params=params

--- a/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -1,6 +1,7 @@
 import logging
 import os
 import re
+import secrets
 import string
 import tempfile
 from abc import ABC
@@ -193,7 +194,7 @@ class LibvirtController(NodeController, ABC):
 
         return result
 
-    def attach_test_disk(self, node_name, disk_size, bootable=False, persistent=False):
+    def attach_test_disk(self, node_name, disk_size, bootable=False, persistent=False, with_wwn=False):
         """
         Attaches a disk with the given size to the given node. All tests disks can later
         be detached with detach_all_test_disks
@@ -220,12 +221,15 @@ class LibvirtController(NodeController, ABC):
         if persistent:
             attach_flags |= libvirt.VIR_DOMAIN_AFFECT_CONFIG
 
+        wwn = f"<wwn>0x{secrets.token_hex(8)}</wwn>" if with_wwn else ""
+
         node.attachDeviceFlags(f"""
             <disk type='file' device='disk'>
                 <alias name='{disk_alias}'/>
                 <driver name='qemu' type='qcow2'/>
                 <source file='{tmp_disk}'/>
                 <target dev='{target_dev}'/>
+                {wwn}
             </disk>
         """, attach_flags)
 

--- a/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
@@ -47,9 +47,10 @@ class NodeController(ABC):
         pass
 
     @abstractmethod
-    def attach_test_disk(self, node_name: str, disk_size: int, bootable=False, persistent=False):
+    def attach_test_disk(self, node_name: str, disk_size: int, bootable=False, persistent=False, with_wwn=False):
         """
         Attaches a test disk. That disk can later be detached with `detach_all_test_disks`
+        :param with_wwn: Weather the disk should have a WWN(World Wide Name), Having a WWN creates a disk by-id link
         :param node_name: Node to attach disk to
         :param disk_size: Size of disk to attach
         :param bootable: Whether to format an MBR sector at the beginning of the disk

--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -139,9 +139,9 @@ class BaseTest:
     def attach_disk_flags(persistent):
         modified_nodes = set()
 
-        def attach(node, disk_size, bootable=False):
+        def attach(node, disk_size, bootable=False, with_wwn=False):
             nonlocal modified_nodes
-            node.attach_test_disk(disk_size, bootable=bootable, persistent=persistent)
+            node.attach_test_disk(disk_size, bootable=bootable, persistent=persistent, with_wwn=with_wwn)
             modified_nodes.add(node)
 
         yield attach


### PR DESCRIPTION
Support attach disk with a WWN(World Wide Name)
Having a WWN creates a disk by-id link (/dev/disk/by-id)