### PR TITLE
MGMT-4792 Dynamically change vm resources based on enabled operators

### DIFF
--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -345,16 +345,20 @@ def _cluster_create_params():
         "vip_dhcp_allocation": bool(args.vip_dhcp_allocation) and not user_managed_networking,
         "additional_ntp_source": ntp_source,
         "user_managed_networking": user_managed_networking,
-        "high_availability_mode": "None" if args.master_count == 1 else "Full"
+        "high_availability_mode": consts.HighAvailabilityMode.NONE if args.master_count == 1 else consts.HighAvailabilityMode.FULL,
+        "olm_operators": [{'name': name} for name in utils.parse_olm_operators_from_env()]
     }
     return params
 
 
 # convert params from args to terraform tfvars
 def _create_node_details(cluster_name):
+    operators = utils.parse_olm_operators_from_env()
     return {
-        "libvirt_worker_memory": args.worker_memory,
-        "libvirt_master_memory": args.master_memory if not args.master_count == 1 else args.master_memory * 2,
+        "libvirt_worker_memory": utils.resource_param(args.worker_memory, "worker_memory", operators),
+        "libvirt_master_memory": utils.resource_param(args.master_memory if not args.master_count == 1 else args.master_memory * 2, "master_memory", operators),
+        "libvirt_worker_vcpu": utils.resource_param(args.worker_cpu, "worker_vcpu", operators),
+        "libvirt_master_vcpu": utils.resource_param(args.master_cpu, "master_vcpu", operators),
         "worker_count": args.number_of_workers,
         "cluster_name": cluster_name,
         "cluster_domain": args.base_dns_domain,
@@ -818,6 +822,20 @@ if __name__ == "__main__":
         help="Worker memory (ram) in mb",
         type=int,
         default=8192,
+    )
+    parser.add_argument(
+        "-mc",
+        "--master-cpu",
+        help="Master cpu count",
+        type=int,
+        default=consts.MASTER_CPU,
+    )
+    parser.add_argument(
+        "-wc",
+        "--worker-cpu",
+        help="Worker cpu count",
+        type=int,
+        default=consts.WORKER_CPU,
     )
     parser.add_argument(
         "-nw", "--number-of-workers", help="Workers count to spawn", type=int, default=0

--- a/discovery-infra/test_infra/consts.py
+++ b/discovery-infra/test_infra/consts.py
@@ -41,6 +41,23 @@ TEST_TARGET_INTERFACE = "vnet3"
 DEFAULT_NAMESPACE = 'assisted-installer'
 
 
+# operator resource requirements as coded in assisted service
+OPERATOR_PARAMS = {
+    "cnv": {
+        "worker_memory": 360,
+        "master_memory": 150,
+        "worker_vcpu": 2,
+        "master_vcpu": 4,
+    },
+    "ocs": {
+        "worker_memory": 14000,
+        "master_memory": 24000,
+        "worker_vcpu": 6,
+        "master_vcpu": 8,
+    }
+}
+
+
 class ImageType:
     FULL_ISO = "full-iso"
     MINIMAL_ISO = "minimal-iso"

--- a/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -43,10 +43,11 @@ class TerraformController(LibvirtController):
 
     # TODO move all those to conftest and pass it as kwargs
     def _terraform_params(self, **kwargs):
-        params = {"libvirt_worker_memory": kwargs.get('worker_memory'),
-                  "libvirt_master_memory": kwargs.get('master_memory', 16984),
-                  "libvirt_worker_vcpu": kwargs.get("worker_vcpu", 4),
-                  "libvirt_master_vcpu": kwargs.get("master_vcpu", 4),
+        operators = [o['name'] for o in kwargs.get("olm_operators")]
+        params = {"libvirt_worker_memory": utils.resource_param(kwargs.get("worker_memory"), "worker_memory", operators),
+                  "libvirt_master_memory": utils.resource_param(kwargs.get("master_memory", 16984), "master_memory", operators),
+                  "libvirt_worker_vcpu": utils.resource_param(kwargs.get("worker_vcpu", 4), "worker_vcpu", operators),
+                  "libvirt_master_vcpu": utils.resource_param(kwargs.get("master_vcpu", 4), "master_vcpu", operators),
                   "worker_count": kwargs.get('num_workers', 0),
                   "master_count": kwargs.get('num_masters', consts.NUMBER_OF_MASTERS),
                   "cluster_name": self.cluster_name,
@@ -74,9 +75,6 @@ class TerraformController(LibvirtController):
             if value is not None:
                 params[key] = value
         return Munch.fromDict(params)
-
-    def list_nodes(self):
-        return self.list_nodes_with_name_filter(self.cluster_name)
 
     # Run make run terraform -> creates vms
     def _create_nodes(self, running=True):

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -933,3 +933,12 @@ def download_iso(image_url, image_path):
             open(image_path, "wb") as out:
         for chunk in image.iter_content(chunk_size=1024):
             out.write(chunk)
+
+def parse_olm_operators_from_env():
+    return get_env("OLM_OPERATORS", "").lower().split()
+
+def resource_param(value, param_name, operators):
+    try:
+        return sum((consts.OPERATOR_PARAMS[operator][param_name] for operator in operators), value)
+    except KeyError as e:
+        raise ValueError(f"Unknown operator name {e.args[0]}")


### PR DESCRIPTION
Based on `OLM_OPERATORS` environment variable we need to add enough resources to nodes vms so validations for those operators would pass. Before running terraform we add resources as specified by `consts.OPERATOR_PARAMS` for corresponding operators.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>