### PR TITLE
Fix operator status when waiting for operator to finish

### DIFF
--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -532,11 +532,16 @@ class Cluster:
         timeout=consts.CLUSTER_INSTALLATION_TIMEOUT,
         fall_on_error_status=True
     ):
+        if fall_on_error_status:
+            statuses = [consts.OperatorStatus.AVAILABLE]
+        else:
+            statuses = [consts.OperatorStatus.AVAILABLE, consts.OperatorStatus.FAILED]
+
         utils.wait_till_all_operators_are_in_status(
             client=self.api_client,
             cluster_id=self.id,
             operators_count=len(self.get_operators()),
-            statuses=[consts.OperatorStatus.AVAILABLE, consts.OperatorStatus.FAILED],
+            statuses=statuses,
             timeout=timeout,
             fall_on_error_status=fall_on_error_status,
         )


### PR DESCRIPTION
Currently wait_till_all_operators_are_in_status in most cases will end with success, even when operators finish with failure. This PR fix that - in any case where operator fails - then test should fail, unless specified otherwise (fall_on_error_status=True)