### PR TITLE
MGMT-5265 Add doc reference to DISABLED_HOST_VALIDATIONS environment variable

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,7 +86,7 @@ Check the [Install Guide](GUIDE.md) for installation instructions.
 | NO_PROXY_VALUES             | A comma-separated list of destination domain names, domains, IP addresses, or other network CIDRs to exclude proxying                       |
 | NUM_MASTERS                 | number of VMs to spawn as masters, default: 3                                                                                               |
 | NUM_WORKERS                 | number of VMs to spawn as workers, default: 0                                                                                               |
-| OCM_BASE_URL                | OCM API URL used to communicate with OCM and AMS, default: https://api.integration.openshift.com/                  |
+| OCM_BASE_URL                | OCM API URL used to communicate with OCM and AMS, default: https://api.integration.openshift.com/                                           |
 | OCM_CLIENT_ID               | ID of Service Account used to communicate with OCM and AMS for Agent Auth and Authz                                                         |
 | OCM_CLIENT_SECRET           | Password of Service Account used to communicate with OCM and AMS for Agent Auth and Authz                                                   |
 | OC_MODE                     | if set, use oc instead of minikube                                                                                                          |
@@ -112,6 +112,7 @@ Check the [Install Guide](GUIDE.md) for installation instructions.
 | PUBLIC_CONTAINER_REGISTRIES | comma-separated list of registries that do not require authentication for pulling assisted installer images                                 |
 | CHECK_CLUSTER_VERSION       | If "True", the controller will wait for CVO to finish                                                                                       |
 | ENABLE_KUBE_API             | If set, deploy assisted-service with Kube API controllers (minikube only)                                                                   |
+| DISABLED_HOST_VALIDATIONS   | comma-separated list of validation IDs to be excluded from the host validation process.                                                     |
 
 ## Instructions
 


### PR DESCRIPTION
Briefly describes the new environment variable to allow disabling host validations at runtime.