### PR TITLE
MGMT-5289: Remove redundant REST calls in Kube-API flow

### DIFF
--- a/discovery-infra/test_infra/kubeapi_utils.py
+++ b/discovery-infra/test_infra/kubeapi_utils.py
@@ -143,3 +143,18 @@ def delete_kube_api_resources_for_namespace(
         name=nmstate_name or f'{name}-nmstate-config',
         namespace=namespace,
     ).delete()
+
+
+def get_api_and_ingress_vips(cluster_deployment):
+    cluster_info = cluster_deployment.get()
+    assert 'spec' in cluster_info
+    spec = cluster_info['spec']
+    assert 'platform' in spec
+    platform = spec['platform']
+    assert 'agentBareMetal' in platform
+    agent_bare_metal = platform['agentBareMetal']
+
+    api_vip = agent_bare_metal.get('apiVIP')
+    ingress_vip = agent_bare_metal.get('ingressVIP')
+
+    return api_vip, ingress_vip


### PR DESCRIPTION
There are a few places that are still using REST API calls in the Kube-API flow.
They will cause failure in case the REST is not available.
In this PR I replace these calls with Kube-API calls instead.