### PR TITLE
MGMT-3879 Update ClusterDeployment conditions

### DIFF
--- a/discovery-infra/install_cluster.py
+++ b/discovery-infra/install_cluster.py
@@ -205,7 +205,7 @@ def run_installation_flow_kube_api(
         agent.approve()
 
     log.info("Waiting for installation to start")
-    cluster_deployment.wait_for_state(consts.ClusterStatus.INSTALLING)
+    cluster_deployment.wait_to_be_installing()
 
     log.info("Waiting until cluster finishes installation")
     cluster_deployment.wait_to_be_installed()

--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -738,7 +738,8 @@ def execute_kube_api_flow():
         secret=secret,
         base_domain=args.base_dns_domain,
     )
-    cluster_deployment.wait_for_state(consts.ClusterStatus.INSUFFICIENT)
+    cluster_deployment.wait_to_be_ready(False)
+
     apply_static_network_config(
         cluster_name=cluster_name,
         kube_client=kube_client,

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
@@ -13,7 +13,7 @@ def test_kube_api_wait_for_install(kube_api_context):
     cluster_deployment = deploy_default_cluster_deployment(
         kube_api_client, 'test-cluster', **installation_params
     )
-    cluster_deployment.wait_for_state('installing')
+    cluster_deployment.wait_to_be_installing()
 
 An Agent CRD will be created for each registered host. In order to start the
 installation all agents must be approved.

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/cluster_deployment.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/cluster_deployment.py
@@ -20,7 +20,6 @@ from .global_vars import (
     DEFAULT_MACHINE_CIDR,
     DEFAULT_CLUSTER_CIDR,
     DEFAULT_SERVICE_CIDR,
-    FAILURE_STATES,
     DEFAULT_WAIT_FOR_CRD_STATUS_TIMEOUT,
     DEFAULT_WAIT_FOR_CRD_STATE_TIMEOUT,
     DEFAULT_WAIT_FOR_AGENTS_TIMEOUT,
@@ -288,51 +287,36 @@ class ClusterDeployment(BaseCustomResource):
             expected_exceptions=KeyError,
         )
 
-    def state(
+    def condition(
             self,
+            cond_type,
             timeout: Union[int, float] = DEFAULT_WAIT_FOR_CRD_STATE_TIMEOUT,
     ) -> Tuple[str, str]:
-        state, state_info = None, None
         for condition in self.status(timeout).get('conditions', []):
-            reason = condition.get('reason')
+            if cond_type == condition.get('type'):
+                return condition.get('status'), condition.get('reason')
+        return None, None
 
-            if reason == 'AgentPlatformState':
-                state = condition.get('message')
-            elif reason == 'AgentPlatformStateInfo':
-                state_info = condition.get('message')
-
-            if state and state_info:
-                break
-
-        return state, state_info
-
-    def wait_for_state(
+    def wait_for_condition(
             self,
-            required_state: str,
+            cond_type: str,
+            required_status: str,
+            required_reason: str,
             timeout: Union[int, float] = DEFAULT_WAIT_FOR_CRD_STATE_TIMEOUT,
-            *,
-            raise_on_states: Iterable[str] = FAILURE_STATES,
     ) -> None:
-        required_state = required_state.lower()
-        raise_on_states = [x.lower() for x in raise_on_states]
-
-        def _has_required_state() -> Optional[bool]:
-            state, state_info = self.state(timeout=0.5)
-            state = state.lower() if state else state
-            if state == required_state:
+        def _has_required_condition() -> Optional[bool]:
+            status, reason = self.condition(cond_type=cond_type, timeout=0.5)
+            if status == required_status:
+                if required_reason:
+                    return required_reason == reason
                 return True
-            elif state in raise_on_states:
-                raise UnexpectedStateError(
-                    f'while waiting for state `{required_state}`, cluster '
-                    f'{self.ref} state changed unexpectedly to `{state}`: '
-                    f'{state_info}'
-                )
+            return False
 
-        logger.info("Waiting till cluster will be in %s state", required_state)
+        logger.info("Waiting till cluster will be in condition %s with status: %s reason: %s ", cond_type, required_status, required_reason)
         waiting.wait(
-            _has_required_state,
+            _has_required_condition,
             timeout_seconds=timeout,
-            waiting_for=f'cluster {self.ref} state to be {required_state}',
+            waiting_for=f'cluster {self.ref} condition {cond_type} to be {required_status}',
             expected_exceptions=waiting.exceptions.TimeoutExpired,
         )
 
@@ -355,6 +339,16 @@ class ClusterDeployment(BaseCustomResource):
             timeout_seconds=timeout,
             waiting_for=f'cluster {self.ref} to have {num_agents} agents',
         )
+
+    def wait_to_be_installing(self
+    ) -> None:
+        return self.wait_for_condition("ReadyForInstallation","False","ClusterAlreadyInstalling")
+
+    def wait_to_be_ready(
+            self,
+            ready: bool,
+    ) -> None:
+        return self.wait_for_condition("ReadyForInstallation",str(ready),None)
 
     def wait_to_be_installed(
             self, 

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/global_vars.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/global_vars.py
@@ -14,8 +14,6 @@ DEFAULT_MACHINE_CIDR = env_variables.get('machine_cidr', '')
 DEFAULT_CLUSTER_CIDR = env_variables.get('cluster_cidr', '172.30.0.0/16')
 DEFAULT_SERVICE_CIDR = env_variables.get('service_cidr', '10.128.0.0/14')
 
-FAILURE_STATES = ('error', 'cancelled')
-
 _MINUTE = 60
 _HOUR = 60 * _MINUTE
 


### PR DESCRIPTION
The ClusterDeployment CRD will now support the following conditions:
- SpecSynced
- ReadyForInstallation
- Installed
- Validated

    
Before, the hive condition `UnreachableCondition` was used.
Implemented in:  https://github.com/openshift/assisted-service/pull/1524
