### PR TITLE
Restore list_nodes

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -76,6 +76,9 @@ class TerraformController(LibvirtController):
                 params[key] = value
         return Munch.fromDict(params)
 
+    def list_nodes(self):
+        return self.list_nodes_with_name_filter(self.cluster_name)
+
     # Run make run terraform -> creates vms
     def _create_nodes(self, running=True):
         logging.info("Creating tfvars")


### PR DESCRIPTION
Due to rebase glitch list_nodes was removed accidentially. This PR restores it.

Signed-off-by: Piotr Kliczewski <piotr.kliczewski@gmail.com>