### PR TITLE
MGMT-5275 - Fix NodeController.list_nodes to return List[Node]

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
@@ -1,5 +1,5 @@
 from abc import ABC, abstractmethod
-from typing import Dict, List, Any, Tuple, Callable
+from typing import List, Any, Tuple, Callable
 
 import libvirt
 
@@ -8,8 +8,9 @@ from test_infra.controllers.node_controllers.node import Node
 
 
 class NodeController(ABC):
+
     @abstractmethod
-    def list_nodes(self) -> Dict[str, Node]:
+    def list_nodes(self) -> List[Node]:
         pass
 
     @abstractmethod

--- a/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -4,10 +4,12 @@ import logging
 import os
 import shutil
 import uuid
+from typing import List
 
 from munch import Munch
 from test_infra import consts, utils, virsh_cleanup
 from test_infra.controllers.node_controllers.libvirt_controller import LibvirtController
+from test_infra.controllers.node_controllers.node import Node
 from test_infra.tools import static_network, terraform_utils
 
 
@@ -76,7 +78,7 @@ class TerraformController(LibvirtController):
                 params[key] = value
         return Munch.fromDict(params)
 
-    def list_nodes(self):
+    def list_nodes(self) -> List[Node]:
         return self.list_nodes_with_name_filter(self.cluster_name)
 
     # Run make run terraform -> creates vms

--- a/discovery-infra/test_infra/helper_classes/nodes.py
+++ b/discovery-infra/test_infra/helper_classes/nodes.py
@@ -30,7 +30,7 @@ class Nodes:
     @property
     def nodes(self) -> List[Node]:
         if not self._nodes:
-            self._nodes = self._list()
+            self._nodes = self.controller.list_nodes()
         return self._nodes
 
     def __getitem__(self, i):
@@ -77,11 +77,6 @@ class Nodes:
         if not self._nodes_as_dict:
             self._nodes_as_dict = {node.name: node for node in self.nodes}
         return self._nodes_as_dict
-
-    def _list(self):
-        # TODO list_nodes return type is Dict[str, Node] but returns list
-        nodes = self.controller.list_nodes()
-        return [Node(node.name(), self.controller, self.private_ssh_key_path) for node in nodes]
 
     @property
     def setup_time(self):


### PR DESCRIPTION
`NodeController.list_nodes` now return List[Node] instead of List[virDomain]
https://issues.redhat.com/browse/MGMT-5275