### PR TITLE
MGMT-5360 - remove support for mirror registry configuration from the…

### DIFF
--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -139,10 +139,9 @@ class InventoryClient(object):
                     f'Actual size: {actual_file_size}. Expected size: {content_length}'
                 )
 
-    def generate_image(self, cluster_id, ssh_key, image_type=consts.ImageType.FULL_ISO, static_network_config=None, mirror_registries_ca_config=None):
+    def generate_image(self, cluster_id, ssh_key, image_type=consts.ImageType.FULL_ISO, static_network_config=None):
         log.info("Generating image for cluster %s", cluster_id)
-        image_create_params = models.ImageCreateParams(ssh_public_key=ssh_key, static_network_config=static_network_config, image_type=image_type,
-                                                       mirror_registries_ca_config=mirror_registries_ca_config)
+        image_create_params = models.ImageCreateParams(ssh_public_key=ssh_key, static_network_config=static_network_config, image_type=image_type)
         log.info("Generating image with params %s", image_create_params.__dict__)
         return self.client.generate_cluster_iso(
             cluster_id=cluster_id, image_create_params=image_create_params
@@ -158,9 +157,8 @@ class InventoryClient(object):
         self._download(response=response_obj, file_path=image_path, verify_file_size=True)
 
     def generate_and_download_image(self, cluster_id, ssh_key, image_path, image_type=consts.ImageType.FULL_ISO,
-                                    static_network_config=None, mirror_registries_ca_config=None):
-        self.generate_image(cluster_id=cluster_id, ssh_key=ssh_key, image_type=image_type,
-                            static_network_config=static_network_config, mirror_registries_ca_config=mirror_registries_ca_config)
+                                    static_network_config=None):
+        self.generate_image(cluster_id=cluster_id, ssh_key=ssh_key, image_type=image_type, static_network_config=static_network_config)
         self.download_image(cluster_id=cluster_id, image_path=image_path)
 
     def update_hosts(self, cluster_id, hosts_with_roles, hosts_names=None):


### PR DESCRIPTION
… image create flow

the mirror registry configuration will be setinto Assisted Service during deployment,
so we no longer need this option in the create image API