### PR TITLE
MGMT-4577 kube_api: use 4.8 release image

### DIFF
--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -718,7 +718,7 @@ def execute_kube_api_flow():
         kube_api_client=kube_client,
         name=f"{cluster_name}-image-set",
     )
-    releaseImage=utils.get_env('OPENSHIFT_INSTALL_RELEASE_IMAGE', utils.get_openshift_release_image())
+    releaseImage=utils.get_env('OPENSHIFT_INSTALL_RELEASE_IMAGE', utils.get_openshift_release_image("4.8"))
     imageSet.apply(releaseImage=releaseImage)
 
     ipv4 = args.ipv4 and args.ipv4.lower() in MachineNetwork.YES_VALUES

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -841,12 +841,12 @@ def get_openshift_version(default=consts.DEFAULT_OPENSHIFT_VERSION):
     return get_env('OPENSHIFT_VERSION', default)
 
 
-def get_openshift_release_image():
+def get_openshift_release_image(ocp_version=consts.DEFAULT_OPENSHIFT_VERSION):
     release_image = os.getenv('OPENSHIFT_INSTALL_RELEASE_IMAGE')
 
     if not release_image:
         stdout, _, _ = run_command(
-            f"jq -r '.[] | select(.default == true).release_image' assisted-service/default_ocp_versions.json",
+            f"jq -r '.[\"{ocp_version}\"].release_image' assisted-service/default_ocp_versions.json",
             shell=True)
         return stdout
 


### PR DESCRIPTION
As only 4.8 is supported when KUBE_API is enabled (see scripts/deploy_assisted_service.sh),
the relevant release image should be fetched accordingly.