### PR TITLE
Remove some unnecessary debug prints

### DIFF
--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -9,11 +9,13 @@ import os
 
 import yaml
 import dns.resolver
+from assisted_service_client import models
 from assisted_service_client.rest import ApiException
 from netaddr import IPNetwork
 from test_infra import assisted_service_api, consts, utils, kubeapi_utils, warn_deprecate
 from test_infra.helper_classes import cluster as helper_cluster
 from test_infra.tools import static_network, terraform_utils
+
 from test_infra.helper_classes.kube_helpers import (
     create_kube_api_client, ClusterDeployment, Platform,
     InstallStrategy, Secret, InfraEnv, Proxy, NMStateConfig,
@@ -259,19 +261,14 @@ def wait_until_nodes_are_registered_rest_api(
 
 
 def set_cluster_vips(client, cluster_id, machine_net):
-    cluster_info = client.cluster_get(cluster_id)
     api_vip, ingress_vip = _get_vips_ips(machine_net)
-    cluster_info.vip_dhcp_allocation = False
-    cluster_info.api_vip = api_vip
-    cluster_info.ingress_vip = ingress_vip
-    client.update_cluster(cluster_id, cluster_info)
+    update_params = models.ClusterUpdateParams(vip_dhcp_allocation=False, api_vip=api_vip, ingress_vip=ingress_vip)
+    client.update_cluster(cluster_id, update_params)
 
 
 def set_cluster_machine_cidr(client, cluster_id, machine_net, set_vip_dhcp_allocation=True):
-    cluster_info = client.cluster_get(cluster_id)
-    cluster_info.vip_dhcp_allocation = set_vip_dhcp_allocation
-    cluster_info.machine_network_cidr = get_machine_cidr_from_machine_net(machine_net)
-    client.update_cluster(cluster_id, cluster_info)
+    update_params = models.ClusterUpdateParams(vip_dhcp_allocation=set_vip_dhcp_allocation, machine_network_cidr=get_machine_cidr_from_machine_net(machine_net))
+    client.update_cluster(cluster_id, update_params)
 
 
 def get_machine_cidr_from_machine_net(machine_net):

--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -102,11 +102,9 @@ class InventoryClient(object):
         return result
 
     def get_cluster_hosts(self, cluster_id):
-        log.info("Getting registered nodes for cluster %s", cluster_id)
         return self.client.list_hosts(cluster_id=cluster_id)
 
     def get_cluster_operators(self, cluster_id):
-        log.info("Getting monitored operators for cluster %s", cluster_id)
         return self.cluster_get(cluster_id=cluster_id).monitored_operators
 
     def get_hosts_in_statuses(self, cluster_id, statuses):
@@ -123,7 +121,6 @@ class InventoryClient(object):
         return self.client.list_clusters(get_unregistered_clusters=True)
 
     def cluster_get(self, cluster_id):
-        log.info("Getting cluster with id %s", cluster_id)
         return self.client.get_cluster(cluster_id=cluster_id)
 
     @classmethod

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -186,18 +186,16 @@ def are_hosts_in_status(
             > 0
     ):
         hosts_in_error = [
-            host for host in hosts if host["status"] == consts.NodesStatus.ERROR
+            (i, host["id"], host["requested_hostname"], host["role"], host["status"], host["status_info"])
+            for host in enumerate(hosts, start=1) if host["status"] == consts.NodesStatus.ERROR
         ]
-        log.error(
-            "Some of the hosts are in insufficient or error status. Hosts in error %s",
-            pformat(hosts_in_error),
-        )
+        log.error("Some of the hosts are in insufficient or error status. Hosts in error %s", hosts_in_error)
         raise Exception("All the nodes must be in valid status, but got some in error")
 
     log.info(
         "Asked hosts to be in one of the statuses from %s and currently hosts statuses are %s",
         statuses,
-        [(host["id"], host["status"], host["status_info"]) for host in hosts],
+        [(i, host["id"], host["requested_hostname"], host["role"], host["status"], host["status_info"]) for i, host in enumerate(hosts, start=1)],
     )
     return False
 
@@ -242,22 +240,17 @@ def wait_till_hosts_with_macs_are_in_status(
 ):
     log.info("Wait till %s nodes are in one of the statuses %s", len(macs), statuses)
 
-    try:
-        waiting.wait(
-            lambda: are_hosts_in_status(
-                get_cluster_hosts_with_mac(client, cluster_id, macs),
-                len(macs),
-                statuses,
-                fall_on_error_status,
-            ),
-            timeout_seconds=timeout,
-            sleep_seconds=interval,
-            waiting_for="Nodes to be in of the statuses %s" % statuses,
-        )
-    except BaseException:
-        hosts = get_cluster_hosts_with_mac(client, cluster_id, macs)
-        log.info("All nodes: %s", hosts)
-        raise
+    waiting.wait(
+        lambda: are_hosts_in_status(
+            get_cluster_hosts_with_mac(client, cluster_id, macs),
+            len(macs),
+            statuses,
+            fall_on_error_status,
+        ),
+        timeout_seconds=timeout,
+        sleep_seconds=interval,
+        waiting_for="Nodes to be in of the statuses %s" % statuses,
+    )
 
 
 def wait_till_all_operators_are_in_status(
@@ -300,22 +293,17 @@ def wait_till_all_hosts_are_in_status(
 ):
     log.info("Wait till %s nodes are in one of the statuses %s", nodes_count, statuses)
 
-    try:
-        waiting.wait(
-            lambda: are_hosts_in_status(
-                client.get_cluster_hosts(cluster_id),
-                nodes_count,
-                statuses,
-                fall_on_error_status,
-            ),
-            timeout_seconds=timeout,
-            sleep_seconds=interval,
-            waiting_for="Nodes to be in of the statuses %s" % statuses,
-        )
-    except BaseException:
-        hosts = client.get_cluster_hosts(cluster_id)
-        log.info("All nodes: %s", hosts)
-        raise
+    waiting.wait(
+        lambda: are_hosts_in_status(
+            client.get_cluster_hosts(cluster_id),
+            nodes_count,
+            statuses,
+            fall_on_error_status,
+        ),
+        timeout_seconds=timeout,
+        sleep_seconds=interval,
+        waiting_for="Nodes to be in of the statuses %s" % statuses,
+    )
 
 
 def wait_till_at_least_one_host_is_in_status(
@@ -329,23 +317,17 @@ def wait_till_at_least_one_host_is_in_status(
 ):
     log.info("Wait till 1 node is in one of the statuses %s", statuses)
 
-    try:
-        waiting.wait(
-            lambda: are_hosts_in_status(
-                client.get_cluster_hosts(cluster_id),
-                nodes_count,
-                statuses,
-                fall_on_error_status,
-            ),
-            timeout_seconds=timeout,
-            sleep_seconds=interval,
-            waiting_for="Node to be in of the statuses %s" % statuses,
-        )
-    except BaseException:
-        hosts = client.get_cluster_hosts(cluster_id)
-        log.info("All nodes: %s", hosts)
-        raise
-
+    waiting.wait(
+        lambda: are_hosts_in_status(
+            client.get_cluster_hosts(cluster_id),
+            nodes_count,
+            statuses,
+            fall_on_error_status,
+        ),
+        timeout_seconds=timeout,
+        sleep_seconds=interval,
+        waiting_for="Node to be in of the statuses %s" % statuses,
+    )
 
 def wait_till_specific_host_is_in_status(
         client,
@@ -359,22 +341,17 @@ def wait_till_specific_host_is_in_status(
 ):
     log.info(f"Wait till {nodes_count} host is in one of the statuses: {statuses}")
 
-    try:
-        waiting.wait(
-            lambda: are_hosts_in_status(
-                [client.get_host_by_name(cluster_id, host_name)],
-                nodes_count,
-                statuses,
-                fall_on_error_status,
-            ),
-            timeout_seconds=timeout,
-            sleep_seconds=interval,
-            waiting_for="Node to be in of the statuses %s" % statuses,
-        )
-    except BaseException:
-        hosts = client.get_cluster_hosts(cluster_id)
-        log.info("All nodes: %s", hosts)
-        raise
+    waiting.wait(
+        lambda: are_hosts_in_status(
+            [client.get_host_by_name(cluster_id, host_name)],
+            nodes_count,
+            statuses,
+            fall_on_error_status,
+        ),
+        timeout_seconds=timeout,
+        sleep_seconds=interval,
+        waiting_for="Node to be in of the statuses %s" % statuses,
+    )
 
 
 def wait_till_at_least_one_host_is_in_stage(


### PR DESCRIPTION
Removing unnecessary huge JSONS printed for hosts.
For hosts printing name and role
```
2021-04-27 14:23:17,335 INFO       - 140210914888576 - Asked hosts to be in one of the statuses from ['installed'] and currently hosts statuses are [(1, '40e11568-89e1-45b1-9360-4a2b743b5892', 'test-infra-cluster-assisted-installer-worker-0', 'worker', 'installing', 'Installation is in progress'), (2, 'ea884ec8-c334-4bca-9327-5e5e294a0c40', 'test-infra-cluster-assisted-installer-master-1', 'master', 'installing', 'Installation is in progress'), (3, '29d027f8-1038-4b9b-a663-23e9e953c819', 'test-infra-cluster-assisted-installer-worker-1', 'worker', 'installing', 'Installation is in progress'), (4, '883ecc98-4a40-4e17-8a73-8fef4419037d', 'test-infra-cluster-assisted-installer-master-2', 'master', 'installing', 'Installation is in progress'), (5, '9d154cbc-cadf-483f-83ba-3fa26c1579d7', 'test-infra-cluster-assisted-installer-master-0', 'master', 'installing', 'Installation is in progress')] 	(/home/assisted/discovery-infra/test_infra/utils.py:198)
```