### PR TITLE
MGMT-5411 - Refactor operator resource consts

### DIFF
--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -353,11 +353,11 @@ def _cluster_create_params():
 def _create_node_details(cluster_name):
     operators = utils.parse_olm_operators_from_env()
     return {
-        "libvirt_worker_memory": utils.resource_param(args.worker_memory, "worker_memory", operators),
+        "libvirt_worker_memory": utils.resource_param(args.worker_memory, consts.OperatorResource.WORKER_MEMORY_KEY, operators),
         "libvirt_master_memory": utils.resource_param(
-            args.master_memory if not args.master_count == 1 else args.master_memory * 2, "master_memory", operators),
-        "libvirt_worker_vcpu": utils.resource_param(args.worker_cpu, "worker_vcpu", operators),
-        "libvirt_master_vcpu": utils.resource_param(args.master_cpu, "master_vcpu", operators),
+            args.master_memory if not args.master_count == 1 else args.master_memory * 2, consts.OperatorResource.MASTER_MEMORY_KEY, operators),
+        "libvirt_worker_vcpu": utils.resource_param(args.worker_cpu, consts.OperatorResource.WORKER_VCPU_KEY, operators),
+        "libvirt_master_vcpu": utils.resource_param(args.master_cpu, consts.OperatorResource.MASTER_VCPU_KEY, operators),
         "worker_count": args.number_of_workers,
         "cluster_name": cluster_name,
         "cluster_domain": args.base_dns_domain,

--- a/discovery-infra/test_infra/consts/__init__.py
+++ b/discovery-infra/test_infra/consts/__init__.py
@@ -1,0 +1,9 @@
+from .consts import *  # TODO - temporary import all old consts
+from .olm_operators import OperatorResource, OperatorType, OperatorStatus
+
+
+__all__ = [
+    "OperatorType",
+    "OperatorResource",
+    "OperatorStatus"
+]

--- a/discovery-infra/test_infra/consts/consts.py
+++ b/discovery-infra/test_infra/consts/consts.py
@@ -42,23 +42,6 @@ DEFAULT_TEST_INFRA_DOMAIN = f".{CLUSTER_PREFIX}-{DEFAULT_NAMESPACE}.{DEFAULT_BAS
 TEST_TARGET_INTERFACE = "vnet3"
 
 
-# operator resource requirements as coded in assisted service
-OPERATOR_PARAMS = {
-    "cnv": {
-        "worker_memory": 360,
-        "master_memory": 150,
-        "worker_vcpu": 2,
-        "master_vcpu": 4,
-    },
-    "ocs": {
-        "worker_memory": 14000,
-        "master_memory": 24000,
-        "worker_vcpu": 6,
-        "master_vcpu": 8,
-    }
-}
-
-
 class ImageType:
     FULL_ISO = "full-iso"
     MINIMAL_ISO = "minimal-iso"
@@ -107,12 +90,6 @@ class HostsProgressStages:
     JOINED = "Joined"
     CONFIGURING = "Configuring"
     DONE = "Done"
-
-
-class OperatorStatus:
-    FAILED = "failed"
-    PROGRESSING = "progressing"
-    AVAILABLE = "available"
 
 
 all_host_stages = [HostsProgressStages.START_INSTALLATION, HostsProgressStages.INSTALLING,

--- a/discovery-infra/test_infra/consts/olm_operators.py
+++ b/discovery-infra/test_infra/consts/olm_operators.py
@@ -1,0 +1,36 @@
+class OperatorType:
+    CNV = "cnv"
+    OCS = "scs"
+
+
+class OperatorStatus:
+    FAILED = "failed"
+    PROGRESSING = "progressing"
+    AVAILABLE = "available"
+
+
+class OperatorResource:
+    """ operator resource requirements as coded in assisted service """
+
+    WORKER_MEMORY_KEY: str = "worker_memory"
+    MASTER_MEMORY_KEY: str = "master_memory"
+    WORKER_VCPU_KEY: str = "worker_vcpu"
+    MASTER_VCPU_KEY: str = "master_vcpu"
+
+    @classmethod
+    def _get_resource_dict(cls, worker_memory: int, master_memory: int, worker_vcpu: int, master_vcpu: int):
+        return {
+            cls.WORKER_MEMORY_KEY: worker_memory,
+            cls.MASTER_MEMORY_KEY: master_memory,
+            cls.WORKER_VCPU_KEY: worker_vcpu,
+            cls.MASTER_VCPU_KEY: master_vcpu
+        }
+
+    @classmethod
+    def values(cls) -> dict:
+        return {
+            OperatorType.CNV:
+                cls._get_resource_dict(worker_memory=360, master_memory=150, worker_vcpu=2, master_vcpu=4),
+            OperatorType.OCS:
+                cls._get_resource_dict(worker_memory=14000, master_memory=24000, worker_vcpu=6, master_vcpu=8)
+        }

--- a/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -46,31 +46,34 @@ class TerraformController(LibvirtController):
     # TODO move all those to conftest and pass it as kwargs
     def _terraform_params(self, **kwargs):
         operators = [o['name'] for o in kwargs.get("olm_operators", [])]
-        params = {"libvirt_worker_memory": utils.resource_param(kwargs.get("worker_memory"), "worker_memory", operators),
-                  "libvirt_master_memory": utils.resource_param(kwargs.get("master_memory", 16984), "master_memory", operators),
-                  "libvirt_worker_vcpu": utils.resource_param(kwargs.get("worker_vcpu", 4), "worker_vcpu", operators),
-                  "libvirt_master_vcpu": utils.resource_param(kwargs.get("master_vcpu", 4), "master_vcpu", operators),
-                  "worker_count": kwargs.get('num_workers', 0),
-                  "master_count": kwargs.get('num_masters', consts.NUMBER_OF_MASTERS),
-                  "cluster_name": self.cluster_name,
-                  "cluster_domain": self.cluster_domain,
-                  "machine_cidr": self.get_machine_cidr(),
-                  "libvirt_network_name": self.network_name,
-                  "libvirt_network_mtu": kwargs.get('network_mtu', '1500'),
-                  # TODO change to namespace index
-                  "libvirt_network_if": self.network_conf.libvirt_network_if,
-                  "libvirt_worker_disk": kwargs.get('worker_disk', '21474836480'),
-                  "libvirt_master_disk": kwargs.get('master_disk', '128849018880'),
-                  "libvirt_secondary_network_name": consts.TEST_SECONDARY_NETWORK + self.cluster_suffix,
-                  "libvirt_storage_pool_path": kwargs.get('storage_pool_path',
-                                                          os.path.join(os.getcwd(),
-                                                                       "storage_pool")),
-                  # TODO change to namespace index
-                  "libvirt_secondary_network_if": self.network_conf.libvirt_secondary_network_if,
-                  "provisioning_cidr": self.network_conf.provisioning_cidr,
-                  "running": True,
-                  "single_node_ip": kwargs.get('single_node_ip', ''),
-                  }
+        params = {
+            "libvirt_worker_memory": utils.resource_param(
+                kwargs.get("worker_memory"), consts.OperatorResource.WORKER_MEMORY_KEY, operators),
+            "libvirt_master_memory": utils.resource_param(
+                kwargs.get("master_memory", 16984), consts.OperatorResource.MASTER_MEMORY_KEY, operators),
+            "libvirt_worker_vcpu": utils.resource_param(
+                kwargs.get("worker_vcpu", 4), consts.OperatorResource.WORKER_VCPU_KEY, operators),
+            "libvirt_master_vcpu": utils.resource_param(
+                kwargs.get("master_vcpu", 4), consts.OperatorResource.MASTER_VCPU_KEY, operators),
+            "worker_count": kwargs.get('num_workers', 0),
+            "master_count": kwargs.get('num_masters', consts.NUMBER_OF_MASTERS),
+            "cluster_name": self.cluster_name,
+            "cluster_domain": self.cluster_domain,
+            "machine_cidr": self.get_machine_cidr(),
+            "libvirt_network_name": self.network_name,
+            "libvirt_network_mtu": kwargs.get('network_mtu', '1500'),
+            # TODO change to namespace index
+            "libvirt_network_if": self.network_conf.libvirt_network_if,
+            "libvirt_worker_disk": kwargs.get('worker_disk', '21474836480'),
+            "libvirt_master_disk": kwargs.get('master_disk', '128849018880'),
+            "libvirt_secondary_network_name": consts.TEST_SECONDARY_NETWORK + self.cluster_suffix,
+            "libvirt_storage_pool_path": kwargs.get('storage_pool_path', os.path.join(os.getcwd(), "storage_pool")),
+            # TODO change to namespace index
+            "libvirt_secondary_network_if": self.network_conf.libvirt_secondary_network_if,
+            "provisioning_cidr": self.network_conf.provisioning_cidr,
+            "running": True,
+            "single_node_ip": kwargs.get('single_node_ip', ''),
+            }
         for key in ["libvirt_master_ips", "libvirt_secondary_master_ips", "libvirt_worker_ips",
                     "libvirt_secondary_worker_ips"]:
             value = kwargs.get(key)

--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -159,16 +159,16 @@ class Cluster:
         self.api_client.select_installation_disk(self.id, hosts_with_disk_paths)
 
     def set_ocs(self, properties=None):
-        self.set_olm_operator('ocs', properties=properties)
+        self.set_olm_operator(consts.OperatorType.OCS, properties=properties)
 
     def set_cnv(self, properties=None):
-        self.set_olm_operator('cnv', properties=properties)
+        self.set_olm_operator(consts.OperatorType.CNV, properties=properties)
 
     def unset_ocs(self):
-        self.unset_olm_operator('ocs')
+        self.unset_olm_operator(consts.OperatorType.OCS)
 
     def unset_cnv(self):
-        self.unset_olm_operator('cnv')
+        self.unset_olm_operator(consts.OperatorType.CNV)
 
     def unset_olm_operator(self, operator_name):
         logging.info(f'Unsetting {operator_name} for cluster: {self.id}')

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -29,7 +29,8 @@ from assisted_service_client.models.monitored_operator import MonitoredOperator
 from logger import log
 from retry import retry
 
-from test_infra import consts
+import test_infra.consts as consts
+
 
 conn = libvirt.open("qemu:///system")
 
@@ -923,11 +924,13 @@ def download_iso(image_url, image_path):
         for chunk in image.iter_content(chunk_size=1024):
             out.write(chunk)
 
+
 def parse_olm_operators_from_env():
     return get_env("OLM_OPERATORS", default="").lower().split()
 
-def resource_param(value, param_name, operators):
+
+def resource_param(base_value: int, resource_name: str, operators: List):
     try:
-        return sum((consts.OPERATOR_PARAMS[operator][param_name] for operator in operators), value)
+        return sum((consts.OperatorResource.values()[operator][resource_name] for operator in operators), base_value)
     except KeyError as e:
         raise ValueError(f"Unknown operator name {e.args[0]}")


### PR DESCRIPTION
https://issues.redhat.com/browse/MGMT-5411

Changes:

-  Create OLM Operators consts classes 
-  Create consts package instead of consts module - preparation for consts total refactoring

Node: Keys in environment variables with the same name as the operators resource keys will be modified on later tasks.