### PR TITLE
NO-ISSUE increase timeout of SSH connection action

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/ssh.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/ssh.py
@@ -30,7 +30,7 @@ class SshConnection:
             self._ssh_client.close()
             self._ssh_client = None
 
-    def connect(self, timeout=10):
+    def connect(self, timeout=60):
         logging.info("Going to connect to ip %s", self._ip)
         self.wait_for_tcp_server()
         self._ssh_client = paramiko.SSHClient()


### PR DESCRIPTION
Looking here, it looks like sometimes connecting to VMs requires more connection time:
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_release/18239/rehearse-18239-periodic-ci-openshift-release-master-nightly-4.8-e2e-metal-assisted/1388753965369266176/artifacts/e2e-metal-assisted/baremetalds-assisted-gather/build-log.txt
```
Traceback (most recent call last):
  File "./discovery-infra/download_logs.py", line 255, in gather_sosreport_from_node
    node.upload_file(SOSREPORT_SCRIPT, "/tmp/man_sosreport.sh")
  File "/home/assisted/discovery-infra/test_infra/controllers/node_controllers/node.py", line 57, in upload_file
    with self.ssh_connection as _ssh:
  File "/home/assisted/discovery-infra/test_infra/controllers/node_controllers/ssh.py", line 22, in __enter__
    self.connect()
  File "/home/assisted/discovery-infra/test_infra/controllers/node_controllers/ssh.py", line 35, in connect
    self.wait_for_tcp_server()
  File "/home/assisted/discovery-infra/test_infra/controllers/node_controllers/ssh.py", line 57, in wait_for_tcp_server
    hostname=self._ip, port=self._port))
TimeoutError: SSH TCP Server '192.168.126.12:22' did not respond within timeout
```

This is at least required in the context of working with busy machines (especially when cluster installation is successful / partly successful)

/cc @YuviGold @tsorya 
/hold