### PR TITLE
MGMT-3470: Extending events test to make sure we don't spam events.

### DIFF
--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -24,6 +24,7 @@ from test_infra.tools import static_network, terraform_utils
 
 class Cluster:
     MINIMUM_NODES_TO_WAIT = 1
+    EVENTS_THRESHOLD = 500
 
     def __init__(self, api_client: InventoryClient, config: BaseClusterConfig):
         self._config = config


### PR DESCRIPTION
After adding events for validations we need to make sure we don't spam
the DB in the process.

Signed-off-by: Yoni Bettan <ybettan@redhat.com>