### PR TITLE
MGMT-4554 kube-api: include only rhcos in deploy service

### DIFF
--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -21,9 +21,8 @@ export OPENSHIFT_VERSIONS_CMD=""
 if [[ "${ENABLE_KUBE_API}" == "true" && -z "${OPENSHIFT_VERSIONS}" ]]; then
     # Supporting version 4.8 for kube-api
     supported_version=$(cat assisted-service/default_ocp_versions.json |
-        jq -rc 'with_entries(.key = "4.8")')
-        # TODO: include only 'rhcos_image' and 'rhcos_version' when custom
-        #       OCP version is supported in assisted-service (MGMT-4554)
+       jq -rc 'with_entries(.key = "4.8") | with_entries(
+           {key: .key, value: {rhcos_image: .value.rhcos_image, rhcos_version: .value.rhcos_version}})')
     json_template=\''%s'\'
     OPENSHIFT_VERSIONS=$(printf "$json_template" "$supported_version")
     OPENSHIFT_VERSIONS_CMD="OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS}"


### PR DESCRIPTION
As [MGMT-4554](https://issues.redhat.com/browse/MGMT-4554) is already merged (https://github.com/openshift/assisted-service/pull/1319),
the versions json can include only rhcos_image and rhcos_version properties
when deploying the service.

I.e. when ENABLE_KUBE_API is true, OPENSHIFT_VERSIONS env var should be in the following format:
```
{
   "4.8": {
      "rhcos_image": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso",
      "rhcos_version": "47.83.202102090044-0"
  }
}
```

Instead of:
```
{
  "4.8": {
    "display_name": "4.8.0-fc.0",
    "release_version": "4.8.0-fc.0",
    "release_image": "quay.io/openshift-release-dev/ocp-release:4.8.0-fc.0-x86_64",
    "rhcos_image": "https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.0/rhcos-4.7.0-x86_64-live.x86_64.iso",
    "rhcos_version": "47.83.202102090044-0",
    "support_level": "beta"
  }
}
```