### PR TITLE
MGMT-6049 Wait for operators to finish first wait for builtin then to OLM

### DIFF
--- a/discovery-infra/install_cluster.py
+++ b/discovery-infra/install_cluster.py
@@ -9,6 +9,8 @@ from test_infra import assisted_service_api, consts, utils, warn_deprecate
 from test_infra.helper_classes import cluster as helper_cluster
 from test_infra.tools import terraform_utils
 
+from assisted_service_client.models.operator_type import OperatorType
+
 import oc_utils
 from logger import log
 
@@ -64,6 +66,7 @@ def wait_till_installed(client, cluster, timeout=60 * 60 * 2):
             client=client,
             cluster_id=cluster.id,
             operators_count=len(cluster.monitored_operators),
+            operator_types=[OperatorType.BUILTIN, OperatorType.OLM],
             statuses=[consts.OperatorStatus.AVAILABLE, consts.OperatorStatus.FAILED],
             timeout=consts.CLUSTER_INSTALLATION_TIMEOUT,
             fall_on_error_status=False,

--- a/discovery-infra/test_infra/utils.py
+++ b/discovery-infra/test_infra/utils.py
@@ -257,29 +257,34 @@ def wait_till_all_operators_are_in_status(
         client,
         cluster_id,
         operators_count,
+        operator_types,
         statuses,
         timeout=consts.CLUSTER_INSTALLATION_TIMEOUT,
         fall_on_error_status=False,
         interval=5,
 ):
-    log.info("Wait till %s operators are in one of the statuses %s", operators_count, statuses)
+    log.info(f"Wait till {operators_count} {operator_types} operators are in one of the statuses {statuses}")
 
     try:
         waiting.wait(
             lambda: are_operators_in_status(
-                client.get_cluster_operators(cluster_id),
+                filter_operators_by_type(client.get_cluster_operators(cluster_id), operator_types),
                 operators_count,
                 statuses,
                 fall_on_error_status,
             ),
             timeout_seconds=timeout,
             sleep_seconds=interval,
-            waiting_for="Monitored operators to be in of the statuses %s" % statuses,
+            waiting_for=f"Monitored {operator_types} operators to be in of the statuses {statuses}",
         )
     except BaseException:
         operators = client.get_cluster_operators(cluster_id)
         log.info("All operators: %s", operators)
         raise
+
+
+def filter_operators_by_type(operators: List[MonitoredOperator], operator_types: List[str]) -> List[MonitoredOperator]:
+    return list(filter(lambda operator: operator.operator_type in operator_types, operators))
 
 
 def wait_till_all_hosts_are_in_status(


### PR DESCRIPTION
Builtin operators have to succeed. Otherwise, the cluster isn't
accessible. OLM could fail and then the cluster would be declared as
degraded.

/cc @lalon4 