### PR TITLE
NO-ISSUE fix sosreport gathering from ipv6 nodes

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/ssh.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/ssh.py
@@ -1,6 +1,7 @@
 import logging
 import socket
 import time
+from ipaddress import IPv4Address, ip_address
 
 import paramiko
 import scp
@@ -58,7 +59,12 @@ class SshConnection:
 
     @classmethod
     def _raw_tcp_connect(cls, tcp_endpoint):
-        s = socket.socket()
+        if isinstance(ip_address(tcp_endpoint[0]), IPv4Address):
+            family = socket.AF_INET
+        else:
+            family = socket.AF_INET6
+
+        s = socket.socket(family=family)
         try:
             s.connect(tcp_endpoint)
             return True


### PR DESCRIPTION
Right now we're using the wrong IP family on ipv6 hosts:
```
2021-05-11 04:55:04,460 INFO       - 139918223341312 - Wait for 1001:db8::19 to be available 	(/home/assisted/discovery-infra/test_infra/controllers/node_controllers/ssh.py:50)
2021-05-11 04:56:04,540 ERROR      - 139918457161472 - Failed accessing node test-infra-cluster-assisted-installer-worker-0 for sosreport data gathering 	(./discovery-infra/download_logs.py:262)
Traceback (most recent call last):
  File "./discovery-infra/download_logs.py", line 255, in gather_sosreport_from_node
    node.upload_file(SOSREPORT_SCRIPT, "/tmp/man_sosreport.sh")
  File "/home/assisted/discovery-infra/test_infra/controllers/node_controllers/node.py", line 57, in upload_file
    with self.ssh_connection as _ssh:
  File "/home/assisted/discovery-infra/test_infra/controllers/node_controllers/ssh.py", line 22, in __enter__
    self.connect()
  File "/home/assisted/discovery-infra/test_infra/controllers/node_controllers/ssh.py", line 35, in connect
    self.wait_for_tcp_server()
  File "/home/assisted/discovery-infra/test_infra/controllers/node_controllers/ssh.py", line 57, in wait_for_tcp_server
    hostname=self._ip, port=self._port))
TimeoutError: SSH TCP Server '1001:db8::19:22' did not respond within timeout
```

This change will use the right IP family based on the provided IP address.
/cc @YuviGold @tsorya 
/hold