### PR TITLE
MGMT-4640 Renamed generate-ocp-version target

### DIFF
--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -37,10 +37,10 @@ if [ "${OPENSHIFT_INSTALL_RELEASE_IMAGE}" != "" ]; then
 
     if [ "${DEPLOY_TARGET}" == "onprem" ]; then
         if [ -x "$(command -v docker)" ]; then
-            make -C assisted-service/ generate-ocp-version
+            make -C assisted-service/ generate-configuration
         else
             ln -s $(which podman) /usr/bin/docker
-            make -C assisted-service/ generate-ocp-version
+            make -C assisted-service/ generate-configuration
             rm -f /usr/bin/docker
         fi
     fi


### PR DESCRIPTION
Adjusting make target to a new name: `generate-ocp-version` in assisted-service Makefile became `generate-configuration`.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>