### PR TITLE
MGMT-5274 Deploy assisted operator

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ This project deploys the OpenShift Assisted Installer in Minikube and spawns lib
   - [Test installer, controller, `assisted-service` and agent images in the same flow](#test-installer-controller-assisted-service-and-agent-images-in-the-same-flow)
     - [Test infra image](#test-infra-image)
   - [In case you would like to build the image with a different `assisted-service` client](#in-case-you-would-like-to-build-the-image-with-a-different-assisted-service-client)
-  - [Test with Authentication](#test-with-authentication)
+  - [Test with RHSSO Authentication](#test-with-rhsso-authentication)
   - [Single Node - Bootstrap in place with Assisted Service](#single-node---bootstrap-in-place-with-assisted-service)
   - [Single Node - Bootstrap in place with Assisted Service and IPv6](#single-node---bootstrap-in-place-with-assisted-service-and-ipv6)
   - [On-prem](#on-prem)
+  - [Run operator](#run-operator)
 
 ## Prerequisites
 
@@ -391,4 +392,28 @@ To cleanup after the full flow:
 
 ```
 make destroy
+```
+
+## Run operator
+
+The current implementation installs an OCP cluster using assisted service on minikube.
+Afterwards, we install the assisted-service-operator on top of that cluster.
+The first step would be removed once we could either:
+
+- Have an OCP cluster easily (i.e. [CRC](https://developers.redhat.com/products/codeready-containers/overview))
+- Install the assisted-service operator on top of pure-k8s cluster. (At the moment there are some OCP component prerequisites)
+
+```bash
+# Deploy AI with LSO
+OLM_OPERATORS=lso make run_full_flow_with_install
+
+# Deploy AI Operator on top of the new cluster
+export KUBECONFIG=./build/kubeconfig
+make deploy_assisted_operator
+```
+
+Clear the operator deployment
+
+```bash
+make clear_operator
 ```

--- a/scripts/assisted_deployment.sh
+++ b/scripts/assisted_deployment.sh
@@ -18,12 +18,17 @@ function set_dns() {
       echo IP for interface tt$NAMESPACE_INDEX was not found
       exit 1
     fi
+
+    update_vips
+
     FILE="/etc/NetworkManager/conf.d/dnsmasq.conf"
     if ! [ -f "${FILE}" ]; then
         echo -e "[main]\ndns=dnsmasq" | sudo tee $FILE
     fi
     sudo truncate -s0 /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
     echo "server=/api.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}/${NAMESERVER_IP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
+    echo "server=/.apps.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}/${NAMESERVER_IP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
+
     sudo systemctl reload NetworkManager
 
     echo "Finished setting dns"
@@ -31,10 +36,12 @@ function set_dns() {
 
 function update_vips() {
     API_VIP=$(sudo virsh net-dhcp-leases test-infra-net-${NAMESPACE} | grep api | awk '{print $5}' | cut -d"/" -f1)
+    INGRESS_VIP=$(sudo virsh net-dhcp-leases test-infra-net-${NAMESPACE} | grep ingress | awk '{print $5}' | cut -d"/" -f1)
+
     virsh net-update test-infra-net-${NAMESPACE} delete dns-host "<host ip='192.168.126.100'><hostname>api.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}</hostname></host>"
     virsh net-update test-infra-net-${NAMESPACE} add dns-host "<host ip='${API_VIP}'><hostname>api.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}</hostname></host>"
+    virsh net-update test-infra-net-${NAMESPACE} add dns-host "<host ip='${INGRESS_VIP}'><hostname>assisted-service-assisted-installer.apps.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}</hostname></host>"
 }
-
 
 # Delete after pushing fix to dev-scripts
 function wait_for_cluster() {

--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -18,14 +18,13 @@ export ENABLE_KUBE_API_CMD="ENABLE_KUBE_API=${ENABLE_KUBE_API}"
 export OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS:-}
 export OPENSHIFT_VERSIONS_CMD=""
 
-if [[ "${ENABLE_KUBE_API}" == "true" && -z "${OPENSHIFT_VERSIONS}" ]]; then
+if [[ "${ENABLE_KUBE_API}" == "true" || "${DEPLOY_TARGET}" == "operator" && -z "${OPENSHIFT_VERSIONS}" ]]; then
     # Supporting version 4.8 for kube-api
-    supported_version=$(cat assisted-service/default_ocp_versions.json |
+    OPENSHIFT_VERSIONS=$(cat assisted-service/default_ocp_versions.json |
        jq -rc 'with_entries(.key = "4.8") | with_entries(
            {key: .key, value: {rhcos_image: .value.rhcos_image, rhcos_version: .value.rhcos_version}})')
     json_template=\''%s'\'
-    OPENSHIFT_VERSIONS=$(printf "$json_template" "$supported_version")
-    OPENSHIFT_VERSIONS_CMD="OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS}"
+    OPENSHIFT_VERSIONS_CMD="OPENSHIFT_VERSIONS=$(printf "${json_template}" "${OPENSHIFT_VERSIONS}")"
 fi
 
 mkdir -p build
@@ -72,6 +71,40 @@ elif [ "${DEPLOY_TARGET}" == "ocp" ]; then
 
     wait_for_url_and_run "$SERVICE_BASE_URL" "spawn_port_forwarding_command $SERVICE_NAME $OCP_SERVICE_PORT $NAMESPACE $NAMESPACE_INDEX $OCP_KUBECONFIG ocp $CLUSTER_VIP $SERVICE_NODEPORT"
     print_log "${SERVICE_NAME} can be reached at ${SERVICE_BASE_URL}"
+elif [ "${DEPLOY_TARGET}" == "operator" ]; then
+    # This nginx would listen to http on OCP_SERVICE_PORT and it would proxy_pass it to the actual route.
+    export SERVICE_BASE_URL=http://${SERVICE_URL}:${OCP_SERVICE_PORT}
+    add_firewalld_port ${OCP_SERVICE_PORT}
+
+    # TODO: Find a way to get the route dest dynamically.
+    # Currently it's not possible since it would be available only after the operator would be deployed
+    # The deploy.sh script would wait for the operator to succeed - so we need to have the LB before that.
+    # ROUTE=$(kubectl get routes -n assisted-installer --no-headers | awk '{print $2}')
+
+    ROUTE=assisted-service-assisted-installer.apps.test-infra-cluster-assisted-installer.redhat.com
+
+    tee << EOF ${HOME}/.test-infra/etc/nginx/conf.d/http_localhost.conf
+upstream upstream_${SERVICE_URL//./_} {
+    server ${ROUTE}:443;
+}
+
+server {
+    listen ${SERVICE_URL}:${OCP_SERVICE_PORT};
+
+    location / {
+        proxy_pass https://upstream_${SERVICE_URL//./_};
+        proxy_set_header Host ${ROUTE};
+    }
+}
+EOF
+
+    export DISKS="${LSO_DISKS:-}"
+    export ASSISTED_NAMESPACE=${NAMESPACE}
+    export SERVICE_IMAGE=${SERVICE}
+    export STORAGE_CLASS_NAME="localblock-sc"
+
+    INSTALL_LSO=false ./assisted-service/deploy/operator/deploy.sh
+    echo "Installation of Assisted Install operator passed successfully!"
 else
     print_log "Updating assisted_service params"
     skipper run discovery-infra/update_assisted_service_cm.py

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -22,7 +22,7 @@ volumes:
   - /var/ai-logs:/var/ai-logs
 
   # sockets
-  - $HOME/.test-infra/etc/nginx/stream.d:/etc/nginx/stream.d
+  - $HOME/.test-infra/etc/nginx/conf.d:/etc/nginx/conf.d
 
   # cache
   - $HOME/.cache/go-build/:/go/pkg/mod/

--- a/terraform_files/none/main.tf
+++ b/terraform_files/none/main.tf
@@ -107,7 +107,7 @@ data "libvirt_network_dns_host_template" "masters_oauth" {
 resource "local_file" "load_balancer_config" {
   count    = var.load_balancer_ip != "" && var.load_balancer_config_file != "" ? 1 : 0
   content  = var.load_balancer_config_file
-  filename = format("/etc/nginx/stream.d/%s.conf", replace(var.load_balancer_ip,"/[:.]/" , "_"))
+  filename = format("/etc/nginx/conf.d/stream_%s.conf", replace(var.load_balancer_ip,"/[:.]/" , "_"))
 }
 
 resource "libvirt_domain" "master" {


### PR DESCRIPTION
Add new 'operator' DEPLOY_TARGET to deploy_assisted_service.sh that
calls deploy/operator/deploy.sh script from assisted-service repository.

The current workflow to install an operator is to make a regular
installation with AI, and afterwards use its KUBECONFIG to deploy the
assisted-operator on top of it.

A cluster installed with test-infra is provisoned with nat networking.
It created iptables rules by design to ignore inbound connections except
from the host.
Hence, in order to make new VMs from a new network to reach the
assisted operator that is installed on the cluster - we have to pass the
communication through the host. It is made by overriding
SERVICE_BASE_URL.

Before deploying, we will start an nginx load balacer and configure it
to listen to http and proxy pass the communication to the OCP route.
The OCP route looks at the layer 7 Host field for destination - so we
change that as well with "proxy_set_header Host" configuration.