### PR TITLE
SSH through all available node IPs

### DIFF
--- a/discovery-infra/download_logs.py
+++ b/discovery-infra/download_logs.py
@@ -69,7 +69,8 @@ def main():
                 download_logs(client, cluster, args.dest, args.must_gather, args.update_by_events,
                               pull_secret=args.pull_secret)
 
-        print(Counter(map(lambda cluster: cluster['status'], clusters)))
+        log.info("Cluster installation statuses: %s",
+                 dict(Counter(cluster["status"] for cluster in clusters).items()))
 
 
 def get_clusters(client, all_cluster):

--- a/discovery-infra/test_infra/controllers/node_controllers/ssh.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/ssh.py
@@ -54,7 +54,7 @@ class SshConnection:
             if self._raw_tcp_connect((self._ip, self._port)):
                 return
             time.sleep(interval)
-        raise TimeoutError("SSH TCP Server '%(hostname)s:%(port)s' did not respond within timeout" % dict(
+        raise TimeoutError("SSH TCP Server '[%(hostname)s]:%(port)s' did not respond within timeout" % dict(
             hostname=self._ip, port=self._port))
 
     @classmethod


### PR DESCRIPTION
When configuring a SSH connection, we need to decide which IP address to use.
Currently we get all DHCP leases from libvirt, and use the first provided address. It will work on IPv4 because DHCP will always return the same address to the hosts, but on IPv6 environment the returned addresses are not constant.
This change is making a complete traversal over all IP addresses of the node, over all networks. This will ensure that as long as the node is up, we'll be able to reach it.