### PR TITLE
MGMT-6438 remove references to deprecated env variables

### DIFF
--- a/discovery-infra/update_assisted_service_cm.py
+++ b/discovery-infra/update_assisted_service_cm.py
@@ -23,12 +23,7 @@ warn_deprecate()
 CM_PATH = "assisted-service/deploy/assisted-service-configmap.yaml"
 ENVS = [
     ("HW_VALIDATOR_MIN_CPU_CORES", "2"),
-    ("HW_VALIDATOR_MIN_CPU_CORES_WORKER", "2"),
-    ("HW_VALIDATOR_MIN_CPU_CORES_MASTER", "4"),
     ("HW_VALIDATOR_MIN_RAM_GIB", "3"),
-    ("HW_VALIDATOR_MIN_RAM_GIB_WORKER", "3"),
-    ("HW_VALIDATOR_MIN_RAM_GIB_MASTER", "8"),
-    ("HW_VALIDATOR_MIN_DISK_SIZE_GIB", "10"),
     ("INSTALLER_IMAGE", ""),
     ("CONTROLLER_IMAGE", ""),
     ("SERVICE_BASE_URL", ""),

--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -61,9 +61,6 @@ if [ "${DEPLOY_TARGET}" == "onprem" ]; then
     fi
     sed -i "s/SERVICE_BASE_URL=http:\/\/127.0.0.1/SERVICE_BASE_URL=http:\/\/${ASSISTED_SERVICE_HOST}/" assisted-service/onprem-environment
 
-    # deprecated; remove when support is removed from assisted-service
-    echo $'\nHW_VALIDATOR_MIN_DISK_SIZE_GIB=20'>> assisted-service/onprem-environment
-
     validator_requirements=$(grep HW_VALIDATOR_REQUIREMENTS assisted-service/onprem-environment | cut -d '=' -f2)
     HW_VALIDATOR_REQUIREMENTS_LOW_DISK=$(echo $validator_requirements | jq '(.[].worker.disk_size_gb, .[].master.disk_size_gb) |= 20' | tr -d "\n\t ")
     sed -i "s|HW_VALIDATOR_REQUIREMENTS=.*|HW_VALIDATOR_REQUIREMENTS=${HW_VALIDATOR_REQUIREMENTS_LOW_DISK}|" assisted-service/onprem-environment


### PR DESCRIPTION
his PR removes last traces of env variables removed in #1715:

- HW_VALIDATOR_MIN_CPU_CORES_WORKER
- HW_VALIDATOR_MIN_CPU_CORES_MASTER
- HW_VALIDATOR_MIN_RAM_GIB_WORKER
- HW_VALIDATOR_MIN_RAM_GIB_MASTER
- HW_VALIDATOR_MIN_DISK_SIZE_GIB

Currently all of the above requirements have to be set using `HW_VALIDATOR_REQUIREMENTS`.

Signed-off-by: Jakub Dzon <jdzon@redhat.com>