### PR TITLE
NO-ISSUE define REST client after gathering sosreport

### DIFF
--- a/discovery-infra/download_logs.py
+++ b/discovery-infra/download_logs.py
@@ -48,11 +48,11 @@ warn_deprecate()
 
 def main():
     args = handle_arguments()
-    client = create_client(url=args.inventory_url, timeout=CONNECTION_TIMEOUT)
 
     if args.sosreport:
         gather_sosreport_data(output_dir=args.dest)
 
+    client = create_client(url=args.inventory_url, timeout=CONNECTION_TIMEOUT)
     if args.cluster_id:
         cluster = client.cluster_get(args.cluster_id)
         download_logs(client, json.loads(json.dumps(cluster.to_dict(), sort_keys=True, default=str)), args.dest,


### PR DESCRIPTION
On kube-api we cannot create the REST client, which makes a too early failure before gathering sosreport.
/cc @YuviGold @filanov 
/hold