### PR TITLE
MGMT-6587 Include disk_index as part of disk name on format_disk

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -524,7 +524,7 @@ class LibvirtController(NodeController, ABC):
         current_xml = dom.XMLDesc(0)
         return minidom.parseString(current_xml.encode('utf-8'))
 
-    def format_node_disk(self, node_name: str) -> None:
+    def format_node_disk(self, node_name: str, disk_index: int = 0) -> None:
         raise NotImplementedError
 
     def get_ingress_and_api_vips(self) -> dict:

--- a/discovery-infra/test_infra/controllers/node_controllers/node.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/node.py
@@ -107,8 +107,8 @@ class Node:
         self.format_disk()
         self.start()
 
-    def format_disk(self):
-        self.node_controller.format_node_disk(self.name)
+    def format_disk(self, disk_index: int = 0):
+        self.node_controller.format_node_disk(self.name, disk_index)
 
     def kill_installer(self):
         self.kill_podman_container_by_name("assisted-installer")

--- a/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
@@ -46,7 +46,7 @@ class NodeController(ABC):
         pass
 
     @abstractmethod
-    def format_node_disk(self, node_name: str) -> None:
+    def format_node_disk(self, node_name: str, disk_index: int = 0) -> None:
         pass
 
     @abstractmethod

--- a/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -197,9 +197,9 @@ class TerraformController(LibvirtController):
         else:
             return super().start_all_nodes()
 
-    def format_node_disk(self, node_name):
+    def format_node_disk(self, node_name: str, disk_index: int = 0):
         logging.info("Formating disk for %s", node_name)
-        self.format_disk(f'{self.params.libvirt_storage_pool_path}/{self.cluster_name}/{node_name}')
+        self.format_disk(f'{self.params.libvirt_storage_pool_path}/{self.cluster_name}/{node_name}-disk-{disk_index}')
 
     def get_ingress_and_api_vips(self):
         network_subnet_starting_ip = str(


### PR DESCRIPTION
On https://github.com/openshift/assisted-test-infra/pull/772 disks names
were changed in order to support creation of multiple disks.
Now instead of the disk name to be the same as the node name
<cluster_name>-<node_role>-<node_index>, it is now
<cluster_name>-<node_role>-<node_index>-disk-<disk_index>

For now, format_disk will receive the disk index as a parameter.

cc @lalon4 @patrickdillon @tsorya  @omertuc 