### PR TITLE
MGMT-6579: download_logs.sh: collect kube-api CRs

### DIFF
--- a/scripts/download_logs.sh
+++ b/scripts/download_logs.sh
@@ -10,6 +10,7 @@ CLUSTER_ID=${CLUSTER_ID:-""}
 ADDITIONAL_PARAMS=${ADDITIONAL_PARAMS:-""}
 KUBECTL=${KUBECTL:-kubectl}
 LOGS_DEST=${LOGS_DEST:-build}
+KUBE_CRS=( clusterdeployment infraenv agentclusterinstall agent )
 
 function download_service_logs() {
   mkdir -p ${LOGS_DEST} || true
@@ -18,11 +19,16 @@ function download_service_logs() {
     podman ps -a || true
 
     for service in "installer" "db"; do
-        podman logs ${service} > ${LOGS_DEST}/onprem_${service}.log || true
+      podman logs ${service} > ${LOGS_DEST}/onprem_${service}.log || true
     done
   else
+    CRS=node,pod,svc,deployment,pv,pvc
+    if [ ${ENABLE_KUBE_API} == "true"  ]; then
+      collect_kube_api_resources
+      CRS+=$(printf ",%s" "${KUBE_CRS[@]}")
+    fi
     ${KUBECTL} cluster-info
-    ${KUBECTL} get node,pod,svc,deployment,pv,pvc -n ${NAMESPACE} -o wide || true
+    ${KUBECTL} get ${CRS} -n ${NAMESPACE} -o wide || true
     ${KUBECTL} get pods -n ${NAMESPACE} -o=custom-columns=NAME:.metadata.name --no-headers | xargs -r -I {} sh -c "${KUBECTL} logs {} -n ${NAMESPACE} --all-containers > ${LOGS_DEST}/k8s_{}.log" || true
     ${KUBECTL} get events -n ${NAMESPACE} --sort-by=.metadata.creationTimestamp > ${LOGS_DEST}/k8s_events.log || true
   fi
@@ -41,5 +47,13 @@ function download_cluster_logs() {
 
   skipper run ./discovery-infra/download_logs.py ${SERVICE_URL} ${LOGS_DEST} --cluster-id ${CLUSTER_ID} ${ADDITIONAL_PARAMS}
 }
+
+function collect_kube_api_resources() {
+    for CR in "${KUBE_CRS[@]}"
+    do
+      ${KUBECTL} get ${CR} -n ${NAMESPACE} -o=custom-columns=NAME:.metadata.name --no-headers | xargs -r -I {} sh -c "${KUBECTL} get -ojson ${CR} {} -n ${NAMESPACE} > ${LOGS_DEST}/${CR}_{}.json" || true
+    done
+}
+
 
 "$@"


### PR DESCRIPTION
Collect data and description of cluster deployment, agent cluster install,
InfraEnv, and the agents in kube-api mode.

https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_assisted-test-infra/826/pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-kube-api/1396781858645086208/artifacts/e2e-metal-assisted-kube-api/baremetalds-assisted-gather/artifacts/