### PR TITLE
MGMT-6544 Create API VIP DNS

### DIFF
--- a/scripts/assisted_deployment.sh
+++ b/scripts/assisted_deployment.sh
@@ -19,8 +19,6 @@ function set_dns() {
       exit 1
     fi
 
-    update_vips
-
     FILE="/etc/NetworkManager/conf.d/dnsmasq.conf"
     if ! [ -f "${FILE}" ]; then
         echo -e "[main]\ndns=dnsmasq" | sudo tee $FILE
@@ -32,15 +30,6 @@ function set_dns() {
     sudo systemctl reload NetworkManager
 
     echo "Finished setting dns"
-}
-
-function update_vips() {
-    API_VIP=$(sudo virsh net-dhcp-leases test-infra-net-${NAMESPACE} | grep api | awk '{print $5}' | cut -d"/" -f1)
-    INGRESS_VIP=$(sudo virsh net-dhcp-leases test-infra-net-${NAMESPACE} | grep ingress | awk '{print $5}' | cut -d"/" -f1)
-
-    virsh net-update test-infra-net-${NAMESPACE} delete dns-host "<host ip='192.168.126.100'><hostname>api.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}</hostname></host>"
-    virsh net-update test-infra-net-${NAMESPACE} add dns-host "<host ip='${API_VIP}'><hostname>api.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}</hostname></host>"
-    virsh net-update test-infra-net-${NAMESPACE} add dns-host "<host ip='${INGRESS_VIP}'><hostname>assisted-service-assisted-installer.apps.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}</hostname></host>"
 }
 
 # Delete after pushing fix to dev-scripts

--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -191,31 +191,33 @@ resource "libvirt_domain" "worker" {
 # the count directive to include/exclude elements
 
 data "libvirt_network_dns_host_template" "api" {
-  count    = !var.bootstrap_in_place || var.single_node_ip != "" ? 1 : 0
+  # API VIP is always present. A value is set by the installation flow that updates 
+  # either the single node IP or API VIP, depending on the scenario
+  count    = 1
   ip       = var.bootstrap_in_place ? var.single_node_ip : var.api_vip
   hostname = "api.${var.cluster_name}.${var.cluster_domain}"
 }
 
 data "libvirt_network_dns_host_template" "api-int" {
-  count    = var.bootstrap_in_place && var.single_node_ip != "" ? 1 : 0
+  count    = var.bootstrap_in_place ? 1 : 0
   ip       = var.single_node_ip
   hostname = "api-int.${var.cluster_name}.${var.cluster_domain}"
 }
 
 data "libvirt_network_dns_host_template" "oauth" {
-  count    = var.bootstrap_in_place  && var.single_node_ip != "" ? 1 : 0
+  count    = var.bootstrap_in_place ? 1 : 0
   ip       = var.single_node_ip
   hostname = "oauth-openshift.apps.${var.cluster_name}.${var.cluster_domain}"
 }
 
 data "libvirt_network_dns_host_template" "console" {
-  count    = var.bootstrap_in_place && var.single_node_ip != "" ? 1 : 0
+  count    = var.bootstrap_in_place ? 1 : 0
   ip       = var.single_node_ip
   hostname = "console-openshift-console.apps.${var.cluster_name}.${var.cluster_domain}"
 }
 
 data "libvirt_network_dns_host_template" "canary" {
-  count    = var.bootstrap_in_place && var.single_node_ip != "" ? 1 : 0
+  count    = var.bootstrap_in_place ? 1 : 0
   ip       = var.single_node_ip
   hostname = "canary-openshift-ingress-canary.apps.${var.cluster_name}.${var.cluster_domain}"
 }

--- a/terraform_files/baremetal/terraform.tfvars.json
+++ b/terraform_files/baremetal/terraform.tfvars.json
@@ -28,6 +28,7 @@
   "libvirt_network_name": "test-infra-net",
   "libvirt_secondary_network_name": "test-infra-secondary-net",
   "api_vip": "192.168.126.100",
+  "single_node_ip": "192.168.126.100",
   "libvirt_network_mtu": "1500",
   "running": true,
   "bootstrap_in_place": false,


### PR DESCRIPTION
For running conformance tests, API VIP must be accessible by
DNS name 'api.test-infra-cluster-assisted-installer.redhat.com'.

In order for that to work
1. Make sure the libvirt network has a dns-host entry for API,
   (created by Terraform).
2. Update the entry with the correct IP address as soon as it
   becomes known by updating a Terraform variable. This is
   already done in the Python code, so removing the Shell function
   because the logic there is incomplete.
3. Make dnsmasq use the libvirt network's address to handle DNS
   resolution, so that the DNS entry for API can be resolved from
   the host (already implemented by `set_dns()`).

Tested scenarios:
* multinode + IPv4
* SNO + IPv4
* multinode + static network config + IPv4
* SNO + static network config + IPv4
* multinode + IPv6
* SNO + IPv6
* multinode + static network config + IPv6
* SNO + static network config + IPv6