### PR TITLE
MGMT-6550 Add sno requirements to versioned requirements

### DIFF
--- a/discovery-infra/update_assisted_service_cm.py
+++ b/discovery-infra/update_assisted_service_cm.py
@@ -54,10 +54,17 @@ DEFAULT_WORKER_REQUIREMENTS = {
     "disk_size_gb": 10,
     "installation_disk_speed_threshold_ms": 10
 }
+DEFAULT_SNO_REQUIREMENTS = {
+    "cpu_cores": 8,
+    "ram_mib": 32768,
+    "disk_size_gb": 10,
+    "installation_disk_speed_threshold_ms": 10
+}
 DEFAULT_REQUIREMENTS = [{
     "version": "default",
     "master": DEFAULT_MASTER_REQUIREMENTS,
-    "worker": DEFAULT_WORKER_REQUIREMENTS
+    "worker": DEFAULT_WORKER_REQUIREMENTS,
+    "sno": DEFAULT_SNO_REQUIREMENTS
 }]
 
 
@@ -88,6 +95,7 @@ def update_requirements(requirements_json):
         if version_requirements["version"] == "default":
             version_requirements["master"] = DEFAULT_MASTER_REQUIREMENTS
             version_requirements["worker"] = DEFAULT_WORKER_REQUIREMENTS
+            version_requirements["sno"] = DEFAULT_SNO_REQUIREMENTS
 
     return json.dumps(requirements)
 

--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -65,7 +65,7 @@ if [ "${DEPLOY_TARGET}" == "onprem" ]; then
     echo $'\nHW_VALIDATOR_MIN_DISK_SIZE_GIB=20'>> assisted-service/onprem-environment
 
     validator_requirements=$(grep HW_VALIDATOR_REQUIREMENTS assisted-service/onprem-environment | cut -d '=' -f2)
-    HW_VALIDATOR_REQUIREMENTS_LOW_DISK=$(echo $validator_requirements | jq '(.[].worker.disk_size_gb, .[].master.disk_size_gb) |= 20' | tr -d "\n\t ")
+    HW_VALIDATOR_REQUIREMENTS_LOW_DISK=$(echo $validator_requirements | jq '(.[].worker.disk_size_gb, .[].master.disk_size_gb, .[].sno.disk_size_gb) |= 20' | tr -d "\n\t ")
     sed -i "s|HW_VALIDATOR_REQUIREMENTS=.*|HW_VALIDATOR_REQUIREMENTS=${HW_VALIDATOR_REQUIREMENTS_LOW_DISK}|" assisted-service/onprem-environment
 
     make -C assisted-service/ deploy-onprem


### PR DESCRIPTION
This PR adds "sno" requirements to code handling `HW_VALIDATOR_REQUIREMENTS` env variable and config map key updates.

Related to https://github.com/openshift/assisted-service/pull/1818

Signed-off-by: Jakub Dzon <jdzon@redhat.com>