### PR TITLE
MGMT-6521 - move logs methods from utils to logs_utils

### DIFF
--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -21,7 +21,7 @@ from test_infra.controllers.load_balancer_controller import LoadBalancerControll
 from test_infra.helper_classes.config import BaseClusterConfig
 from test_infra.helper_classes.nodes import Nodes
 from test_infra.tools import static_network, terraform_utils
-from test_infra.utils import operators_utils
+from test_infra.utils import operators_utils, logs_utils
 
 
 class Cluster:
@@ -347,7 +347,7 @@ class Cluster:
         self.api_client.install_cluster(cluster_id=self.id)
 
     def wait_for_logs_complete(self, timeout, interval=60, check_host_logs_only=False):
-        utils.wait_for_logs_complete(
+        logs_utils.wait_for_logs_complete(
             client=self.api_client,
             cluster_id=self.id,
             timeout=timeout,


### PR DESCRIPTION
Deprecated functions on `test_infra.utils` are used at https://gitlab.cee.redhat.com/ocp-edge-qe/kni-assisted-installer-auto/-/blob/master/api_tests/test_logs.py