### PR TITLE
MGMT-6549 remove references to deprecated env variables

### DIFF
--- a/discovery-infra/update_assisted_service_cm.py
+++ b/discovery-infra/update_assisted_service_cm.py
@@ -22,8 +22,6 @@ warn_deprecate()
 
 CM_PATH = "assisted-service/deploy/assisted-service-configmap.yaml"
 ENVS = [
-    ("HW_VALIDATOR_MIN_CPU_CORES", "2"),
-    ("HW_VALIDATOR_MIN_RAM_GIB", "3"),
     ("INSTALLER_IMAGE", ""),
     ("CONTROLLER_IMAGE", ""),
     ("SERVICE_BASE_URL", ""),


### PR DESCRIPTION
Support for HW_VALIDATOR_MIN_CPU_CORES and HW_VALIDATOR_MIN_RAM_GIB has been removed from the assisted-service code so the references to them can be removed here as well

Signed-off-by: Jakub Dzon <jdzon@redhat.com>