### PR TITLE
NO-ISSUE - Replace libvirt list_leases usage with utils usage to support ipv6

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -139,7 +139,7 @@ class LibvirtController(NodeController, ABC):
         return self._list_disks(node)
 
     def list_leases(self, network_name):
-        return self.libvirt_connection.networkLookupByName(network_name).DHCPLeases()
+        return utils.get_network_leases(network_name)
 
     def shutdown_node(self, node_name):
         logging.info("Going to shutdown %s", node_name)


### PR DESCRIPTION
It changed on https://github.com/openshift/assisted-test-infra/pull/335 but not on the controller