### PR TITLE
MGMT-6744 Use hostnames from TF if hosts have IPv6

### DIFF
--- a/discovery-infra/day2.py
+++ b/discovery-infra/day2.py
@@ -18,15 +18,15 @@ def set_cluster_pull_secret(client, cluster_id, pull_secret):
     client.set_pull_secret(cluster_id, pull_secret)
 
 
-def execute_day2_cloud_flow(cluster_id, args, has_ipv4):
-    execute_day2_flow(cluster_id, args, "cloud", has_ipv4)
+def execute_day2_cloud_flow(cluster_id, args, has_ipv6):
+    execute_day2_flow(cluster_id, args, "cloud", has_ipv6)
 
 
-def execute_day2_ocp_flow(cluster_id, args, has_ipv4):
-    execute_day2_flow(cluster_id, args, "ocp", has_ipv4)
+def execute_day2_ocp_flow(cluster_id, args, has_ipv6):
+    execute_day2_flow(cluster_id, args, "ocp", has_ipv6)
 
 
-def execute_day2_flow(cluster_id, args, day2_type_flag, has_ipv4):
+def execute_day2_flow(cluster_id, args, day2_type_flag, has_ipv6):
     utils.recreate_folder(consts.IMAGE_FOLDER, force_recreate=False)
     client = assisted_service_api.create_client(
         url=utils.get_assisted_service_url_by_args(args=args)
@@ -73,7 +73,7 @@ def execute_day2_flow(cluster_id, args, day2_type_flag, has_ipv4):
         terraform_cluster_dir_prefix,
         tf_folder,
         cluster,
-        has_ipv4,
+        has_ipv6,
         args.number_of_day2_workers,
         api_vip_ip,
         api_vip_dnsname,
@@ -87,7 +87,7 @@ def day2_nodes_flow(client,
                     terraform_cluster_dir_prefix,
                     tf_folder,
                     cluster,
-                    has_ipv_4,
+                    has_ipv_6,
                     num_worker_nodes,
                     api_vip_ip,
                     api_vip_dnsname,
@@ -124,7 +124,7 @@ def day2_nodes_flow(client,
     set_nodes_hostnames_if_needed(client,
                                   tf_folder,
                                   with_static_network_config,
-                                  has_ipv_4,
+                                  has_ipv_6,
                                   tf_network_name,
                                   cluster.id)
 
@@ -303,14 +303,14 @@ def set_cluster_proxy(client, cluster_id, copy_proxy_from_cluster, args):
 def set_nodes_hostnames_if_needed(client,
                                   tf_folder,
                                   with_static_network_config,
-                                  has_ipv_4,
+                                  has_ipv_6,
                                   network_name,
                                   cluster_id):
-    if not has_ipv_4 or with_static_network_config:
+    if has_ipv_6 or with_static_network_config:
         tf = terraform_utils.TerraformUtils(working_dir=tf_folder)
         libvirt_nodes = utils.extract_nodes_from_tf_state(tf.get_state(), network_name, consts.NodeRoles.WORKER)
         log.info(
             "Set hostnames of day2 cluster %s in case of static network configuration or "
-            "to work around libvirt for Terrafrom not setting hostnames of IPv6-only hosts",
+            "to work around libvirt for Terrafrom not setting hostnames of IPv6 hosts",
             cluster_id)
         utils.update_hosts(client, cluster_id, libvirt_nodes, update_roles=False, update_hostnames=True)

--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -635,7 +635,7 @@ def set_hosts_roles(client, cluster, nodes_details, machine_net, tf, master_coun
     )
 
     # don't set roles in bip role
-    if machine_net.has_ip_v4:
+    if not machine_net.has_ip_v6:
         libvirt_nodes = utils.get_libvirt_nodes_mac_role_ip_and_name(networks_names[0])
         libvirt_nodes.update(utils.get_libvirt_nodes_mac_role_ip_and_name(networks_names[1]))
         if static_network_mode:
@@ -644,7 +644,7 @@ def set_hosts_roles(client, cluster, nodes_details, machine_net, tf, master_coun
         else:
             update_hostnames = False
     else:
-        log.warning("Work around libvirt for Terrafrom not setting hostnames of IPv6-only hosts")
+        log.warning("Work around libvirt for Terrafrom not setting hostnames of IPv6 hosts")
         libvirt_nodes = utils.get_libvirt_nodes_from_tf_state(networks_names, tf.get_state())
         update_hostnames = True
 
@@ -904,11 +904,11 @@ def main():
     elif is_none_platform_mode():
         raise NotImplementedError("None platform currently not supporting day2")
 
-    has_ipv4 = args.ipv4 and args.ipv4.lower() in MachineNetwork.YES_VALUES
+    has_ipv6 = args.ipv6 and args.ipv6.lower() in MachineNetwork.YES_VALUES
     if args.day2_cloud_cluster:
-        day2.execute_day2_cloud_flow(cluster_id, args, has_ipv4)
+        day2.execute_day2_cloud_flow(cluster_id, args, has_ipv6)
     if args.day2_ocp_cluster:
-        day2.execute_day2_ocp_flow(cluster_id, args, has_ipv4)
+        day2.execute_day2_ocp_flow(cluster_id, args, has_ipv6)
     if args.bootstrap_in_place:
         ibip.execute_ibip_flow(args)
 


### PR DESCRIPTION
It looks like libvirt won't have a hostname in the DHCP lease of a VM
that has IPv6, even if it also has an IPv4 address. In this case we
need to get the hostname from Terraform, like we do with IPv6-only
hosts.

This is in preparation for dual stack support (`IPv4=yes IPv6=yes`).