### PR TITLE
OCPBUGSM-26780 api_vip_dns_name resolves to incorrect IP leading to API VIP connection validation failure

### DIFF
--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -541,6 +541,10 @@ def nodes_flow(
                 statuses=[consts.NodesStatus.KNOWN],
             )
 
+            if args.vip_dhcp_allocation:
+                vips_info = helper_cluster.Cluster.get_vips_from_cluster(client, cluster.id)
+                tf.set_new_vip(vips_info["api_vip"])
+
         if args.install_cluster:
             install_cluster.run_install_flow(
                 client=client,

--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -923,6 +923,11 @@ class Cluster:
     def get_worker_ips(client, cluster_id, network):
         return Cluster.get_ips_for_role(client, cluster_id, network, consts.NodeRoles.WORKER)
 
+    @staticmethod
+    def get_vips_from_cluster(client, cluster_id):
+        cluster_info = client.cluster_get(cluster_id)
+        return dict(api_vip=cluster_info.api_vip, ingress_vip=cluster_info.ingress_vip)
+
     def get_host_disks(self, host, filter=None):
         hosts = self.get_hosts()
         selected_host = [h for h in hosts if h["id"] == host["id"]]


### PR DESCRIPTION
When VIP allocation is done using DHCP, the API VIP DNS has to be published after it is allocated.

This flow is irrelevant for non DHCP allocation since the VIPs are static when this flow is used
so they are set before running terraform the first time.

/cc @eliorerz 