### PR TITLE
MGMT-6581 collect debuginfo on cluster install failure

### DIFF
--- a/discovery-infra/test_infra/helper_classes/kube_helpers/agent_cluster_install.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/agent_cluster_install.py
@@ -241,6 +241,8 @@ class AgentClusterInstall(BaseCustomResource):
             cond_type=self._completed_condition_name,
             required_status="True",
             required_reason="InstallationCompleted",
+            exception_status="False",
+            exception_reason="InstallationFailed",
             timeout=timeout,
         )
 
@@ -249,6 +251,8 @@ class AgentClusterInstall(BaseCustomResource):
         cond_type: str,
         required_status: str,
         required_reason: Optional[str] = None,
+        exception_status: Optional[str] = None,
+        exception_reason: Optional[str] = None,
         timeout: Union[int, float] = DEFAULT_WAIT_FOR_CRD_STATE_TIMEOUT,
     ) -> None:
 
@@ -268,6 +272,8 @@ class AgentClusterInstall(BaseCustomResource):
                 if required_reason:
                     return required_reason == reason
                 return True
+            elif status == exception_status and reason == exception_reason:
+                raise Exception(f"Unexpected status and reason: {exception_status} {exception_reason}")
 
         waiting.wait(
             _has_required_condition,

--- a/discovery-infra/tests/test_kube_api.py
+++ b/discovery-infra/tests/test_kube_api.py
@@ -21,6 +21,7 @@ from test_infra.utils.kubeapi_utils import get_ip_for_single_node
 from tests.base_test import BaseTest
 from tests.config import ClusterConfig, TerraformConfig
 from tests.conftest import env_variables
+from download_logs import collect_debug_info_from_cluster
 
 PROXY_PORT = 3129
 
@@ -139,10 +140,13 @@ def kube_api_test(kube_api_context, nodes, cluster_config, proxy_server=None, *,
     logger.info('waiting for agent-cluster-install to be in installing state')
     agent_cluster_install.wait_to_be_installing()
 
-    logger.info('installation started, waiting for completion')
-    agent_cluster_install.wait_to_be_installed()
-
-    logger.info('installation completed successfully')
+    try:
+        logger.info('installation started, waiting for completion')
+        agent_cluster_install.wait_to_be_installed()
+        logger.info('installation completed successfully')
+    except Exception:
+        logger.exception(f"Failure during kube-api installation flow:")
+        collect_debug_info_from_cluster(cluster_deployment, agent_cluster_install)
 
 
 def deploy_image_set(cluster_name, kube_api_context):


### PR DESCRIPTION
In case of a cluster install failure, events and logs
should be collected using Status.DebugInfo in AgentClusterInstall CRD.

* DebugInfo contains eventsURL and logsURL.
* In case of "InstallationFailed" condition, the URLs are queried
  and the responses are stored in build folder (events.json and logs.tar).