### PR TITLE
MGMT-6698 - Fix PEP8 violations on kube_helpers. Delete unused deploy_default_cluster_deployment

### DIFF
--- a/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/__init__.py
@@ -22,7 +22,7 @@ approved, installation will be started automatically.
 """
 
 from .cluster_image_set import ClusterImageSet, ClusterImageSetReference
-from .cluster_deployment import deploy_default_cluster_deployment, ClusterDeployment
+from .cluster_deployment import ClusterDeployment
 from .agent import Agent
 from .nmstate_config import NMStateConfig
 from .secret import deploy_default_secret, Secret
@@ -47,7 +47,6 @@ __all__ = (
     "InfraEnv",
     "NMStateConfig",
     "UnexpectedStateError",
-    "deploy_default_cluster_deployment",
     "deploy_default_secret",
     "deploy_default_infraenv",
     "create_kube_api_client",

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/common.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/common.py
@@ -57,12 +57,12 @@ class ObjectReference(IDict):
     """
 
     def __init__(
-            self,
-            name: str,
-            namespace: str,
-            kind: Optional[str] = None,
-            group: Optional[str] = None,
-            version: Optional[str] = None,
+        self,
+        name: str,
+        namespace: str,
+        kind: Optional[str] = None,
+        group: Optional[str] = None,
+        version: Optional[str] = None,
     ):
         self.name = name
         self.namespace = namespace
@@ -71,13 +71,15 @@ class ObjectReference(IDict):
         self.version = version
 
     def __eq__(self, other: "ObjectReference") -> bool:
-        return all((
-            other.name == self.name,
-            other.namespace == self.namespace,
-            other.kind == self.kind,
-            other.group == self.group,
-            other.version == self.version,
-        ))
+        return all(
+            (
+                other.name == self.name,
+                other.namespace == self.namespace,
+                other.kind == self.kind,
+                other.group == self.group,
+                other.version == self.version,
+            )
+        )
 
     def as_dict(self) -> dict:
         dct = {"name": self.name, "namespace": self.namespace}
@@ -91,6 +93,7 @@ class ObjectReference(IDict):
 
 
 def create_kube_api_client(kubeconfig_path: Optional[str] = None) -> ApiClient:
-    warnings.warn("create_kube_api_client is deprecated. Use ClientFactory.create_kube_api_client instead.",
-                  DeprecationWarning)
+    warnings.warn(
+        "create_kube_api_client is deprecated. Use ClientFactory.create_kube_api_client instead.", DeprecationWarning
+    )
     return ClientFactory.create_kube_api_client(kubeconfig_path)

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/idict.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/idict.py
@@ -2,7 +2,6 @@ from abc import ABC, abstractmethod
 
 
 class IDict(ABC):
-
     def __repr__(self):
         return str(self.as_dict())
 

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/infraenv.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/infraenv.py
@@ -13,8 +13,12 @@ from kubernetes.client import ApiClient, CustomObjectsApi
 from kubernetes.client.rest import ApiException
 
 from test_infra import consts
-from ...consts.kube_api import (CRD_API_GROUP, CRD_API_VERSION, DEFAULT_WAIT_FOR_CRD_STATUS_TIMEOUT,
-                                DEFAULT_WAIT_FOR_ISO_URL_TIMEOUT)
+from test_infra.consts.kube_api import (
+    CRD_API_GROUP,
+    CRD_API_VERSION,
+    DEFAULT_WAIT_FOR_CRD_STATUS_TIMEOUT,
+    DEFAULT_WAIT_FOR_ISO_URL_TIMEOUT,
+)
 from .base_resource import BaseCustomResource
 from .cluster_deployment import ClusterDeployment
 from .idict import IDict
@@ -308,7 +312,7 @@ class InfraEnv(BaseCustomResource):
                 kube_api_client=kube_api_client,
                 name=cluster_deployment.ref.name,
                 namespace=self._reference.namespace,
-                pull_secret=pull_secret
+                pull_secret=pull_secret,
             )
         self.create(
             cluster_deployment=cluster_deployment,
@@ -333,8 +337,9 @@ def deploy_default_infraenv(
     ignition_config_override: Optional[str] = None,
     **kwargs,
 ) -> "InfraEnv":
-    warnings.warn("deploy_default_infraenv is deprecated. Use InfraEnv.deploy_default_infraenv instead.",
-                  DeprecationWarning)
+    warnings.warn(
+        "deploy_default_infraenv is deprecated. Use InfraEnv.deploy_default_infraenv instead.", DeprecationWarning
+    )
 
     return InfraEnv.deploy_default_infraenv(
         kube_api_client,
@@ -347,5 +352,5 @@ def deploy_default_infraenv(
         proxy,
         label_selector,
         ignition_config_override,
-        **kwargs
+        **kwargs,
     )


### PR DESCRIPTION
On this PR:

-  Run `black` command on `kube_helpers`
-  Run `isort` command on `kube_helpers`
-  Removed unused function on `cluster_deployment` - `deploy_default_cluster_deployment`
-  Fix return value bug on `agent_cluster_install` and `cluster_deployment`