### PR TITLE
NO-ISSUE: Bump minikube from 1.18.1 to 1.20.0

### DIFF
--- a/scripts/install_minikube.sh
+++ b/scripts/install_minikube.sh
@@ -7,7 +7,7 @@ function install_minikube() {
         return
     fi
 
-    minikube_version=v1.18.1
+    minikube_version=v1.20.0
     minikube_path=$(command -v minikube)
     if ! [ -x "$minikube_path" ]; then 
         echo "Installing minikube..."


### PR DESCRIPTION
This PR upgrades the minikube version to install if none exists from 1.18.1 to 1.20.0.

@YuviGold can you take a look?

Thanks!