### PR TITLE
Add localhost nameserver on set_dns

### DIFF
--- a/scripts/assisted_deployment.sh
+++ b/scripts/assisted_deployment.sh
@@ -23,11 +23,17 @@ function set_dns() {
     if ! [ -f "${FILE}" ]; then
         echo -e "[main]\ndns=dnsmasq" | sudo tee $FILE
     fi
+
     sudo truncate -s0 /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
     echo "server=/api.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}/${NAMESERVER_IP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
     echo "server=/.apps.${CLUSTER_NAME}-${NAMESPACE}.${BASE_DOMAIN}/${NAMESERVER_IP}" | sudo tee -a /etc/NetworkManager/dnsmasq.d/openshift-${CLUSTER_NAME}.conf
 
     sudo systemctl reload NetworkManager
+
+    LOCALHOST_IP="127.0.0.1"
+    if ! grep -q "${LOCALHOST_IP}" /etc/resolv.conf; then
+        sed -i "0,/nameserver/s/nameserver/nameserver ${LOCALHOST_IP}\nnameserver/" /etc/resolv.conf
+    fi
 
     echo "Finished setting dns"
 }


### PR DESCRIPTION
Dnsmasq would only be requested to resolve in case localhost can be
found under /etc/resolv.conf. For that - the localhost ip(127.0.0.1) is
added at the top of the nameservers on /etc/resolv.conf after
NetworkManager was restarted.

/cc @tsorya  @yevgeny-shnaidman 