### PR TITLE
[WIP] MGMT-6417- Deprecate deploy_nodes Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -322,19 +322,16 @@ install_cluster:
 #########
 
 _deploy_nodes:
-	discovery-infra/start_discovery.py -i $(ISO) -n $(NUM_MASTERS) -p $(STORAGE_POOL_PATH) -k '$(SSH_PUB_KEY)' -md $(MASTER_DISK) -wd $(WORKER_DISK) -mm $(MASTER_MEMORY) -wm $(WORKER_MEMORY) -nw $(NUM_WORKERS) -ps '$(PULL_SECRET)' -bd $(BASE_DOMAIN) -cN $(CLUSTER_NAME) -vN $(NETWORK_CIDR) -nM $(NETWORK_MTU) -iU $(REMOTE_SERVICE_URL) -id $(CLUSTER_ID) -mD $(BASE_DNS_DOMAINS) -ns $(NAMESPACE) -pX $(HTTP_PROXY_URL) -sX $(HTTPS_PROXY_URL) -nX $(NO_PROXY_VALUES) --service-name $(SERVICE_NAME) --vip-dhcp-allocation $(VIP_DHCP_ALLOCATION) --ns-index $(NAMESPACE_INDEX) --deploy-target $(DEPLOY_TARGET) $(DAY1_PARAMS) $(OC_PARAMS) $(KEEP_ISO_FLAG) $(ADDITIONAL_PARAMS) $(DAY2_PARAMS) -ndw $(NUM_DAY2_WORKERS) --ipv4 $(IPv4) --ipv6 $(IPv6) --platform $(PLATFORM) --proxy $(PROXY) --iso-image-type $(ISO_IMAGE_TYPE) --hyperthreading $(HYPERTHREADING) --kube-api $(KUBE_API)
+	python3 ${DEBUG_FLAGS} discovery-infra/targets/deploy_nodes.py $(ADDITIONAL_PARAMS)
 
 deploy_nodes_with_install: start_load_balancer
-	bash scripts/utils.sh local_setup_before_deployment $(PLATFORM) $(NAMESPACE) $(OC_FLAG)
-	skipper make $(SKIPPER_PARAMS) _deploy_nodes NAMESPACE_INDEX=$(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE) $(OC_FLAG)) NAMESPACE=$(NAMESPACE) ADDITIONAL_PARAMS="'-in ${ADDITIONAL_PARAMS}'" $(SKIPPER_PARAMS) DAY1_PARAMS=--day1-cluster
-	$(MAKE) set_dns
+	skipper make $(SKIPPER_PARAMS) _deploy_nodes ADDITIONAL_PARAMS="-i"
 
 deploy_static_network_config_nodes_with_install:
 	make deploy_nodes_with_install ADDITIONAL_PARAMS="'--with-static-network-config'"
 
 deploy_nodes: start_load_balancer
-	bash scripts/utils.sh local_setup_before_deployment $(PLATFORM) $(NAMESPACE) $(OC_FLAG)
-	skipper make $(SKIPPER_PARAMS) _deploy_nodes NAMESPACE_INDEX=$(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE) $(OC_FLAG)) NAMESPACE=$(NAMESPACE) ADDITIONAL_PARAMS=$(ADDITIONAL_PARAMS) DAY1_PARAMS=--day1-cluster
+	skipper make $(SKIPPER_PARAMS) _deploy_nodes
 
 deploy_static_network_config_nodes:
 	make deploy_nodes ADDITIONAL_PARAMS="'--with-static-network-config'"

--- a/discovery-infra/targets/deploy_nodes.py
+++ b/discovery-infra/targets/deploy_nodes.py
@@ -1,0 +1,41 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+
+import argparse
+
+from targets.target import Target
+from test_infra.controllers.nat_controller import NatController
+from test_infra.helper_classes.cluster import Cluster
+from test_infra.helper_classes.nodes import Nodes
+from test_infra.factory import cluster_factory, nodes_factory
+
+
+class DeployNodes(Target):
+
+    def __init__(self):
+        super().__init__()
+        nat_interfaces = (self._terraform_config.net_asset.libvirt_network_if,
+                          self._terraform_config.net_asset.libvirt_secondary_network_if)
+        self._nat = NatController(nat_interfaces)
+        self._nodes: Nodes = nodes_factory(self._terraform_config, self._nat)
+        self._cluster: Cluster = cluster_factory(self._nodes, self._api_client, self._cluster_config)
+
+    def run(self):
+        self._cluster.prepare_for_installation()
+
+
+class DeployNodesWithInstall(DeployNodes):
+    def run(self):
+        super().run()
+        self._cluster.start_install_and_wait_for_installed()
+
+
+if __name__ == '__main__':
+    parser = argparse.ArgumentParser(description="Deploy nodes")
+    parser.add_argument("-i", "--install", help="Install flag", type=bool, nargs='?', default=False, const=True)
+
+    args = parser.parse_args()
+    if args.install:
+        DeployNodesWithInstall().run()
+    else:
+        DeployNodes().run()

--- a/discovery-infra/targets/target.py
+++ b/discovery-infra/targets/target.py
@@ -1,0 +1,30 @@
+from abc import ABC, abstractmethod
+
+from test_infra import utils
+from test_infra.assisted_service_api import InventoryClient, ClientFactory
+from test_infra.tools.assets import LibvirtNetworkAssets
+from test_infra.utils.global_variables import GlobalVariables
+from tests.config import TerraformConfig, ClusterConfig
+
+
+def get_api_client(namespace: str, remote_service_url: str, offline_token=None, **kwargs) -> InventoryClient:
+    if not remote_service_url:
+        remote_service_url = utils.get_local_assisted_service_url(
+            namespace, "assisted-service", utils.get_env("DEPLOY_TARGET"))
+
+    return ClientFactory.create_client(remote_service_url, offline_token, **kwargs)
+
+
+class Target(ABC):
+    def __init__(self):
+        net_asset = LibvirtNetworkAssets()
+        self._global_variables: GlobalVariables = GlobalVariables()
+        self._cluster_config: ClusterConfig = ClusterConfig()
+        self._terraform_config: TerraformConfig = TerraformConfig(net_asset=net_asset.get())
+        self._api_client: InventoryClient = get_api_client(self._global_variables.namespace,
+                                                           self._global_variables.remote_service_url,
+                                                           self._global_variables.offline_token)
+
+    @abstractmethod
+    def run(self):
+        pass

--- a/discovery-infra/test_infra/__init__.py
+++ b/discovery-infra/test_infra/__init__.py
@@ -6,6 +6,8 @@ __displayed_warnings = list()
 
 
 def warn_deprecate():
+    if "targets" in sys.argv[0]:
+        return
     if sys.argv[0] not in __displayed_warnings:
         if sys.argv[0].endswith("__main__.py"):
             return 

--- a/discovery-infra/test_infra/controllers/nat_controller.py
+++ b/discovery-infra/test_infra/controllers/nat_controller.py
@@ -12,9 +12,9 @@ class NatController:
     The logic behind it is to mark packets that are coming from libvirt bridges (i.e input_interfaces), and
     reference this mark in order to perform NAT operation on these packets.
     """
-    def __init__(self, input_interfaces: Union[List, Tuple], ns_index: Union[str, int]):
+    def __init__(self, input_interfaces: Union[List, Tuple], ns_index: Union[str, int, None] = None):
         self._input_interfaces = input_interfaces
-        self._ns_index = ns_index
+        self._ns_index = ns_index if ns_index is not None else self.get_namespace_index(input_interfaces[0])
         self._mark = self._build_mark()
 
     def add_nat_rules(self) -> None:

--- a/discovery-infra/test_infra/factory.py
+++ b/discovery-infra/test_infra/factory.py
@@ -1,0 +1,46 @@
+from netaddr import IPNetwork
+
+from test_infra import utils, consts
+from test_infra.assisted_service_api import InventoryClient
+from test_infra.controllers.nat_controller import NatController
+from test_infra.controllers.node_controllers import TerraformController
+from test_infra.controllers.proxy_controller.proxy_controller import ProxyController
+from test_infra.helper_classes.cluster import Cluster
+from test_infra.helper_classes.nodes import Nodes
+from test_infra.tools.assets import LibvirtNetworkAssets
+from tests.config import TerraformConfig, ClusterConfig
+
+
+def nodes_factory(config: TerraformConfig, nat: NatController):
+    net_asset = LibvirtNetworkAssets()
+    config.net_asset = net_asset.get()
+    controller = TerraformController(config)
+    nodes = Nodes(controller, config.private_ssh_key_path)
+
+    nodes.prepare_nodes()
+    nat.add_nat_rules()
+    return nodes
+
+
+def proxy_server_factory(cluster: Cluster, cluster_config, proxy_name: str = None):
+    if not proxy_name:
+        proxy_name = "squid-" + cluster_config.cluster_name.suffix
+
+    port = utils.scan_for_free_port(consts.DEFAULT_PROXY_SERVER_PORT)
+    proxy_server = ProxyController(name=proxy_name, port=port, dir=proxy_name)
+
+    host_ip = str(IPNetwork(cluster.nodes.controller.get_machine_cidr()).ip + 1)
+    proxy_url = f"http://[{host_ip}]:{consts.DEFAULT_PROXY_SERVER_PORT}"
+    no_proxy = ",".join([cluster.nodes.controller.get_machine_cidr(), cluster_config.service_network_cidr,
+                         cluster_config.cluster_network_cidr,
+                         f".{str(cluster_config.cluster_name)}.redhat.com"])
+    cluster.set_proxy_values(http_proxy=proxy_url, https_proxy=proxy_url, no_proxy=no_proxy)
+    return proxy_server
+
+
+def cluster_factory(nodes: Nodes, api_client: InventoryClient, cluster_config: ClusterConfig):
+    cluster = Cluster(api_client=api_client, config=cluster_config, nodes=nodes)
+    if cluster_config.is_ipv6:
+        proxy_server_factory(cluster, cluster_config)
+
+    return cluster


### PR DESCRIPTION
- This PR is a POC for replacing the old Makefile targets with a new logic.
- Basically, the targets will no longer use the scripts under `discovery-infra` and for each targets group there will be module/class.
- Some of the Makefile logic will be moved to a readable python code instead of Makefile targets.
- Using classes rather than modules allow us to use inheritance for creating new targets.
- As part of this example, factory module is created, the goal is to create a base shared code for the targets and the tests(`BaseTest`) packages
- In this implementation, each target module is inherits from `Target` class that define all basic arguments and parameters that will probably be used an every other target.
- Here, 2 targets were created: `DeployNodes` and `DeployNodesWithInstall`, all env vars are handled within the `Target` class and part of the shared code created in previous tasks (Therefore, there is no need for an infinite number of variables).

Note that the code in factory is partially duplicated with base test code and will be merged to single implementation

/cc @tsorya @osherdp @YuviGold 