### PR TITLE
NO-ISSUE - Fix e2e-metal-single-node-live-iso test fails on cluster_name type mismatch

### DIFF
--- a/discovery-infra/bootstrap_in_place.py
+++ b/discovery-infra/bootstrap_in_place.py
@@ -13,6 +13,7 @@ from test_infra.controllers.node_controllers.terraform_controller import Terrafo
 
 from download_logs import download_must_gather, gather_sosreport_data
 from oc_utils import get_operators_status
+from test_infra.utils.cluster_name import ClusterName
 from tests.config import TerraformConfig
 
 warn_deprecate()
@@ -125,7 +126,7 @@ def str_presenter(dumper, data):
 def create_controller(net_asset):
     return TerraformController(
         TerraformConfig(
-            cluster_name="test-infra-cluster",
+            cluster_name=ClusterName(prefix="test-infra-cluster", suffix=""),
             masters_count=1,
             workers_count=0,
             master_memory=45 * 1024,  # in megabytes

--- a/discovery-infra/test_infra/helper_classes/config/nodes_config.py
+++ b/discovery-infra/test_infra/helper_classes/config/nodes_config.py
@@ -50,3 +50,8 @@ class BaseTerraformConfig(_BaseConfig, ABC):
     tf_folder: str = None
     iso_download_path: str = None
     bootstrap_in_place: bool = None
+
+    def __post_init__(self):
+        super().__post_init__()
+        if isinstance(self.cluster_name, str):
+            self.cluster_name = ClusterName(prefix=self.cluster_name, suffix="")

--- a/discovery-infra/test_infra/utils/cluster_name.py
+++ b/discovery-infra/test_infra/utils/cluster_name.py
@@ -18,7 +18,7 @@ class ClusterName:
         return self.get()
 
     def get(self):
-        name = self.suffix
-        if self.prefix == consts.CLUSTER_PREFIX:
+        name = self.prefix
+        if self.prefix == consts.CLUSTER_PREFIX and self.suffix:
             name = self.prefix + "-" + self.suffix
         return name


### PR DESCRIPTION
Forcing cluster name to be of `ClusterName` type instead of str