### PR TITLE
MGMT-7060 - Move cluster name to cluster config scope

### DIFF
--- a/discovery-infra/bootstrap_in_place.py
+++ b/discovery-infra/bootstrap_in_place.py
@@ -14,7 +14,7 @@ from test_infra.controllers.node_controllers.terraform_controller import Terrafo
 from download_logs import download_must_gather, gather_sosreport_data
 from oc_utils import get_operators_status
 from test_infra.utils.cluster_name import ClusterName
-from tests.config import TerraformConfig
+from tests.config import TerraformConfig, ClusterConfig
 
 warn_deprecate()
 
@@ -126,16 +126,15 @@ def str_presenter(dumper, data):
 def create_controller(net_asset):
     return TerraformController(
         TerraformConfig(
-            cluster_name=ClusterName(prefix="test-infra-cluster", suffix=""),
             masters_count=1,
             workers_count=0,
             master_memory=45 * 1024,  # in megabytes
             master_vcpu=16,
             net_asset=net_asset,
-            iso_download_path="<TBD>",  # will be set later on
             bootstrap_in_place=True,
             single_node_ip=net_asset.machine_cidr.replace("0/24", "10"),
-        )
+        ),
+        cluster_config=ClusterConfig(cluster_name=ClusterName(prefix="test-infra-cluster", suffix=""))
     )
 
 

--- a/discovery-infra/test_infra/helper_classes/config/base_config.py
+++ b/discovery-infra/test_infra/helper_classes/config/base_config.py
@@ -20,5 +20,9 @@ class _BaseConfig(ABC):
     def get_default(key, default=None) -> Any:
         pass
 
+    @abstractmethod
+    def get_copy(self):
+        pass
+
     def get_all(self) -> dict:
         return asdict(self)

--- a/discovery-infra/test_infra/helper_classes/config/nodes_config.py
+++ b/discovery-infra/test_infra/helper_classes/config/nodes_config.py
@@ -7,8 +7,6 @@ from munch import Munch
 
 from .base_config import _BaseConfig
 
-from test_infra.utils.cluster_name import ClusterName
-
 
 @dataclass
 class BaseTerraformConfig(_BaseConfig, ABC):
@@ -40,17 +38,13 @@ class BaseTerraformConfig(_BaseConfig, ABC):
     libvirt_secondary_worker_ips: List[str] = None
 
     private_ssh_key_path: Path = None
-    cluster_name: ClusterName = None
     network_name: str = None
     net_asset: Munch = None
     platform: str = None
     base_dns_domain: str = None  # base_domain
     is_ipv6: bool = None  # ipv6
     tf_folder: str = None
-    iso_download_path: str = None
     bootstrap_in_place: bool = None
 
     def __post_init__(self):
         super().__post_init__()
-        if isinstance(self.cluster_name, str):
-            self.cluster_name = ClusterName(prefix=self.cluster_name, suffix="")

--- a/discovery-infra/test_infra/utils/cluster_name.py
+++ b/discovery-infra/test_infra/utils/cluster_name.py
@@ -1,15 +1,17 @@
 import uuid
 
-from dataclasses import dataclass
-
 from test_infra import consts
 from test_infra.utils import get_env
 
 
-@dataclass
+def get_cluster_name_suffix(length: str = consts.SUFFIX_LENGTH):
+    return str(uuid.uuid4())[: length]
+
+
 class ClusterName:
-    suffix: str = str(uuid.uuid4())[: consts.SUFFIX_LENGTH]
-    prefix: str = get_env("CLUSTER_NAME", f"{consts.CLUSTER_PREFIX}")
+    def __init__(self, prefix: str = None, suffix: str = None):
+        self.prefix = prefix if prefix is not None else get_env("CLUSTER_NAME", f"{consts.CLUSTER_PREFIX}")
+        self.suffix = suffix if suffix is not None else get_cluster_name_suffix()
 
     def __str__(self):
         return self.get()

--- a/discovery-infra/test_infra/utils/global_variables/env_variables_utils.py
+++ b/discovery-infra/test_infra/utils/global_variables/env_variables_utils.py
@@ -8,7 +8,6 @@ from dataclasses import dataclass, field
 from test_infra import consts
 from test_infra.consts import resources, env_defaults
 from test_infra.utils import operators_utils, get_env, get_openshift_version, get_kubeconfig_path
-from test_infra.utils.cluster_name import ClusterName
 
 
 @dataclass(frozen=True)
@@ -32,9 +31,7 @@ class _EnvVariablesUtils(ABC):
     master_disk_count: int = int(get_env("MASTER_DISK_COUNT", resources.DEFAULT_DISK_COUNT))
     worker_disk_count: int = int(get_env("WORKER_DISK_COUNT", resources.DEFAULT_DISK_COUNT))
     storage_pool_path: str = get_env("STORAGE_POOL_PATH", env_defaults.DEFAULT_STORAGE_POOL_PATH)
-    cluster_name: ClusterName = ClusterName()
     private_ssh_key_path: Path = Path(get_env("PRIVATE_KEY_PATH", env_defaults.DEFAULT_SSH_PRIVATE_KEY_PATH))
-    kubeconfig_path: str = get_kubeconfig_path(cluster_name.get())
     installer_kubeconfig_path: str = get_env("INSTALLER_KUBECONFIG", env_defaults.DEFAULT_INSTALLER_KUBECONFIG)
     log_folder: str = get_env("LOG_FOLDER", env_defaults.DEFAULT_LOG_FOLDER)
     service_network_cidr: str = get_env("SERVICE_CIDR", env_defaults.DEFAULT_SERVICE_CIDR)
@@ -66,15 +63,6 @@ class _EnvVariablesUtils(ABC):
 
     def __post_init__(self):
         self._set("olm_operators", operators_utils.parse_olm_operators_from_env())
-        if self.iso_download_path is None:
-            self._set(
-                "iso_download_path",
-                str(
-                    Path(env_defaults.DEFAULT_IMAGE_FOLDER).joinpath(
-                        f"{self.cluster_name}-{self.cluster_name.suffix}" f"-{env_defaults.DEFAULT_IMAGE_FILENAME}"
-                    )
-                ).strip(),
-            )
 
     def _set(self, key: str, value: Any):
         if not hasattr(self, key):

--- a/discovery-infra/tests/config/__init__.py
+++ b/discovery-infra/tests/config/__init__.py
@@ -1,9 +1,10 @@
-from .global_configs import ClusterConfig, TerraformConfig, global_variables
+from .global_configs import ClusterConfig, TerraformConfig, global_variables, Day2ClusterConfig
 from .env_config import EnvConfig
 
 __all__ = [
     "ClusterConfig",
     "EnvConfig",
     "TerraformConfig",
+    "Day2ClusterConfig",
     "global_variables"
 ]

--- a/discovery-infra/tests/config/global_configs.py
+++ b/discovery-infra/tests/config/global_configs.py
@@ -1,7 +1,13 @@
-from typing import Any
+from pathlib import Path
+from typing import Any, ClassVar
 
+from assisted_service_client import models
 from dataclasses import dataclass
 
+from test_infra.assisted_service_api import InventoryClient, ClientFactory
+from test_infra.consts import env_defaults
+from test_infra.utils import get_kubeconfig_path, utils
+from test_infra.utils.cluster_name import ClusterName
 from test_infra.utils.global_variables import GlobalVariables
 from test_infra.helper_classes.config import BaseClusterConfig, BaseTerraformConfig
 
@@ -16,10 +22,64 @@ class ClusterConfig(BaseClusterConfig):
     def get_default(key, default=None) -> Any:
         return getattr(global_variables, key)
 
+    def get_copy(self):
+        return ClusterConfig(**self.get_all())
+
+    @staticmethod
+    def _get_iso_download_path(cluster_name: str):
+        return str(
+            Path(env_defaults.DEFAULT_IMAGE_FOLDER).joinpath(
+                f"{cluster_name}-{env_defaults.DEFAULT_IMAGE_FILENAME}"
+            )
+        ).strip()
+
+    def __post_init__(self):
+        super().__post_init__()
+        if self.cluster_name is None or isinstance(self.cluster_name, str):
+            self.cluster_name = ClusterName()
+        if self.kubeconfig_path is None:
+            self.kubeconfig_path = get_kubeconfig_path(self.cluster_name.get())
+        if self.iso_download_path is None:
+            self.iso_download_path = self._get_iso_download_path(self.cluster_name.get())
+
+
+def get_api_client(offline_token=None, **kwargs) -> InventoryClient:
+    url = global_variables.remote_service_url
+    offline_token = offline_token or global_variables.offline_token
+
+    if not url:
+        url = utils.get_local_assisted_service_url(
+            global_variables.namespace, 'assisted-service', utils.get_env('DEPLOY_TARGET'))
+
+    return ClientFactory.create_client(url, offline_token, **kwargs)
+
+
+@dataclass
+class Day2ClusterConfig(ClusterConfig):
+    _details: ClassVar[models.cluster.Cluster] = None
+    day1_cluster_name: ClusterName = None
+
+    def get_copy(self):
+        return Day2ClusterConfig(**self.get_all())
+
+    def __post_init__(self):
+        super(BaseClusterConfig, self).__post_init__()
+        api_client = get_api_client()
+        self._details = api_client.cluster_get(self.cluster_id)
+        if self.day1_cluster_name is None:
+            raise ValueError("Invalid day1_cluster_name, got None")
+
+        self.cluster_name = ClusterName(prefix=self._details.name)
+        if self.iso_download_path is None:
+            self.iso_download_path = self._get_iso_download_path(self.day1_cluster_name.get())
+
 
 @dataclass
 class TerraformConfig(BaseTerraformConfig):
     """ A Nodes configuration with defaults that obtained from EnvConfig """
+
+    def get_copy(self):
+        return TerraformConfig(**self.get_all())
 
     @staticmethod
     def get_default(key, default=None) -> Any:


### PR DESCRIPTION
- Move cluster name to cluster config scope
- Create configs fixture for getting single instance of configs per test.
-  Remove some of duplicate variables from ClusterConfig.

/cc @YuviGold @lalon4 

/test system-test-ipv6 system-test-olm system-test-operator e2e-metal-assisted-none e2e-metal-single-node-live-iso e2e-metal-assisted-single-node

QE PR: https://gitlab.cee.redhat.com/ocp-edge-qe/kni-assisted-installer-auto/-/merge_requests/369