### PR TITLE
NO-ISSUE Add grace of 1 sec for ES doc to flush and add host the event metadata

### DIFF
--- a/discovery-infra/log_scrap.py
+++ b/discovery-infra/log_scrap.py
@@ -64,6 +64,9 @@ class ScrapeEvents:
             for i, cluster in enumerate(clusters):
                 cluster_id = cluster["id"]
                 log.info(f"{i}/{cluster_count}: Starting process of cluster {cluster_id}")
+                if "hosts" not in cluster or len(cluster["hosts"]) == 0:
+                    cluster["hosts"] = self.client.get_cluster_hosts(cluster_id=cluster["id"])
+
                 self.process_cluster(cluster)
 
     def get_metadata_json(self, cluster: dict):

--- a/discovery-infra/log_scrap.py
+++ b/discovery-infra/log_scrap.py
@@ -121,6 +121,7 @@ class ScrapeEvents:
             return False
 
     def get_cluster_event_count_on_es_db(self, cluster_id):
+        time.sleep(1)
         return self.es.search(index=self.index,
                               body={"query": {"match_phrase": {"cluster.id": cluster_id}}})["hits"]["total"]["value"]
 


### PR DESCRIPTION
* due to race option when checking DB available events vs events to log waiting for all events to flush on the es db 
this will prevent getting a mismatch between the two numbers and save logging time in that case

* add host information to metadata if missing