### PR TITLE
NO-ISSUE Log download continuously to prevent missing fails

### DIFF
--- a/Jenkinsfile.download_logs
+++ b/Jenkinsfile.download_logs
@@ -5,7 +5,7 @@ pipeline {
         string(name: 'REMOTE_SERVICE_URL', defaultValue: 'https://api.openshift.com', description: 'Service URL')
     }
 
-    triggers { cron('H/30 * * * *') }
+    triggers { cron('*/5 * * * *') }
 
     environment {
         SKIPPER_PARAMS = " "


### PR DESCRIPTION
since the log collection is properly run and scans for failed status we miss clusters that failed and moved from this state. 
if we increase the sampling we will not solve this 100% but we will miss fewer clusters since the sampling will give a closer display of the real state of the cluster and will give them less time to change 