### PR TITLE
NO-ISSUE - Fix invalid openshift_version on test_install

### DIFF
--- a/discovery-infra/test_infra/utils/global_variables/global_variables.py
+++ b/discovery-infra/test_infra/utils/global_variables/global_variables.py
@@ -27,6 +27,7 @@ _triggers = frozendict({
         "service_network_cidr": consts.DEFAULT_IPV6_SERVICE_CIDR,
         "cluster_network_cidr": consts.DEFAULT_IPV6_CLUSTER_CIDR,
         "cluster_network_host_prefix": consts.DEFAULT_IPV6_HOST_PREFIX,
+        "openshift_version": consts.OpenshiftVersion.VERSION_4_8.value,
         "vip_dhcp_allocation": False
     }
 })

--- a/discovery-infra/test_infra/utils/utils.py
+++ b/discovery-infra/test_infra/utils/utils.py
@@ -35,7 +35,6 @@ from logger import log
 from retry import retry
 
 import test_infra.consts as consts
-from test_infra.consts import env_defaults
 from test_infra.utils import logs_utils
 
 conn = libvirt.open("qemu:///system")
@@ -709,7 +708,7 @@ def get_kubeconfig_path(cluster_name: str) -> str:
     return kubeconfig_path
 
 
-def get_openshift_version(default=consts.DEFAULT_OPENSHIFT_VERSION):
+def get_openshift_version(default=consts.DEFAULT_OPENSHIFT_VERSION, global_vars=None):
     release_image = os.getenv('OPENSHIFT_INSTALL_RELEASE_IMAGE')
 
     if release_image:
@@ -720,7 +719,7 @@ def get_openshift_version(default=consts.DEFAULT_OPENSHIFT_VERSION):
                 shell=True)
         return stdout
 
-    return get_env('OPENSHIFT_VERSION', default)
+    return global_vars.openshift_version if global_vars else get_env('OPENSHIFT_VERSION', default)
 
 
 def get_openshift_release_image(ocp_version=consts.DEFAULT_OPENSHIFT_VERSION):

--- a/discovery-infra/tests/conftest.py
+++ b/discovery-infra/tests/conftest.py
@@ -26,7 +26,7 @@ def get_api_client(offline_token=None, **kwargs) -> InventoryClient:
 
 def get_available_openshift_versions() -> List[str]:
     available_versions = list(get_api_client().get_openshift_versions().keys())
-    specific_version = utils.get_openshift_version(default=None)
+    specific_version = utils.get_openshift_version(default=None, global_vars=global_variables)
     if specific_version:
         if specific_version in available_versions:
             return [specific_version]


### PR DESCRIPTION
if `make test OPENSHIFT_VERSION=4.7 NUM_MASTERS=1` the triggers mechanism supposed to override the openshift version and set it to 4.8.
This PR is fixing that conflict.
/cc @YuviGold 