### PR TITLE
MGMT-7153 support multi-platform test

### DIFF
--- a/discovery-infra/bootstrap_in_place.py
+++ b/discovery-infra/bootstrap_in_place.py
@@ -166,7 +166,7 @@ def log_collection(vm_ip):
 
     try:
         logging.info("Gathering sosreport data from host...")
-        gather_sosreport_data(output_dir=IBIP_DIR, private_ssh_key_path=SSH_KEY)
+        gather_sosreport_data(output_dir=IBIP_DIR)
     except Exception:
         logging.exception("sosreport gathering failed!")
 

--- a/discovery-infra/download_logs.py
+++ b/discovery-infra/download_logs.py
@@ -29,6 +29,7 @@ from test_infra.utils import (are_host_progress_in_stage, config_etc_hosts,
                               recreate_folder, run_command, verify_logs_uploaded, fetch_url)
 
 from logger import log, suppressAndLog
+from tests.config import TerraformConfig, ClusterConfig
 
 private_ssh_key_path_default = os.path.join(os.getcwd(), str(env_defaults.DEFAULT_SSH_PRIVATE_KEY_PATH))
 
@@ -243,11 +244,11 @@ def download_must_gather(kubeconfig: str, dest_dir: str):
         log.warning(f"Failed to run must gather: {ex}")
 
 
-def gather_sosreport_data(output_dir: str, private_ssh_key_path: str = private_ssh_key_path_default):
+def gather_sosreport_data(output_dir: str):
     sosreport_output = os.path.join(output_dir, "sosreport")
     recreate_folder(sosreport_output)
 
-    controller = LibvirtController(private_ssh_key_path=private_ssh_key_path)
+    controller = LibvirtController(config=TerraformConfig(), cluster_config=ClusterConfig())
     run_concurrently(
         jobs=[(gather_sosreport_from_node, node, sosreport_output)
               for node in controller.list_nodes()],

--- a/discovery-infra/test_infra/consts/consts.py
+++ b/discovery-infra/test_infra/consts/consts.py
@@ -9,7 +9,8 @@ class OpenshiftVersion(Enum):
     VERSION_4_8 = "4.8"
 
 
-TF_FOLDER = "build/terraform"
+WORKING_DIR = "build"
+TF_FOLDER = f"{WORKING_DIR}/terraform"
 TFVARS_JSON_NAME = "terraform.tfvars.json"
 IMAGE_FOLDER = "/tmp/test_images"
 TF_MAIN_JSON_NAME = "main.tf"
@@ -33,8 +34,9 @@ READY_TIMEOUT = 15 * MINUTE
 DISCONNECTED_TIMEOUT = 10 * MINUTE
 PENDING_USER_ACTION_TIMEOUT = 30 * MINUTE
 ERROR_TIMEOUT = 10 * MINUTE
-TF_TEMPLATE_BARE_METAL_FLOW = "terraform_files/baremetal"
-TF_TEMPLATE_NONE_PLATFORM_FLOW = "terraform_files/none"
+TF_TEMPLATES_ROOT = "terraform_files"
+TF_TEMPLATE_BARE_METAL_FLOW = f"{TF_TEMPLATES_ROOT}/baremetal"
+TF_TEMPLATE_NONE_PLATFORM_FLOW = f"{TF_TEMPLATES_ROOT}/none"
 TF_NETWORK_POOL_PATH = "/tmp/tf_network_pool.json"
 NUMBER_OF_MASTERS = 3
 TEST_INFRA = "test-infra"
@@ -120,10 +122,12 @@ class HostsProgressStages:
     CONFIGURING = "Configuring"
     DONE = "Done"
 
+
 class AgentStatus:
     VALIDATED = "Validated"
     INSTALLED = "Installed"
     REQUIREMENTS_MET = "RequirementsMet"
+
 
 all_host_stages = [HostsProgressStages.START_INSTALLATION, HostsProgressStages.INSTALLING,
                    HostsProgressStages.WRITE_IMAGE_TO_DISK, HostsProgressStages.WAIT_FOR_CONTROL_PLANE,
@@ -179,6 +183,7 @@ class Events:
 class Platforms:
     BARE_METAL = 'baremetal'
     NONE = 'none'
+    VSPHERE = 'vsphere'
 
 
 class HighAvailabilityMode:

--- a/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -13,6 +13,8 @@ from xml.dom import minidom
 import libvirt
 import waiting
 
+from test_infra.helper_classes.config import BaseClusterConfig
+from test_infra.helper_classes.config.controller_config import BaseNodeConfig
 from test_infra import consts, utils
 from test_infra.controllers.node_controllers.disk import Disk, DiskSourceType
 from test_infra.controllers.node_controllers.node import Node
@@ -22,9 +24,10 @@ from test_infra.controllers.node_controllers.node_controller import NodeControll
 class LibvirtController(NodeController, ABC):
     TEST_DISKS_PREFIX = "ua-TestInfraDisk"
 
-    def __init__(self, private_ssh_key_path: Path):
+    def __init__(self, config: BaseNodeConfig, cluster_config: BaseClusterConfig):
+        super().__init__(config, cluster_config)
         self.libvirt_connection: libvirt.virConnect = libvirt.open('qemu:///system')
-        self.private_ssh_key_path: Path = private_ssh_key_path
+        self.private_ssh_key_path: Path = config.private_ssh_key_path
         self._setup_timestamp: str = utils.run_command("date +\"%Y-%m-%d %T\"")[0]
 
     def __del__(self):
@@ -544,4 +547,7 @@ class LibvirtController(NodeController, ABC):
         raise NotImplementedError
 
     def get_machine_cidr(self) -> str:
+        raise NotImplementedError
+
+    def set_single_node_ip(self, ip):
         raise NotImplementedError

--- a/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/node_controller.py
@@ -3,11 +3,21 @@ from typing import List, Any, Tuple, Callable
 
 import libvirt
 
+from test_infra.helper_classes.config import BaseClusterConfig
+from test_infra.helper_classes.config.controller_config import BaseNodeConfig
 from test_infra.controllers.node_controllers.disk import Disk
 from test_infra.controllers.node_controllers.node import Node
+from test_infra.utils import log
 
 
 class NodeController(ABC):
+
+    def __init__(self, config: BaseNodeConfig, cluster_config: BaseClusterConfig):
+        self._config = config
+        self._cluster_config = cluster_config
+
+    def log_configuration(self):
+        log.info(f"controller configuration={self._config}")
 
     @abstractmethod
     def list_nodes(self) -> List[Node]:
@@ -117,6 +127,10 @@ class NodeController(ABC):
         pass
 
     @abstractmethod
+    def set_single_node_ip(self, ip) -> None:
+        pass
+
+    @abstractmethod
     def get_host_id(self, node_name: str) -> str:
         pass
 
@@ -162,4 +176,7 @@ class NodeController(ABC):
 
     @abstractmethod
     def destroy_network(self, network: libvirt.virNetwork):
+        pass
+
+    def notify_iso_ready(self) -> None:
         pass

--- a/discovery-infra/test_infra/helper_classes/config/cluster_config.py
+++ b/discovery-infra/test_infra/helper_classes/config/cluster_config.py
@@ -1,5 +1,5 @@
 from abc import ABC
-from typing import List, Any
+from typing import List
 
 from dataclasses import dataclass
 

--- a/discovery-infra/test_infra/helper_classes/config/controller_config.py
+++ b/discovery-infra/test_infra/helper_classes/config/controller_config.py
@@ -1,0 +1,41 @@
+from abc import ABC
+from pathlib import Path
+from typing import Any
+
+from dataclasses import dataclass
+
+from test_infra import consts
+from test_infra.utils.global_variables import GlobalVariables
+from .base_config import _BaseConfig
+
+global_variables = GlobalVariables()
+
+
+@dataclass
+class BaseNodeConfig(_BaseConfig, ABC):
+    platform: str = None
+    is_ipv6: bool = None   # Todo - Might change during MGMT-5370
+    bootstrap_in_place: bool = None
+    private_ssh_key_path: Path = None
+    working_dir: str = consts.WORKING_DIR
+
+    master_memory: int = None
+    master_vcpu: int = None
+    masters_count: int = None
+    master_cpu_mode: str = None
+    master_disk: int = None   # disk size in MB.
+    master_disk_size_gib: str = None # disk size in GB.
+    master_disk_count: int = None   # number of disks to create
+
+    worker_memory: int = None
+    worker_vcpu: int = None
+    workers_count: int = None
+    worker_cpu_mode: str = None
+    worker_disk: int = None
+    worker_disk_count: int = None
+
+    network_mtu: int = None
+
+    @staticmethod
+    def get_default(key, default=None) -> Any:
+        return getattr(global_variables, key)

--- a/discovery-infra/test_infra/helper_classes/config/nodes_config.py
+++ b/discovery-infra/test_infra/helper_classes/config/nodes_config.py
@@ -1,33 +1,18 @@
 from abc import ABC
-from pathlib import Path
 from typing import Dict, List
 
 from dataclasses import dataclass, field
 from munch import Munch
 
-from .base_config import _BaseConfig
+from .controller_config import BaseNodeConfig
 
 
 @dataclass
-class BaseTerraformConfig(_BaseConfig, ABC):
+class BaseTerraformConfig(BaseNodeConfig, ABC):
     """
     Define all configurations variables that are needed for Nodes during it's execution
     All arguments must have default to None with type hint
     """
-    worker_memory: int = None
-    master_memory: int = None
-    worker_vcpu: int = None
-    master_vcpu: int = None
-    workers_count: int = None
-    masters_count: int = None
-    worker_cpu_mode: str = None
-    master_cpu_mode: str = None
-    network_mtu: int = None
-    worker_disk: int = None
-    master_disk: int = None
-    master_disk_count: int = None
-    worker_disk_count: int = None
-    storage_pool_path: str = None
     # running: bool = True
     single_node_ip: str = None
     dns_records: Dict[str, str] = field(default_factory=dict)
@@ -37,14 +22,10 @@ class BaseTerraformConfig(_BaseConfig, ABC):
     libvirt_worker_ips: List[str] = None
     libvirt_secondary_worker_ips: List[str] = None
 
-    private_ssh_key_path: Path = None
-    network_name: str = None
     net_asset: Munch = None
-    platform: str = None
-    base_dns_domain: str = None  # base_domain
-    is_ipv6: bool = None  # ipv6
     tf_folder: str = None
-    bootstrap_in_place: bool = None
+    network_name: str = None
+    storage_pool_path: str = None
 
     def __post_init__(self):
         super().__post_init__()

--- a/discovery-infra/test_infra/utils/global_variables/global_variables.py
+++ b/discovery-infra/test_infra/utils/global_variables/global_variables.py
@@ -24,10 +24,12 @@ _triggers = frozendict(
             "master_vcpu": resources.DEFAULT_MASTER_SNO_CPU,
         },
         ("is_ipv6", True): {
+            "is_ipv4": False,
             "service_network_cidr": consts.DEFAULT_IPV6_SERVICE_CIDR,
             "cluster_network_cidr": consts.DEFAULT_IPV6_CLUSTER_CIDR,
             "cluster_network_host_prefix": consts.DEFAULT_IPV6_HOST_PREFIX,
             "vip_dhcp_allocation": False,
+            "openshift_version": consts.OpenshiftVersion.VERSION_4_8.value
         },
     }
 )

--- a/discovery-infra/test_infra/utils/terraform_util.py
+++ b/discovery-infra/test_infra/utils/terraform_util.py
@@ -1,0 +1,26 @@
+import logging
+import os
+
+from test_infra.consts import consts
+from test_infra.utils import utils
+
+
+class TerraformControllerUtil:
+
+    @classmethod
+    def get_folder(cls, cluster_name: str, namespace=None):
+        folder_name = f'{cluster_name}__{namespace}' if namespace else f'{cluster_name}'
+        return os.path.join(consts.TF_FOLDER, folder_name)
+
+    @classmethod
+    def create_folder(cls, cluster_name: str, platform: str):
+        tf_folder = cls.get_folder(cluster_name)
+        logging.info("Creating %s as terraform folder", tf_folder)
+        utils.recreate_folder(tf_folder)
+        cls._copy_template_tree(tf_folder, platform)
+        return tf_folder
+
+    @classmethod
+    def _copy_template_tree(cls, dst, platform: str):
+        src = consts.TF_TEMPLATES_ROOT + "/" + platform
+        utils.copy_tree(src=src, dst=dst)

--- a/discovery-infra/test_infra/utils/utils.py
+++ b/discovery-infra/test_infra/utils/utils.py
@@ -35,7 +35,6 @@ from requests.models import HTTPError
 from retry import retry
 
 import test_infra.consts as consts
-from test_infra.consts import env_defaults
 from test_infra.utils import logs_utils
 
 conn = libvirt.open("qemu:///system")

--- a/discovery-infra/tests/config/__init__.py
+++ b/discovery-infra/tests/config/__init__.py
@@ -1,4 +1,4 @@
-from .global_configs import ClusterConfig, TerraformConfig, global_variables, Day2ClusterConfig
+from .global_configs import ClusterConfig, TerraformConfig, Day2ClusterConfig, global_variables
 from .env_config import EnvConfig
 
 __all__ = [

--- a/discovery-infra/tests/config/global_configs.py
+++ b/discovery-infra/tests/config/global_configs.py
@@ -11,6 +11,7 @@ from test_infra.utils.cluster_name import ClusterName
 from test_infra.utils.global_variables import GlobalVariables
 from test_infra.helper_classes.config import BaseClusterConfig, BaseTerraformConfig
 
+
 global_variables = GlobalVariables()
 
 
@@ -80,7 +81,3 @@ class TerraformConfig(BaseTerraformConfig):
 
     def get_copy(self):
         return TerraformConfig(**self.get_all())
-
-    @staticmethod
-    def get_default(key, default=None) -> Any:
-        return getattr(global_variables, key)

--- a/discovery-infra/tests/conftest.py
+++ b/discovery-infra/tests/conftest.py
@@ -26,7 +26,8 @@ def get_api_client(offline_token=None, **kwargs) -> InventoryClient:
 
 def get_available_openshift_versions() -> List[str]:
     available_versions = list(get_api_client().get_openshift_versions().keys())
-    specific_version = utils.get_openshift_version(default=None)
+    specific_version = utils.get_openshift_version(global_variables.openshift_version)
+
     if specific_version:
         if specific_version in available_versions:
             return [specific_version]

--- a/discovery-infra/tests/test_e2e_install.py
+++ b/discovery-infra/tests/test_e2e_install.py
@@ -1,25 +1,36 @@
 import time
-from typing import Tuple
+from contextlib import suppress
 
 import pytest
+from _pytest.fixtures import FixtureLookupError
 from junit_report import JunitTestSuite
+
 from test_infra.consts import OperatorStatus
 
 from tests.base_test import BaseTest
-from tests.config import ClusterConfig, TerraformConfig
+from tests.config import ClusterConfig
 from tests.conftest import get_available_openshift_versions, get_api_client
 
 
 class TestInstall(BaseTest):
 
+    @pytest.fixture
+    def cluster_configuration(self, request):
+        # Overriding the default BaseTest.cluster_configuration fixture to set the openshift version.
+        config = ClusterConfig()
+
+        with suppress(FixtureLookupError):
+            # Resolving the param value.
+            version = request.getfixturevalue("openshift_version")
+            config.openshift_version = version
+
+        return config
+
     @JunitTestSuite()
     @pytest.mark.parametrize("openshift_version", get_available_openshift_versions())
-    def test_install(self, configs: Tuple[ClusterConfig, TerraformConfig], get_nodes, get_cluster, openshift_version):
-        cluster_config, tf_config = configs
-        cluster_config.openshift_version = openshift_version
-        new_cluster = get_cluster(get_nodes(tf_config, cluster_config), cluster_config)
-        new_cluster.prepare_for_installation()
-        new_cluster.start_install_and_wait_for_installed()
+    def test_install(self, cluster, openshift_version):
+        cluster.prepare_for_installation()
+        cluster.start_install_and_wait_for_installed()
 
     @JunitTestSuite()
     @pytest.mark.parametrize("operators", sorted(get_api_client().get_supported_operators()))


### PR DESCRIPTION
Adding a new simple fixture in addition to the generators fixtures
The purpose of fixtures is build the infrastructure before the act (which is the operation this we are testing) and the test (which is the actual assert statement)
The best practice about fixtures is to create a short single responsibility fixture to avoid tear down issues
Most of our tests just changing the configuration before continue with the installation
In this PR we have created a new flow with simple short fixtures to override that supports multi-platform installation
so you can just set the platform variable to for instance vsphere and that's it
In addition we organized the common configuration into a base classes with a minimum duplication