### PR TITLE
Avoid libvirt error during disks teardown

### DIFF
--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -2,6 +2,7 @@ import json
 import logging
 import os
 import shutil
+import libvirt
 from typing import Callable
 from contextlib import suppress
 from pathlib import Path
@@ -187,7 +188,11 @@ class BaseTest:
         yield attach
         if global_variables.test_teardown:
             for modified_node in modified_nodes:
-                modified_node.detach_all_test_disks()
+                try:
+                    modified_node.detach_all_test_disks()
+                    logging.info(f'Successfully detach test disks from node {modified_node.name}')
+                except (libvirt.libvirtError, FileNotFoundError):
+                    logging.warning(f'Failed to detach test disks from node {modified_node.name}')
 
     @pytest.fixture(scope="function")
     def attach_disk(self):


### PR DESCRIPTION
To avoid failures like: https://auto-jenkins-csb-kniqe.apps.ocp4.prod.psi.redhat.com/job/ocp-assisted-installer-virt/2079/testReport/junit/test_ocs_validations/TestOCSValidations/Run_assisted_installer_Functional_API_Tests___test_ocs_standard_mode_three_workers_multiple_insufficient_disks/

