### PR TITLE
Fix libvirt error

### DIFF
--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -1,6 +1,7 @@
 import json
 import logging
 import os
+import libvirt
 import shutil
 from contextlib import suppress
 from pathlib import Path


### PR DESCRIPTION
This PR fix error: https://auto-jenkins-csb-kniqe.apps.ocp4.prod.psi.redhat.com/job/ocp-assisted-installer-virt/2170/testReport/junit/test_ocs_validations/TestOCSValidations/Run_assisted_installer_Functional_API_Tests___test_ocs_standard_mode_three_workers_multiple_insufficient_disks/

which mistakenly removed here: https://github.com/openshift/assisted-test-infra/commit/e0d79b8148a0373433c27800828001d08b7e0146#diff-6162d2a9234339ec7bb76b9037da27056716d9d64db599e223c8d132bc05787dL5