### PR TITLE
Replace FETCH_BASE with FETCH_NEW

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,8 +309,8 @@ bring_assisted_installer:
 	fi
 
 	@cd assisted-installer && \
-	git fetch --force origin $(INSTALLER_BASE_REF):FETCH_BASE $(INSTALLER_BRANCH) && \
-	git reset --hard FETCH_HEAD && \
+	git fetch --force origin $(INSTALLER_BASE_REF):FETCH_BASE $(INSTALLER_BRANCH):FETCH_NEW && \
+	git reset --hard FETCH_NEW && \
 	git rebase FETCH_BASE
 
 ###########
@@ -409,8 +409,8 @@ bring_assisted_service:
 	fi
 
 	@cd assisted-service && \
-	git fetch --force origin $(SERVICE_BASE_REF):FETCH_BASE $(SERVICE_BRANCH) && \
-	git reset --hard FETCH_HEAD && \
+	git fetch --force origin $(SERVICE_BASE_REF):FETCH_BASE $(SERVICE_BRANCH):FETCH_NEW && \
+	git reset --hard FETCH_NEW && \
 	git rebase FETCH_BASE
 
 deploy_monitoring: bring_assisted_service


### PR DESCRIPTION
When fetching multiple branches they are all being written to `FETCH_HEAD`
file.

```
➜  assisted-service git:(master) cat .git/FETCH_HEAD 
3f35d6cfad5156591fd76eb74dc37ffc5856a965		branch 'master' of https://github.com/rollandf/assisted-service
cd89ac9f840be3c1615bc1aefc1930adf2118858		branch 'MGMT-7148' of https://github.com/rollandf/assisted-service
```
It would be wiser not to depend on the `FETCH_HEAD` structure and just tag
the new branch as `FETCH_NEW`.

```bash
From https://github.com/rollandf/assisted-service
 * [new branch]        master     -> FETCH_BASE
 * [new branch]        MGMT-7148  -> FETCH_NEW
```

/cc @rollandf @osherdp 
