### PR TITLE
Revert "Replace FETCH_BASE with FETCH_NEW"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -309,8 +309,8 @@ bring_assisted_installer:
 	fi
 
 	@cd assisted-installer && \
-	git fetch --force origin $(INSTALLER_BASE_REF):FETCH_BASE $(INSTALLER_BRANCH):FETCH_NEW && \
-	git reset --hard FETCH_NEW && \
+	git fetch --force origin $(INSTALLER_BASE_REF):FETCH_BASE $(INSTALLER_BRANCH) && \
+	git reset --hard FETCH_HEAD && \
 	git rebase FETCH_BASE
 
 ###########
@@ -409,8 +409,8 @@ bring_assisted_service:
 	fi
 
 	@cd assisted-service && \
-	git fetch --force origin $(SERVICE_BASE_REF):FETCH_BASE $(SERVICE_BRANCH):FETCH_NEW && \
-	git reset --hard FETCH_NEW && \
+	git fetch --force origin $(SERVICE_BASE_REF):FETCH_BASE $(SERVICE_BRANCH) && \
+	git reset --hard FETCH_HEAD && \
 	git rebase FETCH_BASE
 
 deploy_monitoring: bring_assisted_service


### PR DESCRIPTION
Reverts openshift/assisted-test-infra#986

It broke assisted-service e2e jobs.
```
Rebasing (1/1)
*** Please tell me who you are.
Run
  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"
to set your account's default identity.
Omit --global to set the identity only in this repository.
fatal: unable to auto-detect email address (got 'root@ipi-ci-op-x8p1cjjc-3bd5c-1419405114711478272.(none)')
```