### PR TITLE
Move from log.warn to log.warning

### DIFF
--- a/discovery-infra/download_logs.py
+++ b/discovery-infra/download_logs.py
@@ -172,7 +172,7 @@ def download_logs(client: InventoryClient, cluster: dict, dest: str, must_gather
                                          check_oc=are_masters_in_join_state)
                     break
                 except AssertionError as ex:
-                    log.warn(f"Cluster logs verification failed: {ex}")
+                    log.warning("Cluster logs verification failed: %s", ex)
 
                     # Skip sleeping on last retry
                     if i < MAX_RETRIES - 1:

--- a/discovery-infra/log_scrap.py
+++ b/discovery-infra/log_scrap.py
@@ -9,7 +9,6 @@ import urllib3
 import logging
 import hashlib
 import tempfile
-import contextlib
 import elasticsearch
 
 from logger import log
@@ -56,7 +55,7 @@ class ScrapeEvents:
             random.shuffle(clusters)
 
             if not clusters:
-                log.warn(f'No clusters were found, waiting {RETRY_INTERVAL/60} min')
+                log.warning(f'No clusters were found, waiting {RETRY_INTERVAL/60} min')
                 time.sleep(RETRY_INTERVAL)
                 break
 
@@ -232,8 +231,8 @@ def main():
                                          es_pass = args.es_pass,
                                          backup_destination=args.backup_destination)
             scrape_events.run_service()
-        except Exception as EX:
-            log.warn(f"Elastefying logs failed with error {EX}, sleeping for {RETRY_INTERVAL} and retrying")
+        except Exception as ex:
+            log.warning("Elastefying logs failed with error %s, sleeping for %s and retrying", ex, RETRY_INTERVAL)
             time.sleep(RETRY_INTERVAL)
 
 if __name__ == '__main__':

--- a/discovery-infra/monitoring/process.py
+++ b/discovery-infra/monitoring/process.py
@@ -9,7 +9,7 @@ REMOVED_FIELDS = [
     "cluster.image_info.ssh_public_key"
     "cluster.connectivity_majority_groups",
     "cluster.controller_logs_collected_at",
-    
+
     "cluster.hosts.connectivity",
     "cluster.hosts.images_status",
 
@@ -94,4 +94,4 @@ def convert_field_to_json(converted_field):
         if type(converted_field) == str:
             return json.loads(converted_field)
     except KeyError:
-        logger.warn("Error while conversing to json")
+        logger.warning("Error while conversing to json")

--- a/discovery-infra/test_infra/utils/utils.py
+++ b/discovery-infra/test_infra/utils/utils.py
@@ -406,7 +406,7 @@ def get_random_name(length=8):
 def folder_exists(file_path):
     folder = Path(file_path).parent
     if not folder:
-        log.warn("Directory %s doesn't exist. Please create it", folder)
+        log.warning("Directory %s doesn't exist. Please create it", folder)
         return False
     return True
 


### PR DESCRIPTION
From [here](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-assisted-ipv6/1419634763982966784):
```
/home/assisted/discovery-infra/download_logs.py:175: DeprecationWarning: The 'warn' method is deprecated, use 'warning' instead
```

So using ```log.warning``` instead.
/cc @YuviGold 