### PR TITLE
Add kube-api mark to pytest markers list

### DIFF
--- a/discovery-infra/tests/pytest.ini
+++ b/discovery-infra/tests/pytest.ini
@@ -1,1 +1,3 @@
 [pytest]
+markers =
+    kube_api: mark test as part of kube api tests.


### PR DESCRIPTION
Without this fix, you'll get:
```
discovery-infra/tests/test_kube_api.py:45
  /home/assisted/discovery-infra/tests/test_kube_api.py:45: PytestUnknownMarkWarning: Unknown pytest.mark.kube_api - is this a typo?  You can register custom marks to avoid this warning - for details, see https://docs.pytest.org/en/stable/mark.html
    @pytest.mark.kube_api
```
(from https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_assisted-service/2301/pull-ci-openshift-assisted-service-ocm-2.3-e2e-metal-assisted-kube-api/1420643061754499072/artifacts/e2e-metal-assisted-kube-api/baremetalds-assisted-setup/build-log.txt)

/cc @YuviGold @michaellevy101 
/hold