### PR TITLE
NO-ISSUE - Fix logs failing while trying to download custom_manifests.yaml file

### DIFF
--- a/discovery-infra/logger.py
+++ b/discovery-infra/logger.py
@@ -2,7 +2,6 @@
 import logging
 import re
 import sys
-from contextlib import suppress
 
 
 class SensitiveFormatter(logging.Formatter):
@@ -27,16 +26,6 @@ class SensitiveFormatter(logging.Formatter):
     def format(self, record):
         original = logging.Formatter.format(self, record)
         return self._filter(original)
-
-
-class suppressAndLog(suppress):
-    def __exit__(self, exctype, excinst, exctb):
-        res = super().__exit__(exctype, excinst, exctb)
-
-        if res:
-            log.exception(exctype)
-
-        return res
 
 
 logging.getLogger("requests").setLevel(logging.ERROR)


### PR DESCRIPTION
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.9-e2e-metal-assisted-ipv6/1420661063333974016/artifacts/e2e-metal-assisted-ipv6/baremetalds-assisted-gather/build-log.txt

```
2021-07-29 09:52:04,989 ERROR      - 140416225086336 - <class 'assisted_service_client.rest.ApiException'> 	(/home/assisted/discovery-infra/logger.py:37)
Traceback (most recent call last):
  File "./discovery-infra/download_logs.py", line 143, in download_logs
    os.path.join(output_folder, "cluster_files", cluster_file))
  File "/home/assisted/discovery-infra/test_infra/assisted_service_api.py", line 253, in download_and_save_file
    cluster_id=cluster_id, file_name=file_name, _preload_content=False
  File "/usr/local/lib/python3.6/site-packages/assisted_service_client/api/installer_api.py", line 580, in download_cluster_files
    (data) = self.download_cluster_files_with_http_info(cluster_id, file_name, **kwargs)  # noqa: E501
  File "/usr/local/lib/python3.6/site-packages/assisted_service_client/api/installer_api.py", line 668, in download_cluster_files_with_http_info
    collection_formats=collection_formats)
  File "/usr/local/lib/python3.6/site-packages/assisted_service_client/api_client.py", line 330, in call_api
    _preload_content, _request_timeout)
  File "/usr/local/lib/python3.6/site-packages/assisted_service_client/api_client.py", line 161, in __call_api
    _request_timeout=_request_timeout)
  File "/usr/local/lib/python3.6/site-packages/assisted_service_client/api_client.py", line 351, in request
    headers=headers)
  File "/usr/local/lib/python3.6/site-packages/assisted_service_client/rest.py", line 238, in GET
    query_params=query_params)
  File "/usr/local/lib/python3.6/site-packages/assisted_service_client/rest.py", line 228, in request
    raise ApiException(http_resp=r)
assisted_service_client.rest.ApiException: (409)
Reason: Conflict
HTTP response headers: HTTPHeaderDict({'Content-Type': 'application/octet-stream', 'Date': 'Thu, 29 Jul 2021 09:52:04 GMT', 'Content-Length': '362'})
HTTP response body: b'{"code":"409","href":"","id":409,"kind":"Error","reason":"Failed to fetch metadata for object bc186278-222b-4673-b253-565a0171146b/custom_manifests.yaml in bucket test: Failed to fetch metadata for object bc186278-222b-4673-b253-565a0171146b/custom_manifests.yaml in bucket test: NotFound: Not Found\\n\\tstatus code: 404, request id: 16963A376862D81E, host id: "}'
```