### PR TITLE
Revert "Bump junit-report from 0.1.24 to 0.1.32 (#1013)"

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -9,7 +9,7 @@ ipdb==0.13.9
 ipython==7.11.1
 Jinja2===3.0.1
 jira==3.0.1
-junit-report==0.1.32
+junit-report==0.1.24
 kubernetes==17.17.0
 libvirt-python==7.6.0
 munch==2.5.0


### PR DESCRIPTION
This reverts commit 28876018 due to some issues on version > v0.1.24
/cc @YuviGold 

junit-report 0.1.32 uses new mechanism for handling pytest fixtures. Is cases some of the reports to show partially reports or no report at all.
It will probably will fix in the next version of junit-report