### PR TITLE
NO-ISSUE: adjust wait for controller interval

### DIFF
--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -514,8 +514,8 @@ class BaseTest:
 
         waiting.wait(
             lambda: check_status(),
-            timeout_seconds=3000,
-            sleep_seconds=90,
+            timeout_seconds=900,
+            sleep_seconds=30,
             waiting_for="controller to be running",
         )
 


### PR DESCRIPTION
There is a race between bootstrap rebooting and logs tests
actions that kills the installer on the bootstrap node
By making the interval for querying the controller 'Running' state
shorter and also considerably shorten the wait for log 'required'
state (see test_logs.py in kni-assisted-installer-auto) we hope
to reduce this race condition frequency