### PR TITLE
Wait for extended time for must-gather logs when hosts are done installation

### DIFF
--- a/discovery-infra/download_logs.py
+++ b/discovery-infra/download_logs.py
@@ -167,7 +167,7 @@ def download_logs(client: InventoryClient, cluster: dict, dest: str, must_gather
             are_masters_in_configuring_state = are_host_progress_in_stage(
                 cluster['hosts'], [HostsProgressStages.CONFIGURING], 2)
             are_masters_in_join_state = are_host_progress_in_stage(
-                cluster['hosts'], [HostsProgressStages.JOINED], 2)
+                cluster['hosts'], [HostsProgressStages.JOINED, HostsProgressStages.DONE], 2)
             max_retries = MUST_GATHER_MAX_RETRIES if are_masters_in_join_state else MAX_RETRIES
             is_controller_expected = cluster['status'] == ClusterStatus.INSTALLED or are_masters_in_configuring_state
             min_number_of_logs = min_number_of_log_files(cluster, is_controller_expected)


### PR DESCRIPTION
Right now we're waiting with 3 retries when hosts are in "done" state, and 15 retries when hosts are in "joined" state.
This change will retry more with those cases that we actually more probable to gather must-gather logs.
/cc @rollandf @michaellevy101 @YuviGold 
