### PR TITLE
MGMT-7571: Attach download logs directory with python logs

### DIFF
--- a/discovery-infra/logger.py
+++ b/discovery-infra/logger.py
@@ -54,6 +54,12 @@ ch.setFormatter(
 )
 log.addHandler(ch)
 
-fh = logging.FileHandler(filename="test_infra.log")
-fh.setFormatter(fmt)
-log.addHandler(fh)
+
+def add_log_file_handler(filename: str) -> logging.FileHandler:
+    fh = logging.FileHandler(filename)
+    fh.setFormatter(fmt)
+    log.addHandler(fh)
+    return fh
+
+
+add_log_file_handler("test_infra.log")


### PR DESCRIPTION
Each cluster logs directory will have its own execution logs alongside the main one including all of them at the root directory.

```
➜  assisted-test-infra git:(MGMT-7571-attach-download-logs-file-handler) find -name test_infra.log -print -exec bash -c "cat {} | wc -l" \; 
./test_infra.log
404
./build/2021-08-16_06:41:04_5a0db5bd-ecb7-4328-96cf-f7f327088f8d/test_infra.log
49
./build/2021-08-14_00:06:23_98b65add-664a-4b8a-b257-e0f8d13390c4/test_infra.log
60
./build/2021-08-16_01:16:40_070bd54d-698d-428e-b0ae-a49795106f97/test_infra.log
49
./build/2021-07-12_03:12:51_c3f6a6fc-452b-4b37-8008-b06d26fd738d/test_infra.log
53
./build/2021-08-16_08:04:24_2ed6c980-bd2f-40cf-b805-57b9fd476a8b/test_infra.log
49
./build/2021-08-12_18:29:51_ea253f07-b5e5-4044-a7be-b80f49b189b4/test_infra.log
28
./build/2021-08-13_15:47:03_b71c539c-6122-49dc-8470-692086ce20c7/test_infra.log
51
```

/cc @osherdp @michaellevy101 