### PR TITLE
NO-ISSUE: raise an error for only relevant error codes

### DIFF
--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -283,7 +283,7 @@ class InventoryClient(object):
         if not (url.startswith("http://") or url.startswith("https://")):
             url = f"http://{url}"
         response = requests.get(f"{url}/metrics")
-        assert response.status_code == 200
+        response.raise_for_status()
 
         with open(dest, "w") as _file:
             _file.write(response.text)


### PR DESCRIPTION
Asserting on return codes which are not 200 is probably not right and assertion message is not indicative enough about the error.
/cc @YuviGold 
/cc @nmagnezi 
/hold