### PR TITLE
NO-ISSUE: catch also HTTPError when metrics endpoint is not accessible

### DIFF
--- a/discovery-infra/download_logs.py
+++ b/discovery-infra/download_logs.py
@@ -149,7 +149,7 @@ def download_logs(client: InventoryClient, cluster: dict, dest: str, must_gather
     try:
         write_metadata_file(client, cluster, os.path.join(output_folder, 'metadata.json'))
 
-        with suppressAndLog(AssertionError, ConnectionError, requests.exceptions.ConnectionError):
+        with suppressAndLog(requests.exceptions.RequestException, ConnectionError):
             client.download_metrics(os.path.join(output_folder, "metrics.txt"))
 
         for cluster_file in ("bootstrap.ign", "master.ign", "worker.ign", "install-config.yaml", "custom_manifests.yaml"):


### PR DESCRIPTION
Now when we're raising on an illegal HTTP status code, it makes sense to catch it and suppress it accordingly.
Relates to #1046 
/cc @nmagnezi @empovit @YuviGold 
/hold