### PR TITLE
NO-ISSUE: Fix pip not upgrading correctly in image build

### DIFF
--- a/Dockerfile.test-infra
+++ b/Dockerfile.test-infra
@@ -18,14 +18,15 @@ RUN yum -y install \
   libvirt-client \
   libvirt-devel \
   libguestfs-tools \
-    && yum clean all && pip3 install --upgrade pip
+    && yum clean all
 
 RUN curl -Lo terraform.zip https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip && unzip terraform.zip -d /usr/bin/ && rm -rf terraform.zip
 
 COPY requirements.txt /tmp/
 COPY --from=service /clients/assisted-service-client-*.tar.gz /build/pip/
-RUN pip3 install --no-cache-dir -I -r /tmp/requirements.txt && \
-  pip3 install --upgrade /build/pip/*
+RUN pip3 install --upgrade pip && \
+      pip3 install --no-cache-dir -I -r /tmp/requirements.txt && \
+      pip3 install --upgrade /build/pip/*
 
 # setting pre-commit env
 ENV PRE_COMMIT_HOME build


### PR DESCRIPTION
For some reason pip was not upgrading properly so it had issues when trying to build in the cryptography package. 
This moves the pip upgrade to the same image layer as the pip install commands.

[Link to failing build](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/21268/rehearse-21268-periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-kube-api-periodic/1430217366439989248)