### PR TITLE
NO-ISSUE: Removed --retry-all-errors due to old curl version in the CI

### DIFF
--- a/discovery-infra/bootstrap_in_place.py
+++ b/discovery-infra/bootstrap_in_place.py
@@ -66,6 +66,8 @@ def installer_gather(ip, ssh_key, out_dir):
     os.remove(bundle_file_path) if os.path.exists(bundle_file_path) else None
 
 
+#ssl handshake failures at server side are not transient thus we cannot rely on curl retry mechanism by itself
+@utils.retry(exceptions=Exception, tries=3, delay=30)
 def download_live_image(download_path):
     if os.path.exists(download_path):
         logging.info("Image %s already exists, skipping download", download_path)
@@ -75,7 +77,7 @@ def download_live_image(download_path):
     # TODO: enable fetching the appropriate rhcos image
     utils.run_command(
         f"curl https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.2/rhcos-live.x86_64.iso"
-        f" --retry 10 --retry-all-errors --retry-connrefused -o {download_path} --continue-at -")
+        f" --retry 10 --retry-connrefused -o {download_path} --continue-at -")
 
 
 def embed(image_name, ignition_file, embed_image_name):


### PR DESCRIPTION
machine
Added retry decorator in order to overcome SSL_ERROR_SYSCALL