### PR TITLE
MGMT-5274: Fix test_kube_api

### DIFF
--- a/discovery-infra/install_cluster.py
+++ b/discovery-infra/install_cluster.py
@@ -216,7 +216,7 @@ def run_installation_flow_kube_api(
         agent.approve()
     
     log.info("Waiting for agent status verification")
-    Agent.wait_for_agents_to_install(agents, nodes_number)
+    Agent.wait_for_agents_to_install(agents)
 
     log.info("Waiting for installation to start")
     agent_cluster_install.wait_to_be_installing()

--- a/discovery-infra/test_infra/consts/consts.py
+++ b/discovery-infra/test_infra/consts/consts.py
@@ -58,6 +58,7 @@ PODMAN_FLAGS = "--cgroup-manager=cgroupfs --storage-driver=vfs --events-backend=
 DEFAULT_ADDITIONAL_NTP_SOURCE = "clock.redhat.com"
 DEFAULT_BASE_DNS_DOMAIN = "redhat.com"
 DEFAULT_NAMESPACE = 'assisted-installer'
+DEFAULT_SPOKE_NAMESPACE = 'assisted-spoke-cluster'
 DEFAULT_TEST_INFRA_DOMAIN = f".{CLUSTER_PREFIX}-{DEFAULT_NAMESPACE}.{DEFAULT_BASE_DNS_DOMAIN}"
 TEST_TARGET_INTERFACE = "vnet3"
 SUFFIX_LENGTH = 8

--- a/discovery-infra/test_infra/helper_classes/kube_helpers/agent.py
+++ b/discovery-infra/test_infra/helper_classes/kube_helpers/agent.py
@@ -116,29 +116,26 @@ class Agent(BaseCustomResource):
         logger.info("approved agent %s", self.ref)
 
     @staticmethod
-    def wait_for_agents_to_install(agents: List["Agent"], nodes_number: int, timeout: Union[int, float] = consts.CLUSTER_INSTALLATION_TIMEOUT) -> None:
+    def wait_for_agents_to_install(agents: List["Agent"], timeout: Union[int, float] = consts.CLUSTER_INSTALLATION_TIMEOUT) -> None:
         Agent.wait_till_all_agents_are_in_status(
             agents=agents,
-            nodes_count=nodes_number,
             statusType=consts.AgentStatus.VALIDATED,
             timeout=timeout,
         )
         Agent.wait_till_all_agents_are_in_status(
             agents=agents,
-            nodes_count=nodes_number,
             statusType=consts.AgentStatus.REQUIREMENTS_MET,
             timeout=timeout,
         )
         Agent.wait_till_all_agents_are_in_status(
             agents=agents,
-            nodes_count=nodes_number,
             statusType=consts.AgentStatus.INSTALLED,
             timeout=timeout,
         )
 
     @staticmethod
     def are_agents_in_status(
-        agents: List["Agent"], nodes_count: int, statusType: str, status: str,
+        agents: List["Agent"], statusType: str, status: str,
     ) -> bool:
         logger.info(
             "Asked agents to have the status [('%s', '%s')] and currently agent statuses are %s",
@@ -148,7 +145,7 @@ class Agent(BaseCustomResource):
             )
 
         agents_in_status = [agent for agent in agents for condition in  agent.status()["conditions"] if condition["type"] == statusType and condition["status"] == status]
-        if len(agents_in_status) >= nodes_count:
+        if len(agents_in_status) >= len(agents):
             return True
         return False
 
@@ -156,7 +153,6 @@ class Agent(BaseCustomResource):
     def wait_till_all_agents_are_in_status(
             agents: List["Agent"],
             statusType: str,
-            nodes_count: int,
             timeout,
             interval=10,
     ) -> None:
@@ -165,7 +161,6 @@ class Agent(BaseCustomResource):
         waiting.wait(
             lambda: Agent.are_agents_in_status(
                 agents,
-                nodes_count,
                 statusType,
                 status="True",
             ),

--- a/discovery-infra/test_infra/utils/global_variables/env_variables_defaults.py
+++ b/discovery-infra/test_infra/utils/global_variables/env_variables_defaults.py
@@ -42,6 +42,7 @@ class _EnvVariablesDefaults(ABC):
     master_vcpu: str = get_env("MASTER_CPU", resources.DEFAULT_MASTER_CPU)
     test_teardown: bool = bool(strtobool(get_env("TEST_TEARDOWN", str(env_defaults.DEFAULT_TEST_TEARDOWN))))
     namespace: str = get_env("NAMESPACE", consts.DEFAULT_NAMESPACE)
+    spoke_namespace: str = get_env("SPOKE_NAMESPACE", consts.DEFAULT_SPOKE_NAMESPACE)
     olm_operators: List[str] = field(default_factory=list)
     platform: str = get_env("PLATFORM", env_defaults.DEFAULT_PLATFORM)
     user_managed_networking: bool = env_defaults.DEFAULT_USER_MANAGED_NETWORKING


### PR DESCRIPTION
- Update load balancer endpoint dynamically according to the
  assisted-service route.
- [MGMT-6788](https://issues.redhat.com/browse/MGMT-6788): Fix `ClusterName` to be an object instead of a string.
- [MGMT-7082](https://issues.redhat.com/browse/MGMT-7082): Use a different namespace for the hub and the spoke
  clusters. By default `assisted-spoke-cluster`. Can be overriden with
  `SPOKE_CLUSTER` environment variable.

/cc @eliorerz 

Depends on https://github.com/openshift/release/pull/21441

/test system-test-operator
/hold