### PR TITLE
Fix broken set_cluster_name method

### DIFF
--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -170,7 +170,7 @@ class Cluster:
 
     def set_cluster_name(self, cluster_name: str):
         log.info(f"Setting Cluster Name:{cluster_name} for cluster: {self.id}")
-        self.update_config(cluster_name=cluster_name)
+        self.update_config(cluster_name=ClusterName(prefix=cluster_name, suffix=None))
         self.api_client.update_cluster(self.id, {"name": cluster_name})
 
     def select_installation_disk(self, hosts_with_disk_paths):


### PR DESCRIPTION
fix test failures:
https://auto-jenkins-csb-kniqe.apps.ocp4.prod.psi.redhat.com/job/ocp-assisted-installer-virt/2995/testReport/junit/test_ocm_integration/TestOCMIntegration/Run_assisted_installer_Functional_API_Tests___test_ocm_subscription_is_updated_with_display_name/

https://auto-jenkins-csb-kniqe.apps.ocp4.prod.psi.redhat.com/job/ocp-assisted-installer-virt/2997/testReport/junit/test_validations/TestValidations/Run_assisted_installer_Functional_API_Tests___test_hosts_and_cluster_max_length/

caused by change: https://github.com/openshift/assisted-test-infra/pull/1057