### PR TITLE
Update OWNERS

### DIFF
--- a/OWNERS
+++ b/OWNERS
@@ -3,13 +3,6 @@
 approvers:
 - tsorya
 - yuvigold
-- romfreiman
-- eranco74
 - osherdp
-- omertuc
-- ori-amizur
-- gamli75
 - michaellevy101
 - eliorerz
-- ybettan
-- lranjbar


### PR DESCRIPTION
Lately, several times a new code was added without consideration of styling, 
other sections of the code, and other clients that might get affected.

Update the OWNERS file to have approvers that are familiar with the whole assisted-test-infra ecosystem
Still, every OpenShift org member would be able to LGTM but it would require an approver in order to get merged.