### PR TITLE
Use kubeconfig path that always exists

### DIFF
--- a/discovery-infra/resources/man_sosreport.sh
+++ b/discovery-infra/resources/man_sosreport.sh
@@ -121,7 +121,7 @@ journalctl -u bootkube.service > ./var/log/bootkube.log 2>> error_log
 journalctl -u crio.service > ./var/log/crio.log 2>> error_log
 
 echo -e "Gathering Openshift data..."
-export KUBECONFIG=/etc/kubernetes/bootstrap-secrets/kubeconfig
+export KUBECONFIG=/etc/kubernetes/static-pod-resources/kube-apiserver-certs/secrets/node-kubeconfigs/localhost.kubeconfig
 oc describe clusteroperators &> clusteroperators
 oc describe clusterversion &> clusterversion
 oc describe nodes &> nodes


### PR DESCRIPTION
The previous one we used doesn't always exist: only on the bootstrap and during bootstrapping phase.
/cc @eranco74 @tsorya 

/test e2e-metal-assisted-ipv6
/hold
