### PR TITLE
MGMT-7744: Add test_networking test

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -495,4 +495,4 @@ _test_setup:
 	rm -f /tmp/tf_network_pool.json
 
 _test_parallel: $(REPORTS) _test_setup
-	JUNIT_REPORT_DIR=$(REPORTS) python3 -m pytest -n $(or ${TEST_WORKERS_NUM}, '3') $(or ${TEST},discovery-infra/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(REPORTS)/unittest.xml
+	JUNIT_REPORT_DIR=$(REPORTS) python3 -m pytest -n $(or ${TEST_WORKERS_NUM}, '4') $(or ${TEST},discovery-infra/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(REPORTS)/unittest.xml

--- a/discovery-infra/tests/conftest.py
+++ b/discovery-infra/tests/conftest.py
@@ -2,6 +2,7 @@ import logging
 from typing import List
 
 import pytest
+from _pytest.nodes import Item
 from test_infra import utils
 from tests.config import global_variables
 
@@ -25,7 +26,7 @@ def get_available_openshift_versions() -> List[str]:
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)
-def pytest_runtest_makereport(item, call):
+def pytest_runtest_makereport(item: Item, call):
     outcome = yield
     result = outcome.get_result()
 


### PR DESCRIPTION
The test will run the different networking options assisted supports
like `network_type` and `static_ips` modes.