### PR TITLE
Use rpmfind.net/linux/centos/8 path to install libgcrypt

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -33,7 +33,7 @@ function install_libvirt() {
     else
         if ! rpm -qa | grep libgcrypt-1.8.5-4; then
             mkdir -p build
-            curl -Lo build/libgcrypt-1.8.5-4.el8.x86_64.rpm https://rpmfind.net/linux/centos/8.3.2011/BaseOS/x86_64/os/Packages/libgcrypt-1.8.5-4.el8.x86_64.rpm && sudo dnf -y install build/libgcrypt-1.8.5-4.el8.x86_64.rpm
+            curl -Lo build/libgcrypt-1.8.5-4.el8.x86_64.rpm https://rpmfind.net/linux/centos/8/BaseOS/x86_64/os/Packages/libgcrypt-1.8.5-4.el8.x86_64.rpm && sudo dnf -y install build/libgcrypt-1.8.5-4.el8.x86_64.rpm
         fi
         start_and_enable_libvirtd_tcp_socket
     fi


### PR DESCRIPTION
https://rpmfind.net/linux/centos/8.3.2011/ path is [depricated](https://rpmfind.net/linux/centos/8.3.2011/readme). Using https://rpmfind.net/linux/centos/8 instead 