### PR TITLE
Ignore libvirt errors when trying to get domain ips and macs

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -455,10 +455,18 @@ class LibvirtController(NodeController, ABC):
 
     @staticmethod
     def _get_domain_ips_and_macs(domain):
-        # getting all DHCP leases IPs
-        interfaces = dict(domain.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE))
-        # getting static IPs via ARP
-        interfaces.update(domain.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_ARP))
+        interfaces_sources = [
+            # getting all DHCP leases IPs
+            libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE,
+
+            # getting static IPs via ARP
+            libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_ARP,
+        ]
+
+        interfaces = {}
+        for addresses_source in interfaces_sources:
+            with suppress(libvirt.libvirtError):
+                interfaces.update(**domain.interfaceAddresses(addresses_source))
 
         ips = []
         macs = []


### PR DESCRIPTION
Sometimes the interfaces aren't available

```
  File "/home/assisted/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py", line 459, in _get_domain_ips_and_macs
    interfaces = dict(domain.interfaceAddresses(libvirt.VIR_DOMAIN_INTERFACE_ADDRESSES_SRC_LEASE))
  File "/usr/local/lib64/python3.6/site-packages/libvirt.py", line 1657, in interfaceAddresses
    raise libvirtError('virDomainInterfaceAddresses() failed')
libvirt.libvirtError: Requested operation is not valid: domain is not running
```

We should try to get all the available IPs and ignore failures in that case.

/cc @osherdp 