### PR TITLE
[WIP] NO-ISSUE: check for None when searching for a node

### DIFF
--- a/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -470,6 +470,7 @@ class LibvirtController(NodeController, ABC):
 
         ips = []
         macs = []
+        logging.info(f"Host {domain.name()} interfaces are {interfaces}")
         if interfaces:
             for (_, val) in interfaces.items():
                 if val['addrs']:

--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -705,8 +705,8 @@ class Cluster:
 
             node = Cluster.find_matching_node(host, nodes)
             if not node:
-                log.warn(f"Failed to find matching node for host with mac address {host.macs()} nodes: {nodes}")
-                continue
+                node_info = [{n.name: {"ips": n.ips, "macs": n.macs}} for n in nodes]
+                log.warn(f"Failed to find matching node for host with mac address {host.macs()} nodes: {node_info}")
 
             role = consts.NodeRoles.MASTER if consts.NodeRoles.MASTER in node.name else consts.NodeRoles.WORKER
             roles.append({"id": host.get_id(), "role": role})

--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -704,6 +704,10 @@ class Cluster:
                 continue
 
             node = Cluster.find_matching_node(host, nodes)
+            if not node:
+                log.warn(f"Failed to find matching node for host with mac address {host.macs()} nodes: {nodes}")
+                continue
+
             role = consts.NodeRoles.MASTER if consts.NodeRoles.MASTER in node.name else consts.NodeRoles.WORKER
             roles.append({"id": host.get_id(), "role": role})
             hostnames.append(models.ClusterupdateparamsHostsNames(id=host.get_id(), hostname=node.name))


### PR DESCRIPTION
There are some tests that are failing with the following error:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.6/site-packages/junit_report/_junit_decorator.py", line 51, in _wrapper
    value = self._execute_wrapped_function(*args, **kwargs)
  File "/usr/local/lib/python3.6/site-packages/junit_report/_junit_decorator.py", line 93, in _execute_wrapped_function
    return self._func(*args, **kwargs)
  File "/home/assisted/discovery-infra/test_infra/helper_classes/cluster.py", line 744, in prepare_for_installation
    self._set_hostnames_and_roles()
  File "/home/assisted/discovery-infra/test_infra/helper_classes/cluster.py", line 707, in _set_hostnames_and_roles
    role = consts.NodeRoles.MASTER if consts.NodeRoles.MASTER in node.name else consts.NodeRoles.WORKER
AttributeError: 'NoneType' object has no attribute 'name'
```

This should help us track down what's going on in these cases

Sepcifically these tests: https://search.ci.openshift.org/?search=AttributeError%3A+%27NoneType%27+object+has+no+attribute+%27name%27&maxAge=48h&context=1&type=bug%2Bjunit&name=.*assisted.*&excludeName=&maxMatches=5&maxBytes=20971520&groupBy=job