### PR TITLE
NO-ISSUE: Force load balancer container to use the host as DNS

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -201,7 +201,7 @@ start_load_balancer:
 	@if [ "$(PLATFORM)" = "none"  ] || [ "$(START_LOAD_BALANCER)" = "true" ]; then \
 		id=`podman ps --quiet --filter "name=load_balancer"`; \
 		( test -z "$$id" && echo "Staring load balancer ..." && \
-		podman run -d --rm --net=host --name=load_balancer \
+		podman run -d --rm --dns=127.0.0.1 --net=host --name=load_balancer \
 			-v $(HOME)/.test-infra/etc/nginx/conf.d:/etc/nginx/conf.d \
 			load_balancer:latest ) || ! test -z "$$id"; \
 	fi


### PR DESCRIPTION
We've noticed that, depending on whether you run with podman, docker,
`--net=host` and also the time you run the container all have the
potential to give the `/etc/resolv.conf` inside the container different
values. Instead of relying on these parameters, we now force the container
to use the host DNS server by passing `podman` the `--dns=127.0.0.1` flag
(along with the `--net=host` flag that was already there).

It seems that when running the load balancer in the CI, its DNS
configuration had an incorrect value and as a result the load balancer
could not connect to the hub cluster's assisted service, resulting in
agents that rely on this load balancer to not be able to register with
the service.

/cc @YuviGold