### PR TITLE
MGMT-7900: Test infra proxy may fail if install-config contains Proxy (Capitalized) instead of proxy

### DIFF
--- a/discovery-infra/test_infra/controllers/proxy_controller/templates/squid.conf.j2
+++ b/discovery-infra/test_infra/controllers/proxy_controller/templates/squid.conf.j2
@@ -4,6 +4,7 @@ acl all_auth proxy_auth REQUIRED
 http_access allow all_auth
 {% else %}
 acl all src 0.0.0.0/0
+acl all src ::/0
 {% if denied_port %}
 acl denied_ports port {{ denied_port }}
 http_access deny denied_ports

--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -432,7 +432,7 @@ class BaseTest:
                              is_ipv6=cluster.nodes.is_ipv6)
         cluster.set_proxy_values(http_proxy=proxy.address, https_proxy=proxy.address, no_proxy=no_proxy)
         install_config = cluster.get_install_config()
-        proxy_details = install_config.get("proxy")
+        proxy_details = install_config.get("proxy") or install_config.get("Proxy")
         assert proxy_details and proxy_details.get("httpProxy") == proxy.address
         assert proxy_details.get("httpsProxy") == proxy.address
 


### PR DESCRIPTION
- Add support for both forms
NO-ISSUE: Add acl for all IPv6 addresses (::/0) in addition to the existing 0.0.0.0/0
- For squid to allow proxying of IPv6 traffic

/cc @eliorerz 
/cc @YuviGold 