### PR TITLE
MGMT-7928: Use infrenv api to generate and download image

### DIFF
--- a/discovery-infra/test_infra/helper_classes/config/base_infra_env_config.py
+++ b/discovery-infra/test_infra/helper_classes/config/base_infra_env_config.py
@@ -1,4 +1,5 @@
 from abc import ABC
+from typing import Dict, List
 
 from dataclasses import dataclass
 
@@ -12,3 +13,6 @@ class BaseInfraEnvConfig(BaseEntityConfig, ABC):
     All arguments must have default to None with type hint
     """
     infra_env_id: str = None
+    cluster_id: str = None
+    static_network_config: List[dict] = None
+    ignition_config_override: str = None

--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -458,7 +458,7 @@ class BaseTest:
             cluster_config = cluster.config
 
             if cluster_config.download_image:
-                cluster.generate_and_download_image(
+                cluster.generate_and_download_infra_env(
                     iso_download_path=cluster_config.iso_download_path,
                 )
             cluster.nodes.start_given(given_nodes)


### PR DESCRIPTION
This PR:

- uses infraenv to create and download cluster image
- moves api client to use v2_register_cluster to create a new cluster
- use infraenv to update host roles and names