### PR TITLE
MGMT-7957 - `test_kube_api` fix to use newer `ClusterConfig` members

### DIFF
--- a/discovery-infra/test_infra/utils/global_variables/global_variables.py
+++ b/discovery-infra/test_infra/utils/global_variables/global_variables.py
@@ -29,6 +29,10 @@ _triggers = frozendict(
             "master_memory": resources.DEFAULT_MASTER_SNO_MEMORY,
             "master_vcpu": resources.DEFAULT_MASTER_SNO_CPU,
         },
+        (("is_ipv4", True), ("is_ipv6", False),): {
+            "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV4,
+            "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV4,
+        },
         (("is_ipv4", False), ("is_ipv6", True),): {
             "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV6,
             "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV6,
@@ -57,12 +61,14 @@ class GlobalVariables(_EnvVariablesDefaults):
         self._set("openshift_version", utils.get_openshift_version(allow_default=True, client=client))
 
         for conditions, values in _triggers.items():
-            assert isinstance(conditions, tuple) and isinstance(conditions[0], tuple), f"Key {conditions} must be tuple of tuples"
-            if all(map(lambda condition: self.is_set(condition[0], condition[1]), conditions)):
+            assert isinstance(conditions, tuple) and all(isinstance(condition, tuple)
+                    for condition in conditions), f"Key {conditions} must be tuple of tuples"
+
+            if all(self.is_set(param, expected_value) for param, expected_value in conditions):
                 self._handle_trigger(conditions, values)
 
-    def is_set(self, var, expected):
-        return getattr(self, var) == expected
+    def is_set(self, var, expected_value):
+        return getattr(self, var) == expected_value
 
     def _handle_trigger(self, conditions, values):
         for k, v in values.items():


### PR DESCRIPTION
aec453f5fcf1da37e6171940df71fef1bc96cf66 changed the format of the `ClusterConfig`
class but forgot to update all usages of it.

For now this is a quick fix just to get the kube-api CI working again, it is
not an entirely correct fix because it has poor support for dual network stack
clusters.

This may be improved in future PRs