### PR TITLE
MGMT-7969 - Remove `InfraEnvConfig` from `cluster.py`

### DIFF
--- a/discovery-infra/test_infra/helper_classes/infra_env.py
+++ b/discovery-infra/test_infra/helper_classes/infra_env.py
@@ -3,7 +3,6 @@ import logging
 import json
 from typing import Optional
 
-from assisted_service_client.models import cluster
 from junit_report import JunitTestCase
 
 import test_infra.utils.waiting
@@ -11,7 +10,6 @@ from test_infra import consts, utils
 from test_infra.assisted_service_api import InventoryClient, models
 from test_infra.helper_classes.config import BaseInfraEnvConfig
 from test_infra.helper_classes.nodes import Nodes
-from test_infra.tools import static_network, terraform_utils
 
 
 class InfraEnv:
@@ -111,6 +109,7 @@ class InfraEnv:
             host_id=host_id,
             cluster_id=cluster_id
         )
+
     def unbind_host(self, host_id: str) -> None:
         self.api_client.unbind_host(infra_env_id=self.id, host_id=host_id)
 


### PR DESCRIPTION
`InfraEnvConfig` is declared ot `tests` package and we must not use it on `test_infra` package (only in `BaseInfraEnvConfig`).
After removing all usages in `InfraEnvConfig` now we must create `InfraEnvConfig` on `BaseTest` and pass it to `Cluster`.
This PR also change cluster `__init__` signature and now get `BaseInfraEnvConfig` as argument.
