### PR TITLE
Reverting test_parallel has 4 test processes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -492,4 +492,4 @@ _test_setup:
 	rm -f /tmp/tf_network_pool.json
 
 _test_parallel: $(REPORTS) _test_setup
-	JUNIT_REPORT_DIR=$(REPORTS) python3 -m pytest -n $(or ${TEST_WORKERS_NUM}, '4') $(or ${TEST},discovery-infra/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(REPORTS)/unittest.xml
+	JUNIT_REPORT_DIR=$(REPORTS) python3 -m pytest -n $(or ${TEST_WORKERS_NUM}, '3') $(or ${TEST},discovery-infra/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(REPORTS)/unittest.xml


### PR DESCRIPTION
Since changing `TEST_WORKERS_NUM` to 4 we observed flaky behavior (Timeout) that can be caused by lack of resources on the executing machines.
This PR reverting `TEST_WORKERS_NUM` to run with 3 test workers