### PR TITLE
MGMT-7996 Adding proxy methods for infraenv

### DIFF
--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -160,6 +160,10 @@ class Cluster:
         self._infra_env = infra_env
         return infra_env
 
+    def update_infra_env_proxy(self, proxy: models.Proxy) -> None:
+        self._infra_env_config.proxy = proxy
+        self._infra_env.update_proxy(proxy=proxy)
+
     def download_infra_env_image(self, iso_download_path = None) -> None:
         iso_download_path = iso_download_path or self._config.iso_download_path
         self._infra_env.download_image(iso_download_path=iso_download_path)
@@ -410,13 +414,14 @@ class Cluster:
     def patch_discovery_ignition(self, ignition):
         self._infra_env.patch_discovery_ignition(ignition_info=ignition)
 
-    def set_proxy_values(self, http_proxy, https_proxy="", no_proxy=""):
+    def set_proxy_values(self, proxy_values: models.Proxy) -> None:
         log.info(
-            f"Setting http_proxy:{http_proxy}, https_proxy:{https_proxy} and no_proxy:{no_proxy} "
-            f"for cluster: {self.id}"
+            f"Setting proxy values {proxy_values} for cluster: {self.id}"
         )
-        self.update_config(proxy=models.Proxy(http_proxy=http_proxy, https_proxy=https_proxy, no_proxy=no_proxy))
-        self.api_client.set_cluster_proxy(self.id, http_proxy, https_proxy, no_proxy)
+        self.update_config(proxy=proxy_values)
+        self.api_client.set_cluster_proxy(
+            self.id, http_proxy=self._config.proxy.http_proxy, https_proxy=self._config.proxy.https_proxy, no_proxy=self._config.proxy.no_proxy
+        )
 
     @JunitTestCase()
     def start_install(self):

--- a/discovery-infra/test_infra/helper_classes/config/base_entity_config.py
+++ b/discovery-infra/test_infra/helper_classes/config/base_entity_config.py
@@ -26,4 +26,4 @@ class BaseEntityConfig(_BaseConfig, ABC):
     base_dns_domain: str = None
     entity_name: BaseName = None
     proxy: models.Proxy = None
-    
+

--- a/discovery-infra/test_infra/helper_classes/infra_env.py
+++ b/discovery-infra/test_infra/helper_classes/infra_env.py
@@ -29,6 +29,7 @@ class InfraEnv:
             ignition_config_override = json.dumps(self._config.ignition_config_override)
         else:
             ignition_config_override = None
+
         return self.api_client.create_infra_env(
             self._config.entity_name.get(),
             pull_secret=self._config.pull_secret,
@@ -121,3 +122,11 @@ class InfraEnv:
 
     def get_details(self) -> models.infra_env.InfraEnv:
         return self.api_client.get_infra_env(infra_env_id=self.id)
+
+    def update_proxy(self, proxy: models.Proxy) -> None:
+        self.update_config(proxy=proxy)
+        infra_env_update_params = models.InfraEnvUpdateParams(
+                proxy=self._config.proxy
+        )
+        self.api_client.update_infra_env(infra_env_id=self.id, infra_env_update_params=infra_env_update_params)
+

--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -12,6 +12,7 @@ import test_infra.utils as infra_utils
 import waiting
 from _pytest.fixtures import FixtureRequest
 from assisted_service_client.rest import ApiException
+from assisted_service_client import models
 from download_logs import download_logs
 from junit_report import JunitFixtureTestCase, JunitTestCase
 from kubernetes.client import CoreV1Api
@@ -434,7 +435,10 @@ class BaseTest:
 
         proxy = proxy_server(name=proxy_name, port=port, dir=proxy_name, host_ip=host_ip,
                              is_ipv6=cluster.nodes.is_ipv6)
-        cluster.set_proxy_values(http_proxy=proxy.address, https_proxy=proxy.address, no_proxy=no_proxy)
+        cluster_proxy_values = models.Proxy(
+            http_proxy=proxy.address, https_proxy=proxy.address, no_proxy=no_proxy
+        )
+        cluster.set_proxy_values(proxy_values=cluster_proxy_values)
         install_config = cluster.get_install_config()
         proxy_details = install_config.get("proxy") or install_config.get("Proxy")
         assert proxy_details, str(install_config)


### PR DESCRIPTION
- move idict and proxy classes `helper_classes/kube_helpers->helper_classes to used in REST cluster and infraenv classes
- Add update_proxy method to InfraEnv
- Add upddate_infra_env_proxy method to Cluster