### PR TITLE
NO-ISSUE: define build-root-image in the repository itself

### DIFF
--- a/.ci-operator.yaml
+++ b/.ci-operator.yaml
@@ -1,0 +1,4 @@
+build_root_image:
+  namespace: openshift
+  name: release
+  tag: golang-1.16


### PR DESCRIPTION
So hopefully, this should allow us to try and use the Dockerfile as it's defined in the PR, and not just take it from master.
It should be followed with changing configuration in ``release`` to use build-root configuration from the repository.

This follows configuration from:
https://docs.ci.openshift.org/docs/architecture/ci-operator/#build-root-image

/cc @eliorerz 
/hold