### PR TITLE
OCPBUGSM-36027 - Fix missing versions in default_release_images.json

### DIFF
--- a/scripts/override_release_images.py
+++ b/scripts/override_release_images.py
@@ -12,6 +12,7 @@ import tempfile
 
 import semver
 
+
 @contextmanager
 def pull_secret_file():
     pull_secret = os.environ.get("PULL_SECRET")
@@ -57,6 +58,16 @@ def get_full_openshift_version_from_release(release_image: str) -> str:
     return stdout
 
 
+def get_release_image(release_images, ocp_version, cpu_architecture="x86_64"):
+    archs_images = [v for v in release_images if v.get('cpu_architecture') == cpu_architecture]
+    release_image = [v for v in archs_images if v.get('openshift_version') == ocp_version]
+    if len(release_image) >= 1:
+        return release_image[0]
+
+    # else get the last version
+    return archs_images[-1]
+
+
 def main():
     # Load default release images
     with open(args.src, 'r') as f:
@@ -69,8 +80,7 @@ def main():
     ocp_version = "{}.{}".format(ocp_semver.major, ocp_semver.minor)
 
     # Find relevant release image
-    release_image = [v for v in release_images
-        if v.get('openshift_version') == ocp_version and v.get('cpu_architecture') == "x86_64"][0]
+    release_image = get_release_image(release_images, ocp_version)
     release_image_index = release_images.index(release_image)
 
     # Update release image


### PR DESCRIPTION
Currently we don't have yet a section for 4.10  in the version files (`override_release_images.py`)