### PR TITLE
NO-ISSUE: added override_os_images script

### DIFF
--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -39,6 +39,7 @@ mkdir -p build
 
 if [ "${OPENSHIFT_INSTALL_RELEASE_IMAGE}" != "" ]; then
     export RELEASE_IMAGES=$(skipper run ./scripts/override_release_images.py --src ./assisted-service/data/default_release_images.json)
+    export OS_IMAGES=$(skipper run ./scripts/override_os_images.py --src ./assisted-service/data/default_os_images.json)
 
     if [ "${DEPLOY_TARGET}" == "onprem" ]; then
         if [ -x "$(command -v docker)" ]; then

--- a/scripts/override_os_images.py
+++ b/scripts/override_os_images.py
@@ -1,0 +1,44 @@
+#!/usr/bin/python3
+# -*- coding: utf-8 -*-
+from argparse import ArgumentParser
+
+import json
+import os
+
+
+def get_os_image(os_images, ocp_version, cpu_architecture="x86_64"):
+    archs_images = [v for v in os_images if v.get('cpu_architecture') == cpu_architecture]
+    os_images = [v for v in archs_images if v.get('openshift_version') == ocp_version]
+    if len(os_images) >= 1:
+        return os_images[0]
+
+    return archs_images[-1]
+
+
+def main():
+    # Load default os images
+    with open(args.src, 'r') as f:
+        os_images: list = json.load(f)
+
+    release_images = json.loads(os.getenv("RELEASE_IMAGES"))
+    latest_ocp_version = release_images[-1]["openshift_version"]
+    os_image = [v for v in os_images if v.get('openshift_version') == latest_ocp_version]
+
+    # If OS image for latest OCP versions doesn't exists, clone latest OS image and override 'openshift_version'
+    os_image = get_os_image(os_images, latest_ocp_version)
+    if os_image["openshift_version"] != latest_ocp_version:
+        os_image["openshift_version"] = latest_ocp_version
+        os_images.append(os_image)
+
+    json.dump(os_images, os.sys.stdout, separators=(',', ':'))
+
+
+if __name__ == "__main__":
+    parser = ArgumentParser()
+    parser.add_argument(
+        '--src',
+        type=str,
+        help='OS images list file path'
+    )
+    args = parser.parse_args()
+    main()


### PR DESCRIPTION
Added override_os_images.py script for appending a "dummy" OS image item in case of latest ocp version is missing.
E.g. when using a nightly 4.10 release image (specified in OPENSHIFT_INSTALL_RELEASE_IMAGE var),
we add a new release image item. But since an OS image for 4.10 is not available yet, need to clone the latest OS image item and override "openshift_version" with 4.10.
This should overcome the issue in available versions tests: https://github.com/openshift/assisted-test-infra/blob/81084fd4f357734c1ed5e8c879e19231baf32052/discovery-infra/tests/conftest.py#L16-L25