### PR TITLE
MGMT-8058: Add logic to detect if running in Openshift CI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -11,6 +11,12 @@ REPORTS = $(ROOT_DIR)/reports
 
 SKIPPER_PARAMS ?= -i
 
+# Openshift CI params
+OPENSHIFT_CI := $(or ${OPENSHIFT_CI}, "false")
+JOB_TYPE := $(or ${JOB_TYPE}, "")
+REPO_NAME := $(or ${REPO_NAME}, "")
+PULL_NUMBER := $(or ${PULL_NUMBER}, "")
+
 # lint
 LINT_CODE_STYLING_DIRS := discovery-infra/tests discovery-infra/test_infra
 
@@ -411,10 +417,17 @@ bring_assisted_service:
 		git clone $(SERVICE_REPO); \
 	fi
 
+ifeq ($(shell [[ $(OPENSHIFT_CI) == "true" && $(REPO_NAME) == "assisted-service" && $(JOB_TYPE) == "presubmit" ]] && echo true),true)
+	@echo "Running in assisted-service pull request"
+	@cd assisted-service && \
+	git fetch origin pull/$(PULL_NUMBER)/head:assisted-service-pr-$(PULL_NUMBER) && \
+	git checkout assisted-service-pr-$(PULL_NUMBER)
+else
 	@cd assisted-service && \
 	git fetch --force origin $(SERVICE_BASE_REF):FETCH_BASE $(SERVICE_BRANCH) && \
 	git reset --hard FETCH_HEAD && \
 	git rebase FETCH_BASE
+endif
 
 deploy_monitoring: bring_assisted_service
 	make -C assisted-service/ deploy-monitoring


### PR DESCRIPTION
Detect if we are running in an assisted-service pull request in Openshift CI or not.

```
[lranjbar@fedora assisted-test-infra]$ make bring_assisted_service 
Running in assisted-service pull request
remote: Enumerating objects: 8, done.
remote: Counting objects: 100% (8/8), done.
remote: Compressing objects: 100% (2/2), done.
remote: Total 5 (delta 3), reused 5 (delta 3), pack-reused 0
Unpacking objects: 100% (5/5), 2.92 KiB | 995.00 KiB/s, done.
From https://github.com/openshift/assisted-service
 * [new ref]           refs/pull/2829/head -> assisted-service-pr-2829
Switched to branch 'assisted-service-pr-2829'
```

vs

```
[lranjbar@fedora assisted-test-infra]$ make bring_assisted_service 
From https://github.com/openshift/assisted-service
 * branch              master     -> FETCH_HEAD
HEAD is now at bba8ede6 NO-ISSUE: Improve asc field descriptions (#2835)
```