### PR TITLE
MGMT-7983 - Fix e2e-metal-assisted-networking flaky test

### DIFF
--- a/discovery-infra/test_infra/helper_classes/config/base_config.py
+++ b/discovery-infra/test_infra/helper_classes/config/base_config.py
@@ -2,9 +2,11 @@ from abc import ABC, abstractmethod
 from dataclasses import asdict, dataclass
 from typing import Any
 
+from test_infra.utils.global_variables.triggerable import Triggerable
+
 
 @dataclass
-class _BaseConfig(ABC):
+class _BaseConfig(Triggerable, ABC):
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 
@@ -27,3 +29,7 @@ class _BaseConfig(ABC):
 
     def get_all(self) -> dict:
         return asdict(self)
+
+    def _set(self, key: str, value: Any):
+        if hasattr(self, key):
+            self.__setattr__(key, value)

--- a/discovery-infra/test_infra/utils/global_variables/global_variables.py
+++ b/discovery-infra/test_infra/utils/global_variables/global_variables.py
@@ -1,59 +1,13 @@
 from contextlib import suppress
-from typing import ClassVar, List
+from typing import Any
 
-from frozendict import frozendict
-from logger import log
-from test_infra import consts
 from test_infra.assisted_service_api import ClientFactory, InventoryClient
-from test_infra.consts import resources
 from test_infra.utils import utils
 from test_infra.utils.global_variables.env_variables_defaults import _EnvVariablesDefaults
-
-_triggers = frozendict(
-    {
-        (("platform", consts.Platforms.NONE),): {
-            "user_managed_networking": True,
-            "vip_dhcp_allocation": False,
-        },
-        (("platform", consts.Platforms.VSPHERE),): {
-            "user_managed_networking": False,
-        },
-        (("masters_count", 1),): {
-            "workers_count": 0,
-            "nodes_count": 1,
-            "high_availability_mode": consts.HighAvailabilityMode.NONE,
-            "user_managed_networking": True,
-            "vip_dhcp_allocation": False,
-            "openshift_version": consts.OpenshiftVersion.VERSION_4_8.value,
-            "master_memory": resources.DEFAULT_MASTER_SNO_MEMORY,
-            "master_vcpu": resources.DEFAULT_MASTER_SNO_CPU,
-        },
-        (("network_type", consts.NetworkType.OVNKubernetes),): {
-            "vip_dhcp_allocation": False,
-        },
-        (("is_ipv4", True), ("is_ipv6", False),): {
-            "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV4,
-            "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV4,
-        },
-        (("is_ipv4", False), ("is_ipv6", True),): {
-            "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV6,
-            "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV6,
-            "vip_dhcp_allocation": False,
-            "openshift_version": consts.OpenshiftVersion.VERSION_4_8.value,
-            "network_type": consts.NetworkType.OVNKubernetes,
-        },
-        (("is_ipv4", True), ("is_ipv6", True),): {
-            "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV4V6,
-            "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV4V6,
-            "network_type": consts.NetworkType.OVNKubernetes,
-        },
-    }
-)
+from test_infra.utils.global_variables.triggerable import Triggerable
 
 
-class GlobalVariables(_EnvVariablesDefaults):
-    _triggered: ClassVar[List[str]] = list()
-
+class GlobalVariables(_EnvVariablesDefaults, Triggerable):
     def __post_init__(self):
         super().__post_init__()
         client = None
@@ -61,24 +15,10 @@ class GlobalVariables(_EnvVariablesDefaults):
             with suppress(RuntimeError, TimeoutError):
                 client = self.get_api_client()
         self._set("openshift_version", utils.get_openshift_version(allow_default=True, client=client))
+        self.trigger(self.get_default_triggers())
 
-        for conditions, values in _triggers.items():
-            assert isinstance(conditions, tuple) and all(
-                isinstance(condition, tuple) for condition in conditions
-            ), f"Key {conditions} must be tuple of tuples"
-
-            if all(self.is_set(param, expected_value) for param, expected_value in conditions):
-                self._handle_trigger(conditions, values)
-
-    def is_set(self, var, expected_value):
-        return getattr(self, var) == expected_value
-
-    def _handle_trigger(self, conditions, values):
-        for k, v in values.items():
-            self._set(k, v)
-
-        self._triggered.append(conditions)
-        log.info(f"{conditions} is triggered. Updating global variables: {values}")
+    def _set(self, key: str, value: Any):
+        _EnvVariablesDefaults._set(self, key, value)
 
     def __getattribute__(self, item):
         try:

--- a/discovery-infra/test_infra/utils/global_variables/triggerable.py
+++ b/discovery-infra/test_infra/utils/global_variables/triggerable.py
@@ -1,0 +1,79 @@
+from abc import ABC, abstractmethod
+from copy import copy
+from typing import Any, Dict, Tuple
+
+from frozendict import frozendict
+from logger import log
+from test_infra.consts import NetworkType, consts, resources
+
+_default_triggers = frozendict(
+    {
+        (("platform", consts.Platforms.NONE),): {
+            "user_managed_networking": True,
+            "vip_dhcp_allocation": False,
+        },
+        (("platform", consts.Platforms.VSPHERE),): {
+            "user_managed_networking": False,
+        },
+        (("masters_count", 1),): {
+            "workers_count": 0,
+            "nodes_count": 1,
+            "high_availability_mode": consts.HighAvailabilityMode.NONE,
+            "user_managed_networking": True,
+            "vip_dhcp_allocation": False,
+            "openshift_version": consts.OpenshiftVersion.VERSION_4_8.value,
+            "master_memory": resources.DEFAULT_MASTER_SNO_MEMORY,
+            "master_vcpu": resources.DEFAULT_MASTER_SNO_CPU,
+        },
+        (("network_type", consts.NetworkType.OVNKubernetes),): {
+            "vip_dhcp_allocation": False,
+        },
+        (("is_ipv4", True), ("is_ipv6", False),): {
+            "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV4,
+            "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV4,
+        },
+        (("is_ipv4", False), ("is_ipv6", True),): {
+            "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV6,
+            "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV6,
+            "vip_dhcp_allocation": False,
+            "openshift_version": consts.OpenshiftVersion.VERSION_4_8.value,
+            "network_type": consts.NetworkType.OVNKubernetes,
+        },
+        (("is_ipv4", True), ("is_ipv6", True),): {
+            "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV4V6,
+            "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV4V6,
+            "network_type": consts.NetworkType.OVNKubernetes,
+        },
+        (("network_type", NetworkType.OVNKubernetes),): {"vip_dhcp_allocation": False},
+    }
+)
+
+
+class Triggerable(ABC):
+    @classmethod
+    def get_default_triggers(cls) -> Dict[Tuple[Tuple[str, Any]], Dict[str, Any]]:
+        return copy(_default_triggers)
+
+    def trigger(self, triggers: Dict[Tuple[Tuple[str, Any]], Dict[str, Any]] = None):
+        if triggers is None:
+            triggers = self.get_default_triggers()
+
+        for conditions, values in triggers.items():
+            assert isinstance(conditions, tuple) and all(
+                isinstance(condition, tuple) for condition in conditions
+            ), f"Key {conditions} must be tuple of tuples"
+
+            if all(self._is_set(param, expected_value) for param, expected_value in conditions):
+                self._handle_trigger(conditions, values)
+
+    def _is_set(self, var, expected_value):
+        return getattr(self, var, None) == expected_value
+
+    def _handle_trigger(self, conditions: Tuple[Tuple[str, Any]], values: Dict[str, Any]) -> None:
+        for k, v in values.items():
+            self._set(k, v)
+        log.info(f"{conditions} is triggered. Updating global variables: {values}")
+
+    @abstractmethod
+    def _set(self, key: str, value: Any):
+        pass

--- a/discovery-infra/tests/test_e2e_install.py
+++ b/discovery-infra/tests/test_e2e_install.py
@@ -19,6 +19,7 @@ class TestInstall(BaseTest):
             with suppress(FixtureLookupError):
                 setattr(config, fixture_name, request.getfixturevalue(fixture_name))
 
+        config.trigger()
         return config
 
     @JunitTestSuite()


### PR DESCRIPTION
Fix flaky networking test,
Fixes in this PR:

-  It's seems like the API returns MAC address that are not yet available on libvirt, so now the test is waiting for all test-infra nodes to have MAC and IP address before setting hostnames and roles
- Fix `VIP DHCP allocation is not supported when the cluster is configured to use OVNKubernetes` error message by adding trigger that set `vip_dhcp_allocation` to False when `OVNKubernetes` is selected
- Fix triggering mechanism not working with pytest parametrize

https://prow.ci.openshift.org/job-history/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-networking-periodic

/cc @tsorya @osherdp 