### PR TITLE
Refactor terraform templates to use baremetal_host module

### DIFF
--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -74,7 +74,8 @@ def set_tf_config(cluster_name):
     tf_folder = utils.get_tf_folder(cluster_name, args.namespace)
     utils.recreate_folder(tf_folder)
 
-    utils.copy_template_tree(tf_folder, is_none_platform_mode())
+    utils.copy_template_tree(tf_folder)
+    baremetal_template = os.path.join(tf_folder, "baremetal")
 
     machine_net = MachineNetwork(args.ipv4, args.ipv6, args.vm_network_cidr, args.vm_network_cidr6, args.ns_index)
     default_image_path = os.path.join(consts.IMAGE_FOLDER, f'{args.namespace}-installer-image.iso')
@@ -83,7 +84,7 @@ def set_tf_config(cluster_name):
         storage_path=args.storage_path,
         master_count=args.master_count,
         nodes_details=nodes_details,
-        tf_folder=tf_folder,
+        tf_folder=baremetal_template,
         machine_net=machine_net
     )
 
@@ -567,8 +568,10 @@ def nodes_flow(
 # If install cluster is set , it will run install cluster command and wait till all nodes will be in installing status
 def nodes_flow_kube_api(cluster_name, machine_net, cluster_deployment, agent_cluster_install):
     tf_folder = utils.get_tf_folder(cluster_name, args.namespace)
-    nodes_details = utils.get_tfvars(tf_folder)
-    tf = terraform_utils.TerraformUtils(working_dir=tf_folder)
+    baremetal_template = os.path.join(tf_folder, "baremetal")
+
+    nodes_details = utils.get_tfvars(baremetal_template)
+    tf = terraform_utils.TerraformUtils(working_dir=baremetal_template)
     is_ipv4 = machine_net.has_ip_v4 or not machine_net.has_ip_v6
     nodes_number = args.master_count + args.number_of_workers
 

--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -75,7 +75,7 @@ def set_tf_config(cluster_name):
     utils.recreate_folder(tf_folder)
 
     utils.copy_template_tree(tf_folder)
-    baremetal_template = os.path.join(tf_folder, "baremetal")
+    baremetal_template = os.path.join(tf_folder, consts.Platforms.BARE_METAL)
 
     machine_net = MachineNetwork(args.ipv4, args.ipv6, args.vm_network_cidr, args.vm_network_cidr6, args.ns_index)
     default_image_path = os.path.join(consts.IMAGE_FOLDER, f'{args.namespace}-installer-image.iso')
@@ -568,7 +568,7 @@ def nodes_flow(
 # If install cluster is set , it will run install cluster command and wait till all nodes will be in installing status
 def nodes_flow_kube_api(cluster_name, machine_net, cluster_deployment, agent_cluster_install):
     tf_folder = utils.get_tf_folder(cluster_name, args.namespace)
-    baremetal_template = os.path.join(tf_folder, "baremetal")
+    baremetal_template = os.path.join(tf_folder, consts.Platforms.BARE_METAL)
 
     nodes_details = utils.get_tfvars(baremetal_template)
     tf = terraform_utils.TerraformUtils(working_dir=baremetal_template)

--- a/discovery-infra/test_infra/consts/consts.py
+++ b/discovery-infra/test_infra/consts/consts.py
@@ -32,9 +32,6 @@ DEFAULT_CLUSTER_KUBECONFIG_DIR_PATH = "build/kubeconfig"
 RELEASE_IMAGES_PATH = "assisted-service/data/default_release_images.json"
 
 TF_TEMPLATES_ROOT = "terraform_files"
-TF_TEMPLATE_BARE_METAL_FLOW = f"{TF_TEMPLATES_ROOT}/baremetal"
-TF_TEMPLATE_NONE_PLATFORM_FLOW = f"{TF_TEMPLATES_ROOT}/none"
-TF_TEMPLATE_BARE_METAL_INFRA_ENV_FLOW = f"{TF_TEMPLATES_ROOT}/baremetal_infra_env"
 TF_NETWORK_POOL_PATH = "/tmp/tf_network_pool.json"
 
 # Timeouts

--- a/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -52,12 +52,12 @@ class TerraformController(LibvirtController):
         utils.copy_template_tree(tf_folder)
 
         if platform == consts.Platforms.NONE:
-            return os.path.join(tf_folder, "none")
+            return os.path.join(tf_folder, consts.Platforms.NONE)
 
         if isinstance(self._entity_config, BaseInfraEnvConfig):
             return os.path.join(tf_folder, "baremetal_infra_env")
 
-        return os.path.join(tf_folder, "baremetal")
+        return os.path.join(tf_folder, consts.Platforms.BARE_METAL)
 
     # TODO move all those to conftest and pass it as kwargs
     # TODO-2 Remove all parameters defaults after moving to new workflow and use config object instead

--- a/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/discovery-infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -49,12 +49,15 @@ class TerraformController(LibvirtController):
         tf_folder = utils.get_tf_folder(name)
         logging.info("Creating %s as terraform folder", tf_folder)
         utils.recreate_folder(tf_folder)
-        utils.copy_template_tree(
-            tf_folder,
-            none_platform_mode=(platform == consts.Platforms.NONE),
-            is_infra_env=isinstance(self._entity_config, BaseInfraEnvConfig),
-        )
-        return tf_folder
+        utils.copy_template_tree(tf_folder)
+
+        if platform == consts.Platforms.NONE:
+            return os.path.join(tf_folder, "none")
+
+        if isinstance(self._entity_config, BaseInfraEnvConfig):
+            return os.path.join(tf_folder, "baremetal_infra_env")
+
+        return os.path.join(tf_folder, "baremetal")
 
     # TODO move all those to conftest and pass it as kwargs
     # TODO-2 Remove all parameters defaults after moving to new workflow and use config object instead

--- a/discovery-infra/test_infra/tools/static_network.py
+++ b/discovery-infra/test_infra/tools/static_network.py
@@ -19,7 +19,7 @@ def generate_macs(count: int) -> List[str]:
 
 
 def generate_day2_static_network_data_from_tf(tf_folder: str, num_day2_workers: int) -> List[Dict[str, List[dict]]]:
-    tfvars_json_file = os.path.join(tf_folder, consts.TFVARS_JSON_NAME)
+    tfvars_json_file = os.path.join(tf_folder, "baremetal", consts.TFVARS_JSON_NAME)
     with open(tfvars_json_file) as _file:
         tfvars = json.load(_file)
 
@@ -43,7 +43,7 @@ def generate_day2_static_network_data_from_tf(tf_folder: str, num_day2_workers: 
 
 
 def generate_static_network_data_from_tf(tf_folder: str) -> List[Dict[str, List[dict]]]:
-    tfvars_json_file = os.path.join(tf_folder, consts.TFVARS_JSON_NAME)
+    tfvars_json_file = os.path.join(tf_folder, "baremetal", consts.TFVARS_JSON_NAME)
     with open(tfvars_json_file) as _file:
         tfvars = json.load(_file)
 

--- a/discovery-infra/test_infra/tools/static_network.py
+++ b/discovery-infra/test_infra/tools/static_network.py
@@ -19,7 +19,7 @@ def generate_macs(count: int) -> List[str]:
 
 
 def generate_day2_static_network_data_from_tf(tf_folder: str, num_day2_workers: int) -> List[Dict[str, List[dict]]]:
-    tfvars_json_file = os.path.join(tf_folder, "baremetal", consts.TFVARS_JSON_NAME)
+    tfvars_json_file = os.path.join(tf_folder, consts.Platforms.BARE_METAL, consts.TFVARS_JSON_NAME)
     with open(tfvars_json_file) as _file:
         tfvars = json.load(_file)
 
@@ -43,7 +43,7 @@ def generate_day2_static_network_data_from_tf(tf_folder: str, num_day2_workers: 
 
 
 def generate_static_network_data_from_tf(tf_folder: str) -> List[Dict[str, List[dict]]]:
-    tfvars_json_file = os.path.join(tf_folder, "baremetal", consts.TFVARS_JSON_NAME)
+    tfvars_json_file = os.path.join(tf_folder, consts.Platforms.BARE_METAL, consts.TFVARS_JSON_NAME)
     with open(tfvars_json_file) as _file:
         tfvars = json.load(_file)
 

--- a/discovery-infra/test_infra/utils/kubeapi_utils.py
+++ b/discovery-infra/test_infra/utils/kubeapi_utils.py
@@ -65,7 +65,7 @@ def get_libvirt_nodes_from_tf_state(network_names: Union[List[str], Tuple[str]],
 
 def get_nodes_details(cluster_name, namespace, tf):
     tf_folder = utils.get_tf_folder(cluster_name, namespace)
-    baremetal_template = os.path.join(tf_folder, "baremetal")
+    baremetal_template = os.path.join(tf_folder, consts.Platforms.BARE_METAL)
 
     tf_vars = utils.get_tfvars(baremetal_template)
     networks_names = (

--- a/discovery-infra/test_infra/utils/kubeapi_utils.py
+++ b/discovery-infra/test_infra/utils/kubeapi_utils.py
@@ -1,5 +1,6 @@
 import functools
 import logging
+import os
 from ipaddress import IPv4Interface, IPv6Interface
 from typing import List, Tuple, Union
 
@@ -64,7 +65,9 @@ def get_libvirt_nodes_from_tf_state(network_names: Union[List[str], Tuple[str]],
 
 def get_nodes_details(cluster_name, namespace, tf):
     tf_folder = utils.get_tf_folder(cluster_name, namespace)
-    tf_vars = utils.get_tfvars(tf_folder)
+    baremetal_template = os.path.join(tf_folder, "baremetal")
+
+    tf_vars = utils.get_tfvars(baremetal_template)
     networks_names = (
         tf_vars["libvirt_network_name"],
         tf_vars["libvirt_secondary_network_name"],

--- a/discovery-infra/test_infra/utils/utils.py
+++ b/discovery-infra/test_infra/utils/utils.py
@@ -360,7 +360,9 @@ def extract_nodes_from_tf_state(tf_state, network_names, role):
     :tags: QE
     """
     data = {}
-    for domains in [r["instances"] for r in tf_state.resources if r["type"] == "libvirt_domain" and role in r["name"]]:
+    for domains in [
+        r["instances"] for r in tf_state.resources if r["type"] == "libvirt_domain" and role in r["module"]
+    ]:
         for d in domains:
             for nic in d["attributes"]["network_interface"]:
 
@@ -504,15 +506,8 @@ def get_openshift_release_image(allow_default=True):
     return release_image
 
 
-def copy_template_tree(dst, none_platform_mode=False, is_infra_env=False):
-    copy_tree(
-        src=consts.TF_TEMPLATE_BARE_METAL_INFRA_ENV_FLOW
-        if is_infra_env
-        else consts.TF_TEMPLATE_NONE_PLATFORM_FLOW
-        if none_platform_mode
-        else consts.TF_TEMPLATE_BARE_METAL_FLOW,
-        dst=dst,
-    )
+def copy_template_tree(dst):
+    copy_tree(src=consts.TF_TEMPLATES_ROOT, dst=dst)
 
 
 @contextmanager

--- a/discovery-infra/test_infra/utils/utils.py
+++ b/discovery-infra/test_infra/utils/utils.py
@@ -506,7 +506,7 @@ def get_openshift_release_image(allow_default=True):
     return release_image
 
 
-def copy_template_tree(dst):
+def copy_template_tree(dst: str):
     copy_tree(src=consts.TF_TEMPLATES_ROOT, dst=dst)
 
 

--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -17,31 +17,6 @@ resource "libvirt_pool" "storage_pool" {
   path = "${var.libvirt_storage_pool_path}/${var.cluster_name}"
 }
 
-locals {
-  worker_names = [
-    for pair in setproduct(range(var.worker_count), range(var.worker_disk_count)) :
-      "${var.cluster_name}-worker-${pair[0]}-disk-${pair[1]}"
-  ]
-  master_names = [
-    for pair in setproduct(range(var.master_count), range(var.master_disk_count)) :
-      "${var.cluster_name}-master-${pair[0]}-disk-${pair[1]}"
-  ]
-}
-
-resource "libvirt_volume" "master" {
-  for_each       = {for idx, obj in local.master_names: idx => obj}
-  name           = each.value
-  pool           = libvirt_pool.storage_pool.name
-  size           =  var.libvirt_master_disk
-}
-
-resource "libvirt_volume" "worker" {
-  for_each       = {for idx, obj in local.worker_names: idx => obj}
-  name           = each.value
-  pool           = libvirt_pool.storage_pool.name
-  size           = var.libvirt_worker_disk
-}
-
 resource "libvirt_network" "net" {
   name = var.libvirt_network_name
   mode   = "nat"
@@ -88,7 +63,6 @@ resource "libvirt_network" "net" {
   }
 }
 
-
 resource "libvirt_network" "secondary_net" {
   name = var.libvirt_secondary_network_name
   mode   = "nat"
@@ -97,111 +71,56 @@ resource "libvirt_network" "secondary_net" {
   autostart = true
 }
 
-resource "libvirt_domain" "master" {
-  count = var.master_count
+module "masters" {
+  source            = "../baremetal_host"
+  count             = var.master_count
 
-  name = "${var.cluster_name}-master-${count.index}"
+  name              = "${var.cluster_name}-master-${count.index}"
+  memory            = var.libvirt_master_memory
+  vcpu              = var.libvirt_master_vcpu
+  running           = var.running
+  image_path        = var.image_path
+  cpu_mode          = var.master_cpu_mode
+  cluster_domain    = var.cluster_domain
 
-  memory = var.libvirt_master_memory
-  vcpu   = var.libvirt_master_vcpu
-  running = var.running
+  primary_network   = libvirt_network.net.name
+  primary_ips       = var.libvirt_master_ips[count.index]
+  primary_mac       = var.libvirt_master_macs[count.index]
 
-  dynamic "disk" {
-    for_each = {
-      for idx, disk in libvirt_volume.master : idx => disk.id if length(regexall(".*-master-${count.index}-disk-.*", disk.name)) > 0
-    }
-    content {
-      volume_id = disk.value
-    }
-  }
+  secondary_network = libvirt_network.secondary_net.name
+  secondary_ips     = var.libvirt_secondary_master_ips[count.index]
+  secondary_mac     = var.libvirt_secondary_master_macs[count.index]
 
-  disk {
-    file = var.image_path
-  }
-
-  console {
-    type        = "pty"
-    target_port = 0
-  }
-
-  cpu = {
-    mode = var.master_cpu_mode
-  }
-
-  network_interface {
-    network_name = libvirt_network.net.name
-    hostname   = "${var.cluster_name}-master-${count.index}.${var.cluster_domain}"
-    addresses  = var.libvirt_master_ips[count.index]
-    mac = var.libvirt_master_macs[count.index]
-  }
-   
-  network_interface {
-    network_name = libvirt_network.secondary_net.name
-    addresses = var.libvirt_secondary_master_ips[count.index]
-    mac = var.libvirt_secondary_master_macs[count.index]
-  }
-
-  boot_device{
-    dev = ["hd", "cdrom"]
-  }
-
-  xml {
-    xslt = file("consolemodel.xsl")
-  }
+  pool              = libvirt_pool.storage_pool.name
+  disk_base_name    = "${var.cluster_name}-master-${count.index}"
+  disk_size         = var.libvirt_master_disk
+  disk_count        = var.master_disk_count
 }
 
+module "workers" {
+  source            = "../baremetal_host"
+  count             = var.worker_count
 
-resource "libvirt_domain" "worker" {
-  count = var.worker_count
+  name              = "${var.cluster_name}-worker-${count.index}"
+  memory            = var.libvirt_worker_memory
+  vcpu              = var.libvirt_worker_vcpu
+  running           = var.running
+  image_path        = var.image_path
+  cpu_mode          = var.worker_cpu_mode
+  cluster_domain    = var.cluster_domain
 
-  name = "${var.cluster_name}-worker-${count.index}"
+  primary_network   = libvirt_network.net.name
+  primary_ips       = var.libvirt_worker_ips[count.index]
+  primary_mac       = var.libvirt_worker_macs[count.index]
 
-  memory = var.libvirt_worker_memory
-  vcpu   = var.libvirt_worker_vcpu
-  running = var.running
+  secondary_network = libvirt_network.secondary_net.name
+  secondary_ips     = var.libvirt_secondary_worker_ips[count.index]
+  secondary_mac     = var.libvirt_secondary_worker_macs[count.index]
 
-  dynamic "disk" {
-    for_each = {
-      for idx, disk in libvirt_volume.worker : idx => disk.id if length(regexall(".*-worker-${count.index}-disk-.*", disk.name)) > 0
-    }
-    content {
-      volume_id = disk.value
-    }
-  }
-
-  disk {
-    file = var.image_path
-  }
-
-  console {
-    type        = "pty"
-    target_port = 0
-  }
-
-  cpu = {
-    mode = var.worker_cpu_mode
-  }
-
-  network_interface {
-    network_name = libvirt_network.net.name
-    hostname   = "${var.cluster_name}-worker-${count.index}.${var.cluster_domain}"
-    addresses  = var.libvirt_worker_ips[count.index]
-    mac = var.libvirt_worker_macs[count.index]
-  }
-
-  network_interface {
-    network_name = libvirt_network.secondary_net.name
-    addresses  = var.libvirt_secondary_worker_ips[count.index]
-    mac = var.libvirt_secondary_worker_macs[count.index]
-  }
-
-  boot_device{
-    dev = ["hd", "cdrom"]
-  }
-
-  xml {
-    xslt = file("consolemodel.xsl")
-  }
+  pool              = libvirt_pool.storage_pool.name
+  disk_base_name    = "${var.cluster_name}-worker-${count.index}"
+  disk_size         = var.libvirt_worker_disk
+  disk_count        = var.worker_disk_count
 }
 
 # Define DNS entries
@@ -209,7 +128,7 @@ resource "libvirt_domain" "worker" {
 # the count directive to include/exclude elements
 
 data "libvirt_network_dns_host_template" "api" {
-  # API VIP is always present. A value is set by the installation flow that updates 
+  # API VIP is always present. A value is set by the installation flow that updates
   # either the single node IP or API VIP, depending on the scenario
   count    = 1
   ip       = var.bootstrap_in_place ? var.single_node_ip : var.api_vip

--- a/terraform_files/baremetal_host/consolemodel.xsl
+++ b/terraform_files/baremetal_host/consolemodel.xsl
@@ -1,0 +1,18 @@
+<?xml version="1.0" ?>
+<xsl:stylesheet version="1.0"
+                xmlns:xsl="http://www.w3.org/1999/XSL/Transform">
+  <xsl:output omit-xml-declaration="yes" indent="yes"/>
+  <xsl:template match="node()|@*">
+     <xsl:copy>
+       <xsl:apply-templates select="node()|@*"/>
+     </xsl:copy>
+  </xsl:template>
+
+  <xsl:template match="/domain/devices/console">
+      <xsl:copy>
+        <xsl:copy-of select="@*"/>
+        <xsl:copy-of select="node()"/>
+        <log file="/var/log/libvirt/qemu/{/domain/name}-console.log" append="on"/>
+      </xsl:copy>
+  </xsl:template>
+</xsl:stylesheet>

--- a/terraform_files/baremetal_host/main.tf
+++ b/terraform_files/baremetal_host/main.tf
@@ -1,0 +1,73 @@
+terraform {
+  required_providers {
+    libvirt = {
+      source = "dmacvicar/libvirt"
+      version = "0.6.9"
+    }
+  }
+}
+
+locals {
+  disk_names = [
+    for index in range(var.disk_count):
+      "${var.disk_base_name}-disk-${index}"
+  ]
+}
+
+resource "libvirt_domain" "host" {
+  name = var.name
+
+  memory = var.memory
+  vcpu   = var.vcpu
+  running = var.running
+
+  dynamic "disk" {
+    for_each = {
+      for idx, disk in libvirt_volume.host : idx => disk.id if length(regexall("${var.disk_base_name}-disk-.*", disk.name)) > 0
+    }
+    content {
+      volume_id = disk.value
+    }
+  }
+
+  disk {
+    file = var.image_path
+  }
+
+  console {
+    type        = "pty"
+    target_port = 0
+  }
+
+  cpu = {
+    mode = var.cpu_mode
+  }
+
+  network_interface {
+    network_name = var.primary_network
+    hostname   = "${var.name}.${var.cluster_domain}"
+    addresses  = var.primary_ips
+    mac = var.primary_mac
+  }
+
+  network_interface {
+    network_name = var.secondary_network
+    addresses  = var.secondary_ips
+    mac = var.secondary_mac
+  }
+
+  boot_device{
+    dev = ["hd", "cdrom"]
+  }
+
+  xml {
+    xslt = file("consolemodel.xsl")
+  }
+}
+
+resource "libvirt_volume" "host" {
+  for_each = {for idx, obj in local.disk_names: idx => obj}
+  name     = each.value
+  pool     = var.pool
+  size     = var.disk_size
+}

--- a/terraform_files/baremetal_host/variables.tf
+++ b/terraform_files/baremetal_host/variables.tf
@@ -1,0 +1,92 @@
+variable "name" {
+  type        = string
+  description = "Identifying name for the host."
+}
+
+variable "memory" {
+  type        = number
+  description = "RAM in MiB allocated to the host."
+}
+
+variable "vcpu" {
+  type        = number
+  description = "Number of virtual cores allocated to the host."
+}
+
+variable "running" {
+  type        = bool
+  description = "Whether or not letting the host start running right away after its creation."
+}
+
+variable "image_path" {
+  type        = string
+  description = "Live CD image that should be booted from if hard disk is not bootable."
+}
+
+variable "cpu_mode" {
+  type        = string
+  description = "How CPU model of the libvirt guest should be configured."
+  default     = "host-passthrough"
+}
+
+variable "cluster_domain" {
+  type        = string
+  description = "The domain for the cluster that all DNS records must belong."
+}
+
+variable "primary_network" {
+  type        = string
+  description = "Name of the libvirt network that should act as the node's primary network."
+  default     = ""
+}
+
+variable "primary_ips" {
+  type        = list(string)
+  description = "IP addresses to assign to the host in the primary network."
+  default     = []
+}
+
+variable "primary_mac" {
+  type        = string
+  description = "MAC address to assign to the host in the primary network."
+  default     = ""
+}
+
+variable "secondary_network" {
+  type        = string
+  description = "Name of the libvirt network that should act as the node's secondary network."
+  default     = ""
+}
+
+variable "secondary_ips" {
+  type        = list(string)
+  description = "IP addresses to assign to the host in the secondary network."
+  default     = []
+}
+
+variable "secondary_mac" {
+  type        = string
+  description = "MAC address to assign to the host in the secondary network."
+  default     = ""
+}
+
+variable "pool" {
+  type        = string
+  description = "Pool name to be used."
+}
+
+variable "disk_base_name" {
+  type        = string
+  description = "Prefix name to be used for namespacing disks."
+}
+
+variable "disk_size" {
+  type        = number
+  description = "Disk space in MiB allocated to the host."
+}
+
+variable "disk_count" {
+  type        = number
+  description = "Number of disks to attach to the host."
+  default     = 1
+}


### PR DESCRIPTION
Currently we have a couple of terraform templates, each for a different installation flow:
* One for most scenarios, including (but not limited) to: ipv4, ipv6, static-networking, defining multiple disks for olm operators like lso, bootstrap-in-place mode for installing SNO just via openshift installer, and more
* None platform scenario. In this case it has a different networking structure where masters and workers are split between several L3 networks
* infra-env template for late-binding scenarios

This PR should remove some of the existing duplication by creating a module for baremetal hosts, and including it in the larger template.
It (currently) doesn't solve some of the duplication that we have regarding networks, DNS configuration etc., but that should be a good start either way.