### PR TITLE
NO-ISSUE: disable VIP DHCP allocation when using OVNKubernetes

### DIFF
--- a/discovery-infra/test_infra/utils/global_variables/global_variables.py
+++ b/discovery-infra/test_infra/utils/global_variables/global_variables.py
@@ -28,6 +28,9 @@ _triggers = frozendict(
             "master_memory": resources.DEFAULT_MASTER_SNO_MEMORY,
             "master_vcpu": resources.DEFAULT_MASTER_SNO_CPU,
         },
+        (("network_type", consts.NetworkType.OVNKubernetes),): {
+            "vip_dhcp_allocation": False,
+        },
         (("is_ipv4", True), ("is_ipv6", False),): {
             "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV4,
             "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV4,


### PR DESCRIPTION
When using ``NETWORK_TYPE=OVNKubernetes`` the cluster cannot become ready.
That leaves the cluster in a state that has no apparent affect, so we should change the default mode we're working with.

/cc @eliorerz 