### PR TITLE
NO-ISSUE: capture stdout and stderr on terraform failure

### DIFF
--- a/discovery-infra/test_infra/tools/terraform_utils.py
+++ b/discovery-infra/test_infra/tools/terraform_utils.py
@@ -23,7 +23,7 @@ class TerraformUtils:
             self.init_tf()
 
     def init_tf(self) -> None:
-        self.tf.cmd("init", raise_on_error=True)
+        self.tf.cmd("init", raise_on_error=True, capture_output=True)
 
     def select_defined_variables(self, **kwargs):
         supported_variables = self.get_variable_list()


### PR DESCRIPTION
Without ``capture_output=True`` the returned error do not contain stdout and stderr of the failing command.
Adding that to have more verbosity when errors occur.
/cc @lalon4 @eliorerz 