### PR TITLE
NO-ISSUE: fix static IP mode after terraform refactoring

### DIFF
--- a/discovery-infra/day2.py
+++ b/discovery-infra/day2.py
@@ -59,7 +59,8 @@ def execute_day2_flow(cluster_id, args, day2_type_flag, has_ipv6):
         f'{args.namespace}-installer-image.iso'
     )
 
-    tf_folder = utils.get_tf_folder(terraform_cluster_dir_prefix, args.namespace)
+    tf_folder = os.path.join(utils.get_tf_folder(terraform_cluster_dir_prefix, args.namespace),
+                             consts.Platforms.BARE_METAL)
     set_day2_tf_configuration(tf_folder, args.number_of_day2_workers, api_vip_ip, api_vip_dnsname)
 
     static_network_config = None

--- a/discovery-infra/start_discovery.py
+++ b/discovery-infra/start_discovery.py
@@ -666,7 +666,8 @@ def apply_static_network_config(cluster_name, kube_client):
     if not args.with_static_network_config:
         return None
 
-    tf_folder = utils.get_tf_folder(cluster_name, args.namespace)
+    tf_folder = os.path.join(utils.get_tf_folder(cluster_name, args.namespace),
+                             consts.Platforms.BARE_METAL)
     static_network_config = static_network.generate_static_network_data_from_tf(tf_folder)
     if args.kube_api:
         if args.master_count != 1:

--- a/discovery-infra/test_infra/tools/static_network.py
+++ b/discovery-infra/test_infra/tools/static_network.py
@@ -19,7 +19,7 @@ def generate_macs(count: int) -> List[str]:
 
 
 def generate_day2_static_network_data_from_tf(tf_folder: str, num_day2_workers: int) -> List[Dict[str, List[dict]]]:
-    tfvars_json_file = os.path.join(tf_folder, consts.Platforms.BARE_METAL, consts.TFVARS_JSON_NAME)
+    tfvars_json_file = os.path.join(tf_folder, consts.TFVARS_JSON_NAME)
     with open(tfvars_json_file) as _file:
         tfvars = json.load(_file)
 
@@ -43,7 +43,7 @@ def generate_day2_static_network_data_from_tf(tf_folder: str, num_day2_workers: 
 
 
 def generate_static_network_data_from_tf(tf_folder: str) -> List[Dict[str, List[dict]]]:
-    tfvars_json_file = os.path.join(tf_folder, consts.Platforms.BARE_METAL, consts.TFVARS_JSON_NAME)
+    tfvars_json_file = os.path.join(tf_folder, consts.TFVARS_JSON_NAME)
     with open(tfvars_json_file) as _file:
         tfvars = json.load(_file)
 


### PR DESCRIPTION
After refactoring on #1201, it seems like we're duplicating the ``baremetal`` template dir in the path:
```
    def generate_static_network_data_from_tf(tf_folder: str) -> List[Dict[str, List[dict]]]:
        tfvars_json_file = os.path.join(tf_folder, consts.Platforms.BARE_METAL, consts.TFVARS_JSON_NAME)
>       with open(tfvars_json_file) as _file:
E       FileNotFoundError: [Errno 2] No such file or directory: 'build/terraform/test-infra-cluster-dd1a1a93/baremetal/baremetal/terraform.tfvars.json'
```
(taken from https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-test-infra/1144/pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-networking/1455801552945025024)

This should fix the duplications.

/cc @eliorerz 
/test e2e-metal-assisted-kube-api e2e-metal-assisted-networking
/hold