### PR TITLE
Adding a retry on tf init

### DIFF
--- a/discovery-infra/test_infra/tools/terraform_utils.py
+++ b/discovery-infra/test_infra/tools/terraform_utils.py
@@ -6,7 +6,8 @@ from builtins import list
 from typing import Any, Dict, List
 
 import hcl2
-from python_terraform import IsFlagged, Terraform, Tfstate
+from retry import retry
+from python_terraform import IsFlagged, Terraform, Tfstate, TerraformCommandError
 
 
 class TerraformUtils:
@@ -22,6 +23,7 @@ class TerraformUtils:
         if terraform_init:
             self.init_tf()
 
+    @retry(exceptions=TerraformCommandError, tries=10, delay=10)
     def init_tf(self) -> None:
         self.tf.cmd("init", raise_on_error=True, capture_output=True)
 


### PR DESCRIPTION
From time to time we are failing to init tf during regression runs i.e
"Failed to\nrequest discovery document: Get\n"https://registry.terraform.io/.well-known/terraform.json": dial tcp: lookup\nregistry.terraform.io on 127.0.0.1:53: read udp 127.0.0.1:53546->127.0.0.1:53:\ni/o timeout\n\x1b[0m\x1b[0m\n'"

This PR add a retry on tf init.
We have same retry on other flows in our QE Jenkins and seems like this retry helps to reduce the occurrence of such failure