### PR TITLE
MGMT-7977 - Move test-infra events from Cluster to separate object

### DIFF
--- a/discovery-infra/test_infra/helper_classes/cluster.py
+++ b/discovery-infra/test_infra/helper_classes/cluster.py
@@ -24,6 +24,7 @@ from test_infra.controllers.node_controllers import Node
 from test_infra.helper_classes.cluster_host import ClusterHost
 from test_infra.helper_classes.config import BaseClusterConfig, BaseInfraEnvConfig
 from test_infra.helper_classes.entity import Entity
+from test_infra.helper_classes.events_handler import EventsHandler
 from test_infra.helper_classes.infra_env import InfraEnv
 from test_infra.helper_classes.nodes import Nodes
 from test_infra.tools import static_network, terraform_utils
@@ -33,7 +34,7 @@ from test_infra.utils.entity_name import ClusterName
 
 class Cluster(Entity):
     MINIMUM_NODES_TO_WAIT = 1
-    EVENTS_THRESHOLD = 500
+    EVENTS_THRESHOLD = 500  # TODO - remove EVENTS_THRESHOLD after removing it from kni-assisted-installer-auto
 
     _config: BaseClusterConfig
 
@@ -950,7 +951,12 @@ class Cluster(Entity):
         cluster.wait_for_ready_to_install()
 
     def get_events(self, host_id="", infra_env_id=""):
-        return self.api_client.get_events(cluster_id=self.id, host_id=host_id, infra_env_id=infra_env_id)
+        warnings.warn(
+            "Cluster.get_events is now deprecated, use EventsHandler.get_events instead",
+            PendingDeprecationWarning,
+        )
+        handler = EventsHandler(self.api_client)
+        return handler.get_events(host_id, self.id, infra_env_id)
 
     def _configure_load_balancer(self):
         main_cidr = self.get_primary_machine_cidr()
@@ -973,32 +979,15 @@ class Cluster(Entity):
         matcher = re.match(r"^tt(\d+)$", libvirt_network_if)
         return int(matcher.groups()[0]) if matcher is not None else 0
 
-    def _find_event(self, event_to_find, reference_time, params_list, host_id, infra_env_id):
-        events_list = self.get_events(host_id=host_id, infra_env_id=infra_env_id)
-        for event in events_list:
-            if event_to_find in event["message"]:
-                # Adding a 2 sec buffer to account for a small time diff between the machine and the time on staging
-                if utils.to_utc(event["event_time"]) >= reference_time - 2:
-                    if all(param in event["message"] for param in params_list):
-                        log.info(f"Event to find: {event_to_find} exists with its params")
-                        return True
-        else:
-            return False
-
     def wait_for_event(self, event_to_find, reference_time, params_list=None, host_id="", infra_env_id="", timeout=10):
-        log.info(f"Searching for event: {event_to_find}")
-        if params_list is None:
-            params_list = list()
-        try:
-            waiting.wait(
-                lambda: self._find_event(event_to_find, reference_time, params_list, host_id, infra_env_id),
-                timeout_seconds=timeout,
-                sleep_seconds=2,
-                waiting_for=f"Event: {event_to_find}",
-            )
-        except waiting.exceptions.TimeoutExpired:
-            log.error(f"Event: {event_to_find} didn't found")
-            raise
+        warnings.warn(
+            "Cluster.wait_for_event is now deprecated, use EventsHandler.wait_for_event instead",
+            PendingDeprecationWarning,
+        )
+        handler = EventsHandler(self.api_client)
+        return handler.wait_for_event(
+            event_to_find, reference_time, params_list, host_id, infra_env_id, self.id, timeout
+        )
 
     @staticmethod
     def get_inventory_host_nics_data(host: dict, ipv4_first=True):

--- a/discovery-infra/test_infra/helper_classes/events_handler.py
+++ b/discovery-infra/test_infra/helper_classes/events_handler.py
@@ -1,0 +1,54 @@
+from typing import List
+
+import waiting
+from logger import log
+from test_infra.assisted_service_api import InventoryClient
+from test_infra.utils import utils
+
+
+class EventsHandler:
+    def __init__(self, api_client: InventoryClient):
+        self.api_client = api_client
+
+    def _find_event(
+        self,
+        event_to_find: str,
+        reference_time: int,
+        params_list: List[str] = None,
+        host_id: str = "",
+        infra_env_id: str = "",
+        cluster_id: str = "",
+    ):
+        events_list = self.get_events(host_id=host_id, cluster_id=cluster_id, infra_env_id=infra_env_id)
+        for event in events_list:
+            if event_to_find not in event["message"]:
+                continue
+            # Adding a 2 sec buffer to account for a small time diff between the machine and the time on staging
+            if utils.to_utc(event["event_time"]) >= reference_time - 2:
+                if all(param in event["message"] for param in params_list):
+                    log.info(f"Event to find: {event_to_find} exists with its params")
+                    return True
+        return False
+
+    def get_events(self, host_id: str = "", cluster_id: str = "", infra_env_id: str = ""):
+        return self.api_client.get_events(cluster_id=cluster_id, host_id=host_id, infra_env_id=infra_env_id)
+
+    def wait_for_event(
+        self,
+        event_to_find: str,
+        reference_time: int,
+        params_list: List[str] = None,
+        host_id: str = "",
+        infra_env_id: str = "",
+        cluster_id: str = "",
+        timeout: int = 10,
+    ):
+        log.info(f"Searching for event: {event_to_find}")
+        if params_list is None:
+            params_list = list()
+        waiting.wait(
+            lambda: self._find_event(event_to_find, reference_time, params_list, host_id, infra_env_id, cluster_id),
+            timeout_seconds=timeout,
+            sleep_seconds=2,
+            waiting_for=f"event {event_to_find}",
+        )

--- a/discovery-infra/test_infra/helper_classes/nodes.py
+++ b/discovery-infra/test_infra/helper_classes/nodes.py
@@ -4,7 +4,7 @@ import random
 from typing import Dict, Iterator, List
 
 import waiting
-from logger import log, SuppressAndLog
+from logger import SuppressAndLog, log
 from munch import Munch
 from test_infra.consts import consts
 from test_infra.controllers.node_controllers.node import Node

--- a/discovery-infra/test_infra/tools/terraform_utils.py
+++ b/discovery-infra/test_infra/tools/terraform_utils.py
@@ -6,8 +6,8 @@ from builtins import list
 from typing import Any, Dict, List
 
 import hcl2
+from python_terraform import IsFlagged, Terraform, TerraformCommandError, Tfstate
 from retry import retry
-from python_terraform import IsFlagged, Terraform, Tfstate, TerraformCommandError
 
 
 class TerraformUtils:

--- a/discovery-infra/tests/base_test.py
+++ b/discovery-infra/tests/base_test.py
@@ -30,6 +30,7 @@ from test_infra.helper_classes.cluster import Cluster
 from test_infra.helper_classes.config import BaseTerraformConfig
 from test_infra.helper_classes.config.controller_config import BaseNodeConfig
 from test_infra.helper_classes.config.vsphere_config import VSphereControllerConfig
+from test_infra.helper_classes.events_handler import EventsHandler
 from test_infra.helper_classes.infra_env import InfraEnv
 from test_infra.helper_classes.kube_helpers import KubeAPIContext, create_kube_api_client
 from test_infra.helper_classes.nodes import Nodes
@@ -220,6 +221,10 @@ class BaseTest:
     def teardown_nat(nat: NatController) -> None:
         if global_variables.test_teardown and nat:
             nat.remove_nat_rules()
+
+    @pytest.fixture
+    def events_handler(self, api_client: InventoryClient) -> EventsHandler:
+        yield EventsHandler(api_client)
 
     @pytest.fixture
     @JunitFixtureTestCase()


### PR DESCRIPTION
See https://github.com/openshift/assisted-test-infra/pull/1153 for more information and motivation
/cc @osherdp

FYI @nshidlin @lalon4 
Deprecated methods on this PR:

1. `Cluster.get_events` - Now can be used as part of `EventsHandler`, note that cluster_id is no longer part of this class.
2. `Cluster.wait_for_event` - Now can be used as part of `EventsHandler`, note that cluster_id is no longer part of this class.
3. `Cluster.EVENTS_THRESHOLD` - Will permanently be removed after will no longer be in use (if needed on specific test - it can be declared there)