### PR TITLE
MGMT-8193 - Remove download_image logic from assisted_service_api.py and use infra_env.download_url to download it

### DIFF
--- a/discovery-infra/test_infra/assisted_service_api.py
+++ b/discovery-infra/test_infra/assisted_service_api.py
@@ -166,6 +166,12 @@ class InventoryClient(object):
 
     @classmethod
     def _download(cls, response: HTTPResponse, file_path: str, verify_file_size=False) -> None:
+        warnings.warn(
+            "_download is deprecated and soon will be deleted. "
+            "Use infra_env.download_image or cluster.download_image instead.",
+            DeprecationWarning,
+        )
+
         with open(file_path, "wb") as f:
             shutil.copyfileobj(response, f)
         if verify_file_size:
@@ -194,6 +200,12 @@ class InventoryClient(object):
 
     @retry(exceptions=RuntimeError, tries=2, delay=3)
     def download_image(self, cluster_id: str, image_path: str) -> None:
+        warnings.warn(
+            "download_image is deprecated and soon will be deleted. "
+            "Use infra_env.download_image or cluster.download_image instead.",
+            DeprecationWarning,
+        )
+
         log.info("Downloading image for cluster %s to %s", cluster_id, image_path)
         response = self.client.download_cluster_iso_with_http_info(cluster_id=cluster_id, _preload_content=False)
         response_obj = response[0]
@@ -207,6 +219,12 @@ class InventoryClient(object):
         image_type: str = consts.ImageType.FULL_ISO,
         static_network_config: Optional[list] = None,
     ):
+        warnings.warn(
+            "generate_and_download_image is deprecated and soon will be deleted. "
+            "Use infra_env.download_image or cluster.generate_and_download_image instead.",
+            DeprecationWarning,
+        )
+
         self.generate_image(
             cluster_id=cluster_id, ssh_key=ssh_key, image_type=image_type, static_network_config=static_network_config
         )
@@ -218,6 +236,12 @@ class InventoryClient(object):
 
     @retry(exceptions=RuntimeError, tries=2, delay=3)
     def download_infraenv_image(self, infraenv_id: str, image_path: str) -> None:
+        warnings.warn(
+            "download_infraenv_image is deprecated and soon will be deleted. "
+            "Use infra_env.download_image or cluster.download_image instead.",
+            DeprecationWarning,
+        )
+
         log.info("Downloading image for infra-env %s to %s", infraenv_id, image_path)
         response = self.client.download_infra_env_discovery_image_with_http_info(
             infra_env_id=infraenv_id, _preload_content=False

--- a/discovery-infra/test_infra/helper_classes/entity.py
+++ b/discovery-infra/test_infra/helper_classes/entity.py
@@ -60,7 +60,3 @@ class Entity(ABC):
     @abstractmethod
     def wait_until_hosts_are_discovered(self, nodes_count: int = None, allow_insufficient=False):
         pass
-
-    @abstractmethod
-    def download_image(self):
-        pass

--- a/discovery-infra/test_infra/helper_classes/infra_env.py
+++ b/discovery-infra/test_infra/helper_classes/infra_env.py
@@ -1,9 +1,11 @@
 import json
 import os
+from pathlib import Path
 from typing import List, Optional
 
 import test_infra.utils.waiting
 from junit_report import JunitTestCase
+from logger import log
 from test_infra import consts, utils
 from test_infra.assisted_service_api import InventoryClient, models
 from test_infra.helper_classes.config import BaseInfraEnvConfig
@@ -37,17 +39,16 @@ class InfraEnv(Entity):
         return infra_env.id
 
     @JunitTestCase()
-    def download_image(self, iso_download_path=None):
+    def download_image(self, iso_download_path: str = None) -> Path:
+        iso_download_url = self.get_details().download_url
         iso_download_path = iso_download_path or self._config.iso_download_path
 
         # ensure file path exists before downloading
         if not os.path.exists(iso_download_path):
             utils.recreate_folder(os.path.dirname(iso_download_path), force_recreate=False)
 
-        self.api_client.download_infraenv_image(
-            infraenv_id=self.id,
-            image_path=iso_download_path,
-        )
+        log.info(f"Downloading image {iso_download_url} to {iso_download_path}")
+        return utils.download_file(iso_download_url, iso_download_path)
 
     @JunitTestCase()
     def wait_until_hosts_are_discovered(self, nodes_count: int, allow_insufficient=False):

--- a/discovery-infra/test_infra/utils/utils.py
+++ b/discovery-infra/test_infra/utils/utils.py
@@ -33,6 +33,18 @@ from requests.models import HTTPError
 from retry import retry
 
 
+def download_file(url: str, local_filename: str, tries=3) -> Path:
+    @retry(exceptions=RuntimeError, tries=tries, delay=5)
+    def _download_file() -> Path:
+        with requests.get(url, stream=True) as r:
+            with open(local_filename, "wb") as f:
+                shutil.copyfileobj(r.raw, f)
+
+        return Path(local_filename)
+
+    return _download_file()
+
+
 def scan_for_free_port(starting_port: int, step: int = 200):
     for port in range(starting_port, starting_port + step):
         with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:


### PR DESCRIPTION
From [MGMT-8193](https://issues.redhat.com/browse/MGMT-8193):


> Currently whenever we need to download the discovery iso during a CI test we're using some API client which assumes we're using the download endpoint on assisted service.
> 
> When we move to the image service, that download url will no longer work and our tests will fail even though the flow for users would be unchanged.
> 
> We should be relying on the same url we present to users when we run CI (the one in the cluster image info and infraEnv).
> 

Deprecated methods in this PR:

1. `assisted_service_client._download`
2. `assisted_service_client.download_infraenv_image`
3. `assisted_service_client.download_image`

/cc @carbonin @osherdp 

FYI @lalon4 @nshidlin 
