### PR TITLE
MGMT-8181: added day2 cloud flow to e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -239,7 +239,7 @@ _run_terraform:
 		terraform apply -auto-approve -input=false -state=terraform.tfstate -state-out=terraform.tfstate -var-file=terraform.tfvars.json
 
 _apply_terraform:
-		cd build/terraform/$(CLUSTER_NAME)__$(NAMESPACE) && \
+		cd build/terraform/$(CLUSTER_NAME)/$(PLATFORM) && \
 		terraform apply -auto-approve -input=false -state=terraform.tfstate -state-out=terraform.tfstate -var-file=terraform.tfvars.json
 
 destroy_terraform:

--- a/discovery-infra/deprecated_utils.py
+++ b/discovery-infra/deprecated_utils.py
@@ -106,7 +106,11 @@ def get_libvirt_nodes_macs(network_name):
 
 
 def are_libvirt_nodes_in_cluster_hosts(client, cluster_id, num_nodes):
-    hosts_macs = client.get_hosts_id_with_macs(cluster_id)
+    try:
+        hosts_macs = client.get_hosts_id_with_macs(cluster_id)
+    except BaseException as e:
+        log.error("Failed to get nodes macs for cluster: %s", cluster_id)
+        return False
     num_macs = len([mac for mac in hosts_macs if mac != ""])
     return num_macs >= num_nodes
 

--- a/discovery-infra/test_infra/consts/env_defaults.py
+++ b/discovery-infra/test_infra/consts/env_defaults.py
@@ -3,7 +3,7 @@ from pathlib import Path
 from test_infra import consts
 
 DEFAULT_NUMBER_OF_MASTERS: int = consts.NUMBER_OF_MASTERS
-DEFAULT_DAY2_WORKERS_COUNT: int = 0
+DEFAULT_DAY2_WORKERS_COUNT: int = 1
 DEFAULT_WORKERS_COUNT: int = 0
 DEFAULT_STORAGE_POOL_PATH: Path = Path.cwd().joinpath("storage_pool")
 DEFAULT_SSH_PRIVATE_KEY_PATH: Path = Path.home() / ".ssh" / "id_rsa"

--- a/discovery-infra/tests/test_day2.py
+++ b/discovery-infra/tests/test_day2.py
@@ -1,0 +1,41 @@
+import day2
+import pytest
+from junit_report import JunitTestSuite
+from tests.base_test import BaseTest
+from tests.config import ClusterConfig, global_variables
+from types import SimpleNamespace
+
+
+class TestDay2(BaseTest):
+    @pytest.fixture
+    def new_cluster_configuration(self):
+        return self.override_cluster_configuration()
+
+    def override_cluster_configuration(self):
+        config = ClusterConfig()
+        config.cluster_id = global_variables.cluster_id
+        return config
+
+    # Install day1 cluster and deploy day2 nodes (cloud flow).
+    # Or, deploy day2 nodes on an installed cluster if CLUSTER_ID env var is specified.
+    @JunitTestSuite()
+    def test_deploy_day2_nodes_cloud(self, cluster, new_cluster_configuration: ClusterConfig):
+        if not global_variables.cluster_id:
+            cluster.prepare_for_installation()
+            cluster.start_install_and_wait_for_installed()
+
+        # TODO: Use a proper structure instead of mimicking cli options
+        args = SimpleNamespace()
+        args.api_client = cluster.api_client
+        args.pull_secret = new_cluster_configuration.pull_secret
+        args.with_static_network_config = new_cluster_configuration.is_static_ip
+        args.num_day2_workers = global_variables.num_day2_workers
+        args.ssh_key = global_variables.ssh_public_key
+        args.install_cluster = True
+
+        if new_cluster_configuration.proxy:
+            args.http_proxy = new_cluster_configuration.proxy.http_proxy
+            args.https_proxy = new_cluster_configuration.proxy.https_proxy
+            args.no_proxy = new_cluster_configuration.proxy.no_proxy
+
+        day2.execute_day2_cloud_flow(new_cluster_configuration.cluster_id, args, new_cluster_configuration.is_ipv6)


### PR DESCRIPTION
As e2e flows are now invoked using pytest, fixed day2 on cloud flow to accommodate for the new infra:
* Added test_day2.py - initialize and execute day2_cloud_flow
* Note: For simplicity, used day2.py mostly as-is. We can rewrite and move its logic into test_day2 later on. Also, should add support for the ocp flow.