### PR TITLE
NO-ISSUE: remove jira from requirements.txt as it's not being used

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,6 @@ frozendict==2.0.7
 ipdb==0.13.9
 ipython==7.11.1
 Jinja2===3.0.2
-jira==3.0.1
 junit-report==0.2.3
 kubernetes==19.15.0
 libvirt-python==7.9.0


### PR DESCRIPTION
It's probably a left-over from having triage creation in assisted-test-infra (it has been moved to assisted-installer-deployment)
/cc @eliorerz 