### PR TITLE
NO-ISSUE: Bump libgcrypt version

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -30,9 +30,9 @@ function install_libvirt() {
     if ! version_is_greater "$current_version" "$minimum_version"; then
         add_libvirt_listen_flag
     else
-        if ! rpm -qa | grep libgcrypt-1.8.5-4; then
+        if ! rpm -qa | grep libgcrypt-1.8.5-6; then
             mkdir -p build
-            curl -Lo build/libgcrypt-1.8.5-4.el8.x86_64.rpm https://rpmfind.net/linux/centos/8/BaseOS/x86_64/os/Packages/libgcrypt-1.8.5-4.el8.x86_64.rpm && sudo dnf -y install build/libgcrypt-1.8.5-4.el8.x86_64.rpm
+            curl -Lo build/libgcrypt-1.8.5-6.el8.x86_64.rpm https://rpmfind.net/linux/centos/8/BaseOS/x86_64/os/Packages/libgcrypt-1.8.5-6.el8.x86_64.rpm && sudo dnf -y install build/libgcrypt-1.8.5-6.el8.x86_64.rpm
         fi
         start_and_enable_libvirtd_tcp_socket
     fi


### PR DESCRIPTION
Bump libgcrypt version form `1.8.5-4` to `1.8.5-6` since version `1.8.5-4` can no longer be found in `rpmfind.net`:

```
$> curl --head -w "${http_code}" https://rpmfind.net/linux/centos/8/BaseOS/x86_64/os/Packages/libgcrypt-1.8.5-4.el8.x86_64.rpm
HTTP/1.1 404 Not Found
Date: Tue, 16 Nov 2021 16:14:58 GMT
Server: Apache/2.4.51 (Fedora) OpenSSL/1.1.1l
Content-Type: text/html; charset=iso-8859-1
```

But for version `1.8.5-6` it can be found:

```
$> curl --head -w "${http_code}" https://rpmfind.net/linux/centos/8/BaseOS/x86_64/os/Packages/libgcrypt-1.8.5-6.el8.x86_64.rpm
HTTP/1.1 200 OK
Date: Tue, 16 Nov 2021 16:15:35 GMT
Server: Apache/2.4.51 (Fedora) OpenSSL/1.1.1l
Last-Modified: Tue, 29 Jun 2021 20:39:30 GMT
ETag: "73a84-5c5ed9a5444c3"
Accept-Ranges: bytes
Content-Length: 473732
Content-Type: application/x-rpm
```

@osherdp can you take a look at this PR? thanks :smile: 