### PR TITLE
Changing workdir to a different directory than /

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -22,6 +22,8 @@ RUN dnf -y install \
 
 RUN curl -Lo terraform.zip https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip && unzip terraform.zip -d /usr/bin/ && rm -rf terraform.zip
 
+WORKDIR /home/assisted-test-infra
+
 COPY requirements-39.txt requirements-dev.txt ./
 COPY --from=service /clients/assisted-service-client-*.tar.gz /build/pip/
 RUN pip3 install --upgrade pip && \


### PR DESCRIPTION
When copying the whole dir of assisted-tes-infra, we get:
```
tar: ./usr/libexec/utempter/utempter: Cannot open: Permission denied
```

Meaning it tries to copy the entire root directory.
This should change the working directory of the image to a different dir.
/cc @eliorerz 