### PR TITLE
Always upgrade libgcrypt package using regular sources (#1248)

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -30,10 +30,7 @@ function install_libvirt() {
     if ! version_is_greater "$current_version" "$minimum_version"; then
         add_libvirt_listen_flag
     else
-        if ! rpm -qa | grep libgcrypt-1.8.5-4; then
-            mkdir -p build
-            curl -Lo build/libgcrypt-1.8.5-4.el8.x86_64.rpm https://rpmfind.net/linux/centos/8/BaseOS/x86_64/os/Packages/libgcrypt-1.8.5-4.el8.x86_64.rpm && sudo dnf -y install build/libgcrypt-1.8.5-4.el8.x86_64.rpm
-        fi
+        sudo dnf upgrade -y libgcrypt
         start_and_enable_libvirtd_tcp_socket
     fi
 


### PR DESCRIPTION
Basically a backport of #1248

Some fedora-like distributions come with a pretty outdated version of libgcrypt, making use of kvm unsustainable
Previously we tried installing a specific version from some source, but this source seems to remove versions from time to time which is inconvenient

This change will just make sure we upgrade the package to its latest version by using the official repositories of the distribution, which should be fine for all cases

Failing build for example:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24063/rehearse-24063-pull-ci-openshift-assisted-test-infra-v1-e2e-metal-assisted/1465295302687723520

/cc @eliorerz 