### PR TITLE
Use container command variable

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -199,16 +199,16 @@ delete_podman_localhost:
 # so it will be used by the python code to fill up load balancing definitions
 start_load_balancer:
 	@if [ "$(PLATFORM)" = "none"  ] || [ "$(START_LOAD_BALANCER)" = "true" ]; then \
-		id=`podman ps --quiet --filter "name=load_balancer"`; \
+		id=$($(CONTAINER_COMMAND) ps --quiet --filter "name=load_balancer"); \
 		( test -z "$$id" && echo "Staring load balancer ..." && \
-		podman run -d --rm --dns=127.0.0.1 --net=host --name=load_balancer \
+		$(CONTAINER_COMMAND) run -d --rm --dns=127.0.0.1 --net=host --name=load_balancer \
 			-v $(HOME)/.test-infra/etc/nginx/conf.d:/etc/nginx/conf.d \
 			quay.io/odepaz/dynamic-load-balancer:latest ) || ! test -z "$$id"; \
 	fi
 
 stop_load_balancer:
-	@id=`podman ps --quiet --filter "name=load_balancer"`; \
-	test ! -z "$$id"  && podman rm -f load_balancer; \
+	@id=$($(CONTAINER_COMMAND) ps --quiet --filter "name=load_balancer"); \
+	test ! -z "$$id"  && $(CONTAINER_COMMAND) rm -f load_balancer; \
 	rm -f  $(HOME)/.test-infra/etc/nginx/conf.d/stream.d/*.conf >& /dev/null || /bin/true
 
 


### PR DESCRIPTION
The container command is being set before invoking the rules.
The Makefile rules should be using the variable instead of an explicit
container command, as it might not be avaiable in certain systems.

Signed-off-by: Moti Asayag <masayag@redhat.com>