### PR TITLE
NO-ISSUE: Install Golang when setting up capi-provider env

### DIFF
--- a/scripts/install_golang.sh
+++ b/scripts/install_golang.sh
@@ -1,0 +1,19 @@
+#!/bin/bash
+set -euo pipefail
+
+GO_VERSION="${GO_VERSION:-1.17.4}"
+
+function install_golang() {
+    if ! [ -x "$(command -v go)" ]; then
+        echo "Installing golang..."
+        curl -s https://storage.googleapis.com/golang/go"$GO_VERSION".linux-amd64.tar.gz | tar -C /usr/local -xz
+        echo "successfully installed golang!"
+    else
+        echo "golang is already installed"
+    fi
+}
+
+install_golang
+export GOPATH=/go
+export GOCACHE=/go/.cache
+export PATH=$PATH:/usr/local/go/bin:/go/bin

--- a/scripts/setup_capi_provider_agent_env.sh
+++ b/scripts/setup_capi_provider_agent_env.sh
@@ -42,6 +42,7 @@ deploy_hypershift()
   capi/hypershift/bin/hypershift install --hypershift-image "$HYPERSHIFT_IMAGE"
 }
 
+source scripts/install_golang.sh
 mkdir -p $BASE_DIR
 deploy_provider
 deploy_hypershift


### PR DESCRIPTION
Added install_golang.sh that will install golang in case go isn't installed already
Call install_golang.sh from setup_capi_provider_agent_env.sh

Golang is required for the setup_capi_provider_agent_env.sh to work