### PR TITLE
NO-ISSUE: updated the capi test

### DIFF
--- a/discovery-infra/tests/test_kube_api.py
+++ b/discovery-infra/tests/test_kube_api.py
@@ -385,11 +385,8 @@ def capi_test(
     logger.info("Waiting for node to join the cluster")
     hypershift.wait_for_nodes(node_count)
     # TODO: validate node is ready
-
-    hypershift.set_nodepool_node_count(kube_api_context.api_client, 0)
-    logger.info("Waiting for node to get deleted")
-    nodes = hypershift.wait_for_nodes(node_count)
-    logger.info(nodes)
+    logger.info("Waiting for node to become ready")
+    hypershift.wait_for_nodes(node_count, ready=True)
 
 
 def kube_api_test(


### PR DESCRIPTION
the test should end with a working hypershift cluster with at least one ready node
otherwise the minimal conformence test that runs afterwards fail due to
missing networks.operator.openshift.io "cluster"