### PR TITLE
NO-ISSUE - Fix arkade not found in PATH on some machines. Add /usr/local/bin to PATH.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -7,7 +7,9 @@ CONTAINER_COMMAND = $(shell if [ -x "$(shell command -v docker)" ];then echo "do
 PULL_PARAM=$(shell if [ "${CONTAINER_COMMAND}" = "podman" ];then echo "--pull-always" ; else echo "--pull";fi)
 
 ROOT_DIR = $(shell dirname $(realpath $(firstword $(MAKEFILE_LIST))))
-PYTHONPATH=$(shell scripts/utils.sh get_pythonpath ${ROOT_DIR})
+PYTHONPATH := "${PYTHONPATH}:${ROOT_DIR}/src"
+PATH := "${PATH}:/usr/local/bin"
+
 
 REPORTS = $(ROOT_DIR)/reports
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -185,15 +185,4 @@ function configure_none_platform_iptables_rules() {
     iptables -t nat -A POSTROUTING ! -d 192.168.0.0/16 -j SNAT --source $sec_network --to-source $ip
 }
 
-function get_pythonpath() {
-  root_dir=$1
-  project_path=${root_dir}/src
-  PYTHONPATH="${PYTHONPATH:-$project_path}"
-
-  if [[ ":${PYTHONPATH}:" != *":${project_path}:"* ]] && [[ ":${PYTHONPATH}:" != *":${project_path}/:"* ]];then
-    echo "${PYTHONPATH:+"$PYTHONPATH:"}$project_path" ;
-  else echo "${PYTHONPATH}";
-  fi
-}
-
 "$@"


### PR DESCRIPTION
```
...
New version of arkade installed to /usr/local/bin
/usr/bin/which: no ark in (/usr/local/sbin:/sbin:/bin:/usr/sbin:/usr/bin:/root/bin)
main: line 176: arkade: command not found
...
```