### PR TITLE
NO-ISSUE: wait_for_nodes should pass the ready option to the get_nodes method

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/hypershift.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/hypershift.py
@@ -83,7 +83,7 @@ class HyperShift:
 
     def wait_for_nodes(self, node_count: int, ready: bool = False) -> V1NodeList:
         def _sufficint_nodes() -> bool:
-            return len(self.get_nodes(ready).items) == node_count
+            return len(self.get_nodes(ready).items, ready) == node_count
 
         return waiting.wait(
             lambda: _sufficint_nodes,


### PR DESCRIPTION
Without passing the arg the wait_for_nodes return regardless of the
nodes ready status