### PR TITLE
NO-ISSUE - Allow multiple assisted-test-infra logs

### DIFF
--- a/src/assisted_test_infra/download_logs/download_logs.py
+++ b/src/assisted_test_infra/download_logs/download_logs.py
@@ -30,7 +30,7 @@ from assisted_test_infra.test_infra.utils import (
     verify_logs_uploaded,
 )
 from consts import ClusterStatus, HostsProgressStages, env_defaults
-from service_client import InventoryClient, SuppressAndLog, add_log_file_handler, log
+from service_client import InventoryClient, SuppressAndLog, add_log_file_handler, log, log_filename
 from tests.config import ClusterConfig, TerraformConfig
 
 private_ssh_key_path_default = os.path.join(os.getcwd(), str(env_defaults.DEFAULT_SSH_PRIVATE_KEY_PATH))
@@ -123,7 +123,7 @@ def download_logs(
 
     recreate_folder(output_folder)
     recreate_folder(os.path.join(output_folder, "cluster_files"))
-    log_handler = add_log_file_handler(os.path.join(output_folder, "../test_infra.log"))
+    log_handler = add_log_file_handler(os.path.join(output_folder, f"../{log_filename}"))
 
     try:
         write_metadata_file(client, cluster, os.path.join(output_folder, "metadata.json"))

--- a/src/service_client/__init__.py
+++ b/src/service_client/__init__.py
@@ -1,5 +1,5 @@
 from .assisted_service_api import InventoryClient
 from .client_factory import ClientFactory
-from .logger import SuppressAndLog, add_log_file_handler, log
+from .logger import SuppressAndLog, add_log_file_handler, log, log_filename
 
-__all__ = ["InventoryClient", "ClientFactory", "log", "SuppressAndLog", "add_log_file_handler"]
+__all__ = ["InventoryClient", "ClientFactory", "log", "SuppressAndLog", "add_log_file_handler", "log_filename"]

--- a/src/service_client/logger.py
+++ b/src/service_client/logger.py
@@ -3,6 +3,7 @@ import logging
 import re
 import sys
 import traceback
+import uuid
 from contextlib import suppress
 from types import TracebackType
 from typing import Type
@@ -53,7 +54,8 @@ def add_log_file_handler(filename: str) -> logging.FileHandler:
     return fh
 
 
-add_log_file_handler("test_infra.log")
+log_filename = f"test_infra_{str(uuid.uuid4())[:8]}.log"
+add_log_file_handler(log_filename)
 
 
 class SuppressAndLog(suppress):


### PR DESCRIPTION
Create random test-infra log name so on tests with POSTSUBMIT tests we will not override test_infra.log.
Clear logs on local environment on every test execution.

/cc @osherdp 