### PR TITLE
MGMT-8598: fix provided variables for onprem deploy target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,8 @@ SKIPPER_PARAMS ?= -i
 
 TEST_INFRA_DOCKERFILE := $(or ${TEST_INFRA_DOCKERFILE}, "Dockerfile.test-infra")
 
+ASSISTED_SERVICE_HOST := $(or ${ASSISTED_SERVICE_HOST},$(shell hostname))
+
 # Openshift CI params
 OPENSHIFT_CI := $(or ${OPENSHIFT_CI}, "false")
 JOB_TYPE := $(or ${JOB_TYPE}, "")

--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -62,10 +62,12 @@ if [ "${DEPLOY_TARGET}" == "onprem" ]; then
     if [ -n "${AGENT_DOCKER_IMAGE:-}" ]; then
         echo "AGENT_DOCKER_IMAGE=${AGENT_DOCKER_IMAGE}" >> assisted-service/onprem-environment
     fi
-    if [ -n "$PUBLIC_CONTAINER_REGISTRIES" ]; then
+    if [ -n "${PUBLIC_CONTAINER_REGISTRIES:-}" ]; then
         sed -i "s|PUBLIC_CONTAINER_REGISTRIES=.*|PUBLIC_CONTAINER_REGISTRIES=${PUBLIC_CONTAINER_REGISTRIES}|" assisted-service/onprem-environment
     fi
-    sed -i "s/SERVICE_BASE_URL=http:\/\/127.0.0.1/SERVICE_BASE_URL=http:\/\/${ASSISTED_SERVICE_HOST}/" assisted-service/onprem-environment
+    if [ -n "${ASSISTED_SERVICE_HOST:-}" ]; then
+	sed -i "s|SERVICE_BASE_URL=http://127.0.0.1|SERVICE_BASE_URL=http://${ASSISTED_SERVICE_HOST}|" assisted-service/onprem-environment
+    fi
 
     validator_requirements=$(grep HW_VALIDATOR_REQUIREMENTS assisted-service/onprem-environment | cut -d '=' -f2)
     HW_VALIDATOR_REQUIREMENTS_LOW_DISK=$(echo $validator_requirements | jq '(.[].worker.disk_size_gb, .[].master.disk_size_gb, .[].sno.disk_size_gb) |= 20' | tr -d "\n\t ")

--- a/scripts/download_logs.sh
+++ b/scripts/download_logs.sh
@@ -19,7 +19,7 @@ function download_service_logs() {
   if [ "${DEPLOY_TARGET:-}" = "onprem" ]; then
     podman ps -a || true
 
-    for service in "installer" "db"; do
+    for service in "installer" "image-service" "ui" "db"; do
       podman logs ${service} > ${LOGS_DEST}/onprem_${service}.log || true
     done
   else


### PR DESCRIPTION
Seems like onprem deployment is broken for the following reasons:
* No value provided for ``ASSISTED_SERVICE_HOST``, which means that the service provides its URL with ``localhost:<port>`` domain, which of course not an appropriate address for the agent.
* Variable ``PUBLIC_CONTAINER_REGISTRIES`` has no default value alternative when used, and bash options forbid from having unbound variables.
* Variable ``ASSISTED_SERVICE_HOST`` not being propagated to the service deployment script.

/cc @eliorerz 