### PR TITLE
MGMT-8660: Fix os image override script

### DIFF
--- a/scripts/override_os_images.py
+++ b/scripts/override_os_images.py
@@ -27,8 +27,10 @@ def main():
     # If OS image for latest OCP versions doesn't exists, clone latest OS image and override 'openshift_version'
     os_image = get_os_image(os_images, latest_ocp_version)
     if os_image["openshift_version"] != latest_ocp_version:
-        os_image["openshift_version"] = latest_ocp_version
-        os_images.append(os_image)
+        new_image = os_image.copy()
+        new_image["openshift_version"] = latest_ocp_version
+        new_image["version"] = f"{os_image['openshift_version']}-assisted-override"
+        os_images.append(new_image)
 
     json.dump(os_images, os.sys.stdout, separators=(',', ':'))
 


### PR DESCRIPTION
Previously this script would edit the image entry in place as well as
appending a new image to the list.

The existing entry should not be edited and the new entry should be made
unique by manufacturing a "version" value. This will prevent the image
service from failing due to [MGMT-8661](https://issues.redhat.com/browse/MGMT-8661).

https://issues.redhat.com/browse/MGMT-8660
https://issues.redhat.com/browse/MGMT-8661
https://bugzilla.redhat.com/show_bug.cgi?id=2012844

Failing job https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-release-master-nightly-4.10-e2e-metal-assisted/1472933614353125376