### PR TITLE
Go back to using upstream terraform-libvirt-provider

### DIFF
--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -1,13 +1,8 @@
 terraform {
   required_providers {
-    # TODO: revert to upstream package when newer version than v0.6.11 has been released
-    # libvirt = {
-    #   source = "dmacvicar/libvirt"
-    #   version = "0.6.9"
-    # }
     libvirt = {
-      source = "osherdp/libvirt"
-      version = "99.9.0"
+      source = "dmacvicar/libvirt"
+      version = "0.6.12"
     }
   }
 }

--- a/terraform_files/baremetal_host/main.tf
+++ b/terraform_files/baremetal_host/main.tf
@@ -1,13 +1,8 @@
 terraform {
   required_providers {
-    # TODO: revert to upstream package when newer version than v0.6.11 has been released
-    # libvirt = {
-    #   source = "dmacvicar/libvirt"
-    #   version = "0.6.9"
-    # }
     libvirt = {
-      source = "osherdp/libvirt"
-      version = "99.9.0"
+      source = "dmacvicar/libvirt"
+      version = "0.6.12"
     }
   }
 }

--- a/terraform_files/baremetal_infra_env/main.tf
+++ b/terraform_files/baremetal_infra_env/main.tf
@@ -1,13 +1,8 @@
 terraform {
   required_providers {
-    # TODO: revert to upstream package when newer version than v0.6.11 has been released
-    # libvirt = {
-    #   source = "dmacvicar/libvirt"
-    #   version = "0.6.9"
-    # }
     libvirt = {
-      source = "osherdp/libvirt"
-      version = "99.9.0"
+      source = "dmacvicar/libvirt"
+      version = "0.6.12"
     }
   }
 }

--- a/terraform_files/none/main.tf
+++ b/terraform_files/none/main.tf
@@ -1,13 +1,8 @@
 terraform {
   required_providers {
-    # TODO: revert to upstream package when newer version than v0.6.11 has been released
-    # libvirt = {
-    #   source = "dmacvicar/libvirt"
-    #   version = "0.6.9"
-    # }
     libvirt = {
-      source = "osherdp/libvirt"
-      version = "99.9.0"
+      source = "dmacvicar/libvirt"
+      version = "0.6.12"
     }
   }
 }


### PR DESCRIPTION
Back in #1254, we decided to use forked libvirt-provider until we have a newer version.
Now that there's a new version, we can use the upstream provider again.
/cc @nmagnezi @eliorerz 