### PR TITLE
MGMT-8769- Fail olm test on operator failure.

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/operators_utils.py
+++ b/src/assisted_test_infra/test_infra/utils/operators_utils.py
@@ -28,16 +28,14 @@ def _are_operators_in_status(
         [(operator.name, operator.status, operator.status_info) for operator in operators],
     )
 
-    if len([operator for operator in operators if operator.status in statuses]) >= operators_count:
-        return True
-
     if fall_on_error_status:
         for operator in operators:
             if operator.status == consts.OperatorStatus.FAILED:
-                raise ValueError(
-                    f"Operator {operator.name} status is {consts.OperatorStatus.FAILED} "
-                    f"with info {operator.status_info}"
-                )
+                _Exception = consts.olm_operators.get_exception_factory(operator.name)
+                raise _Exception(f"Operator {operator.name} status is failed with info {operator.status_info}")
+
+    if len([operator for operator in operators if operator.status in statuses]) >= operators_count:
+        return True
 
     return False
 

--- a/src/consts/olm_operators.py
+++ b/src/consts/olm_operators.py
@@ -68,3 +68,39 @@ class OperatorResource:
             ),
             OperatorType.LSO: cls._get_resource_dict(),
         }
+
+
+class OperatorFailedError(Exception):
+    """Raised on failed status"""
+
+
+class CNVOperatorFailedError(OperatorFailedError):
+    pass
+
+
+class OCSOperatorFailedError(OperatorFailedError):
+    pass
+
+
+class ODFOperatorFailedError(OperatorFailedError):
+    pass
+
+
+class LSOOperatorFailedError(OperatorFailedError):
+    pass
+
+
+def get_exception_factory(operator: str):
+    if operator == OperatorType.CNV:
+        return CNVOperatorFailedError
+
+    if operator == OperatorType.OCS:
+        return OCSOperatorFailedError
+
+    if operator == OperatorType.ODF:
+        return ODFOperatorFailedError
+
+    if operator == OperatorType.LSO:
+        return LSOOperatorFailedError
+
+    return OperatorFailedError

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -753,37 +753,22 @@ class BaseTest:
             if global_variables.test_teardown:
                 v1.delete_namespace(global_variables.spoke_namespace)
 
-    @pytest.fixture(scope="function")
-    def update_olm_config(self) -> Callable:
-        def update_config(tf_config: TerraformConfig, cluster_config: ClusterConfig, operators=None):
-            if tf_config is None:
-                tf_config = TerraformConfig()
-            if cluster_config is None:
-                cluster_config = ClusterConfig()
-            if operators is None:
-                operators = parse_olm_operators_from_env()
+    @classmethod
+    def update_olm_configuration(cls, tf_config: BaseNodeConfig, operators=None) -> None:
+        if operators is None:
+            operators = parse_olm_operators_from_env()
 
-            tf_config.worker_memory = resource_param(
-                tf_config.worker_memory, OperatorResource.WORKER_MEMORY_KEY, operators
-            )
-            tf_config.master_memory = resource_param(
-                tf_config.master_memory, OperatorResource.MASTER_MEMORY_KEY, operators
-            )
-            tf_config.worker_vcpu = resource_param(tf_config.worker_vcpu, OperatorResource.WORKER_VCPU_KEY, operators)
-            tf_config.master_vcpu = resource_param(tf_config.master_vcpu, OperatorResource.MASTER_VCPU_KEY, operators)
-            tf_config.workers_count = resource_param(
-                tf_config.workers_count, OperatorResource.WORKER_COUNT_KEY, operators
-            )
-            tf_config.worker_disk = resource_param(tf_config.worker_disk, OperatorResource.WORKER_DISK_KEY, operators)
-            tf_config.master_disk = resource_param(tf_config.master_disk, OperatorResource.MASTER_DISK_KEY, operators)
-            tf_config.master_disk_count = resource_param(
-                tf_config.master_disk_count, OperatorResource.MASTER_DISK_COUNT_KEY, operators
-            )
-            tf_config.worker_disk_count = resource_param(
-                tf_config.worker_disk_count, OperatorResource.WORKER_DISK_COUNT_KEY, operators
-            )
-
-            tf_config.nodes_count = tf_config.masters_count + tf_config.workers_count
-            cluster_config.olm_operators = [operators]
-
-        yield update_config
+        tf_config.worker_memory = resource_param(tf_config.worker_memory, OperatorResource.WORKER_MEMORY_KEY, operators)
+        tf_config.master_memory = resource_param(tf_config.master_memory, OperatorResource.MASTER_MEMORY_KEY, operators)
+        tf_config.worker_vcpu = resource_param(tf_config.worker_vcpu, OperatorResource.WORKER_VCPU_KEY, operators)
+        tf_config.master_vcpu = resource_param(tf_config.master_vcpu, OperatorResource.MASTER_VCPU_KEY, operators)
+        tf_config.workers_count = resource_param(tf_config.workers_count, OperatorResource.WORKER_COUNT_KEY, operators)
+        tf_config.worker_disk = resource_param(tf_config.worker_disk, OperatorResource.WORKER_DISK_KEY, operators)
+        tf_config.master_disk = resource_param(tf_config.master_disk, OperatorResource.MASTER_DISK_KEY, operators)
+        tf_config.master_disk_count = resource_param(
+            tf_config.master_disk_count, OperatorResource.MASTER_DISK_COUNT_KEY, operators
+        )
+        tf_config.worker_disk_count = resource_param(
+            tf_config.worker_disk_count, OperatorResource.WORKER_DISK_COUNT_KEY, operators
+        )
+        tf_config.nodes_count = tf_config.masters_count + tf_config.workers_count

--- a/src/tests/test_e2e_install.py
+++ b/src/tests/test_e2e_install.py
@@ -5,22 +5,43 @@ from _pytest.fixtures import FixtureLookupError, FixtureRequest
 from junit_report import JunitTestSuite
 
 import consts
+from assisted_test_infra.test_infra.helper_classes.config import BaseNodeConfig, VSphereControllerConfig
 from tests.base_test import BaseTest
-from tests.config import ClusterConfig
+from tests.config import ClusterConfig, TerraformConfig
 from tests.conftest import get_available_openshift_versions, global_variables
 from tests.global_variables import get_default_triggers
 
 
 class TestInstall(BaseTest):
     @pytest.fixture
+    def new_controller_configuration(self, request) -> BaseNodeConfig:
+        """
+        Creates the controller configuration object according to the platform.
+        Override this fixture in your test class to provide a custom configuration object
+        :rtype: new node controller configuration
+        """
+        if global_variables.platform == consts.Platforms.VSPHERE:
+            config = VSphereControllerConfig()
+        else:
+            config = TerraformConfig()
+
+        with suppress(FixtureLookupError):
+            operators = request.getfixturevalue("olm_operators")
+            self.update_olm_configuration(config, operators)
+
+        return config
+
+    @pytest.fixture
     def new_cluster_configuration(self, request: FixtureRequest):
         # Overriding the default BaseTest.new_cluster_configuration fixture to set custom configs.
         config = ClusterConfig()
 
-        for fixture_name in ["openshift_version", "network_type", "is_static_ip"]:
+        for fixture_name in ["openshift_version", "network_type", "is_static_ip", "olm_operators"]:
             with suppress(FixtureLookupError):
-                setattr(config, fixture_name, request.getfixturevalue(fixture_name))
-
+                if hasattr(config, fixture_name):
+                    config.set_value(fixture_name, request.getfixturevalue(fixture_name))
+                else:
+                    raise AttributeError(f"No attribute name {fixture_name} in ClusterConfig object type")
         config.trigger(get_default_triggers())
         return config
 
@@ -43,12 +64,7 @@ class TestInstall(BaseTest):
         cluster.start_install_and_wait_for_installed()
 
     @JunitTestSuite()
-    @pytest.mark.parametrize("operators", sorted(global_variables.get_api_client().get_supported_operators()))
-    def test_olm_operator(self, configs, get_nodes, get_cluster, operators, update_olm_config):
-        cluster_config, tf_config = configs
-        update_olm_config(tf_config=tf_config, cluster_config=cluster_config, operators=operators)
-
-        new_cluster = get_cluster(get_nodes(tf_config, cluster_config), cluster_config)
-        new_cluster.prepare_for_installation()
-        new_cluster.start_install_and_wait_for_installed()
-        assert new_cluster.is_operator_in_status(operators, consts.OperatorStatus.AVAILABLE)
+    @pytest.mark.parametrize("olm_operators", sorted(global_variables.get_api_client().get_supported_operators()))
+    def test_olm_operator(self, cluster, olm_operators):
+        cluster.prepare_for_installation()
+        cluster.start_install_and_wait_for_installed()


### PR DESCRIPTION
Use cluster fixture in test_olm_operator instead of outdated fixture get_cluster.
Raise error on new_cluster_configuration on missing ClusterConfig attribute

/cc @osherdp 