### PR TITLE
allow gathering from the new name of assisted-service container

### DIFF
--- a/scripts/download_logs.sh
+++ b/scripts/download_logs.sh
@@ -19,7 +19,7 @@ function download_service_logs() {
   if [ "${DEPLOY_TARGET:-}" = "onprem" ]; then
     podman ps -a || true
 
-    for service in "installer" "image-service" "ui" "db"; do
+    for service in "assisted-service" "assisted-image-service" "assisted-installer-ui" "postgres"; do
       podman logs ${service} > ${LOGS_DEST}/onprem_${service}.log || true
     done
   else


### PR DESCRIPTION
On openshift/assisted-service#3096, we will use a new container name for assisted-service.
This should gather logs from both names, until we'll do the transition.
/cc @eliorerz 