### PR TITLE
NO-ISSUE: Get minikube logs in case it failed to start properly

### DIFF
--- a/scripts/run_minikube.sh
+++ b/scripts/run_minikube.sh
@@ -30,6 +30,8 @@ function init_minikube() {
 
         if minikube status ; then
             break
+        else
+          minikube logs
         fi
     done
 

--- a/scripts/run_minikube.sh
+++ b/scripts/run_minikube.sh
@@ -32,6 +32,7 @@ function init_minikube() {
             break
         else
           minikube logs
+          systemctl restart libvirtd.service
         fi
     done
 


### PR DESCRIPTION
When the CI jobs fail to start minikube it instructs to get the logs with this command.
Hopefully, this will help us understand why minikube fail to start
 
https://prow.ci.openshift.org/job-history/gs/origin-ci-test/pr-logs/directory/rehearse-24867-pull-ci-openshift-cluster-api-provider-agent-master-e2e-capi-provider-hypershift