### PR TITLE
NO-ISSUE: don't fail the run_minikube script in case of failure to get the logs

### DIFF
--- a/scripts/run_minikube.sh
+++ b/scripts/run_minikube.sh
@@ -31,8 +31,8 @@ function init_minikube() {
         if minikube status ; then
             break
         else
-          minikube logs
-          systemctl restart libvirtd.service
+          minikube logs || true
+          systemctl restart libvirtd.service || true
         fi
     done
 


### PR DESCRIPTION
`minikube logs` return non 0 exit code in case minikube API isn't available
Failure to restartlibvirtd shouldn't fail the script as well