### PR TITLE
Fixing none-platform network interfaces

### DIFF
--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -84,13 +84,19 @@ module "masters" {
   cluster_domain    = var.cluster_domain
   vtpm2             = var.master_vtpm2
 
-  primary_network   = libvirt_network.net.name
-  primary_ips       = var.libvirt_master_ips[count.index]
-  primary_mac       = var.libvirt_master_macs[count.index]
-
-  secondary_network = libvirt_network.secondary_net.name
-  secondary_ips     = var.libvirt_secondary_master_ips[count.index]
-  secondary_mac     = var.libvirt_secondary_master_macs[count.index]
+  networks          = [
+                        {
+                          name     = libvirt_network.net.name
+                          hostname = "${var.cluster_name}-master-${count.index}"
+                          ips      = var.libvirt_master_ips[count.index]
+                          mac      = var.libvirt_master_macs[count.index]
+                        },
+                        {
+                          name     = libvirt_network.secondary_net.name
+                          ips      = var.libvirt_secondary_master_ips[count.index]
+                          mac      = var.libvirt_secondary_master_macs[count.index]
+                        },
+                      ]
 
   pool              = libvirt_pool.storage_pool.name
   disk_base_name    = "${var.cluster_name}-master-${count.index}"
@@ -111,13 +117,19 @@ module "workers" {
   cluster_domain    = var.cluster_domain
   vtpm2             = var.worker_vtpm2
 
-  primary_network   = libvirt_network.net.name
-  primary_ips       = var.libvirt_worker_ips[count.index]
-  primary_mac       = var.libvirt_worker_macs[count.index]
-
-  secondary_network = libvirt_network.secondary_net.name
-  secondary_ips     = var.libvirt_secondary_worker_ips[count.index]
-  secondary_mac     = var.libvirt_secondary_worker_macs[count.index]
+  networks          = [
+                        {
+                          name     = libvirt_network.net.name
+                          hostname = "${var.cluster_name}-worker-${count.index}"
+                          ips      = var.libvirt_worker_ips[count.index]
+                          mac      = var.libvirt_worker_macs[count.index]
+                        },
+                        {
+                          name     = libvirt_network.secondary_net.name
+                          ips      = var.libvirt_secondary_worker_ips[count.index]
+                          mac      = var.libvirt_secondary_worker_macs[count.index]
+                        },
+                      ]
 
   pool              = libvirt_pool.storage_pool.name
   disk_base_name    = "${var.cluster_name}-worker-${count.index}"

--- a/terraform_files/baremetal_host/main.tf
+++ b/terraform_files/baremetal_host/main.tf
@@ -5,6 +5,8 @@ terraform {
       version = "0.6.12"
     }
   }
+
+  experiments = [module_variable_optional_attrs]
 }
 
 locals {
@@ -43,17 +45,14 @@ resource "libvirt_domain" "host" {
     mode = var.cpu_mode
   }
 
-  network_interface {
-    network_name = var.primary_network
-    hostname   = "${var.name}.${var.cluster_domain}"
-    addresses  = var.primary_ips
-    mac = var.primary_mac
-  }
-
-  network_interface {
-    network_name = var.secondary_network
-    addresses  = var.secondary_ips
-    mac = var.secondary_mac
+  dynamic "network_interface" {
+    for_each = var.networks
+    content {
+      network_name = network_interface.value.name
+      hostname     = network_interface.value.hostname
+      addresses    = network_interface.value.ips
+      mac          = network_interface.value.mac
+    }
   }
 
   boot_device{

--- a/terraform_files/baremetal_host/variables.tf
+++ b/terraform_files/baremetal_host/variables.tf
@@ -34,40 +34,15 @@ variable "cluster_domain" {
   description = "The domain for the cluster that all DNS records must belong."
 }
 
-variable "primary_network" {
-  type        = string
-  description = "Name of the libvirt network that should act as the node's primary network."
-  default     = ""
-}
-
-variable "primary_ips" {
-  type        = list(string)
-  description = "IP addresses to assign to the host in the primary network."
+variable "networks" {
+  type        = list(object({
+    name     = string,
+    hostname = optional(string),
+    ips      = list(string),
+    mac      = string
+  }))
+  description = "Network devices configuration for the host."
   default     = []
-}
-
-variable "primary_mac" {
-  type        = string
-  description = "MAC address to assign to the host in the primary network."
-  default     = ""
-}
-
-variable "secondary_network" {
-  type        = string
-  description = "Name of the libvirt network that should act as the node's secondary network."
-  default     = ""
-}
-
-variable "secondary_ips" {
-  type        = list(string)
-  description = "IP addresses to assign to the host in the secondary network."
-  default     = []
-}
-
-variable "secondary_mac" {
-  type        = string
-  description = "MAC address to assign to the host in the secondary network."
-  default     = ""
 }
 
 variable "pool" {

--- a/terraform_files/baremetal_infra_env/main.tf
+++ b/terraform_files/baremetal_infra_env/main.tf
@@ -69,13 +69,19 @@ module "masters" {
   cluster_domain    = var.infra_env_domain
   vtpm2             = var.master_vtpm2
 
-  primary_network   = libvirt_network.net.name
-  primary_ips       = var.libvirt_master_ips[count.index]
-  primary_mac       = var.libvirt_master_macs[count.index]
-
-  secondary_network = libvirt_network.secondary_net.name
-  secondary_ips     = var.libvirt_secondary_master_ips[count.index]
-  secondary_mac     = var.libvirt_secondary_master_macs[count.index]
+  networks          = [
+                        {
+                          name     = libvirt_network.net.name
+                          hostname = "${var.infra_env_name}-master-${count.index}"
+                          ips      = var.libvirt_master_ips[count.index]
+                          mac      = var.libvirt_master_macs[count.index]
+                        },
+                        {
+                          name     = libvirt_network.secondary_net.name
+                          ips      = var.libvirt_secondary_master_ips[count.index]
+                          mac      = var.libvirt_secondary_master_macs[count.index]
+                        },
+                      ]
 
   pool              = libvirt_pool.storage_pool.name
   disk_base_name    = "${var.infra_env_name}-master-${count.index}"
@@ -96,13 +102,19 @@ module "workers" {
   cluster_domain    = var.infra_env_domain
   vtpm2             = var.worker_vtpm2
 
-  primary_network   = libvirt_network.net.name
-  primary_ips       = var.libvirt_worker_ips[count.index]
-  primary_mac       = var.libvirt_worker_macs[count.index]
-
-  secondary_network = libvirt_network.secondary_net.name
-  secondary_ips     = var.libvirt_secondary_worker_ips[count.index]
-  secondary_mac     = var.libvirt_secondary_worker_macs[count.index]
+  networks          = [
+                        {
+                          name     = libvirt_network.net.name
+                          hostname = "${var.infra_env_name}-worker-${count.index}"
+                          ips      = var.libvirt_worker_ips[count.index]
+                          mac      = var.libvirt_worker_macs[count.index]
+                        },
+                        {
+                          name     = libvirt_network.secondary_net.name
+                          ips      = var.libvirt_secondary_worker_ips[count.index]
+                          mac      = var.libvirt_secondary_worker_macs[count.index]
+                        },
+                      ]
 
   pool              = libvirt_pool.storage_pool.name
   disk_base_name    = "${var.infra_env_name}-worker-${count.index}"

--- a/terraform_files/none/main.tf
+++ b/terraform_files/none/main.tf
@@ -81,8 +81,14 @@ module "masters" {
   cluster_domain    = var.cluster_domain
   vtpm2             = var.master_vtpm2
 
-  primary_network   = count.index % 2 == 0 ? libvirt_network.net.name : libvirt_network.secondary_net.name
-  primary_ips       = count.index % 2 == 0 ? var.libvirt_master_ips[count.index] : var.libvirt_secondary_master_ips[count.index]
+  networks          = [
+                        {
+                          name     = count.index % 2 == 0 ? libvirt_network.net.name : libvirt_network.secondary_net.name
+                          hostname = count.index % 2 == 0 ? "${var.cluster_name}-master-${count.index}" : "${var.cluster_name}-master-secondary-${count.index}"
+                          ips      = count.index % 2 == 0 ? var.libvirt_master_ips[count.index] : var.libvirt_secondary_master_ips[count.index]
+                          mac      = var.libvirt_master_macs[count.index]
+                        }
+                      ]
 
   pool              = libvirt_pool.storage_pool.name
   disk_base_name    = "${var.cluster_name}-master-${count.index}"
@@ -101,8 +107,14 @@ module "workers" {
   cluster_domain    = var.cluster_domain
   vtpm2             = var.worker_vtpm2
 
-  primary_network   = count.index % 2 == 0 ? libvirt_network.net.name : libvirt_network.secondary_net.name
-  primary_ips       = count.index % 2 == 0 ? var.libvirt_worker_ips[count.index] : var.libvirt_secondary_worker_ips[count.index]
+  networks          = [
+                        {
+                          name     = count.index % 2 == 0 ? libvirt_network.net.name : libvirt_network.secondary_net.name
+                          hostname = "${var.cluster_name}-worker-${count.index}"
+                          ips      = count.index % 2 == 0 ? var.libvirt_worker_ips[count.index] : var.libvirt_secondary_worker_ips[count.index]
+                          mac      = var.libvirt_worker_macs[count.index]
+                        }
+                      ]
 
   pool              = libvirt_pool.storage_pool.name
   disk_base_name    = "${var.cluster_name}-worker-${count.index}"

--- a/terraform_files/none/variables-libvirt.tf
+++ b/terraform_files/none/variables-libvirt.tf
@@ -68,6 +68,11 @@ variable "libvirt_secondary_master_ips" {
   description = "the list of desired master second interface ips. Must match master_count"
 }
 
+variable "libvirt_master_macs" {
+  type        = list(string)
+  description = "the list of the desired macs for master interface"
+}
+
 variable "libvirt_worker_ips" {
   type        = list(list(string))
   description = "the list of desired worker ips. Must match master_count"
@@ -76,6 +81,11 @@ variable "libvirt_worker_ips" {
 variable "libvirt_secondary_worker_ips" {
   type        = list(list(string))
   description = "the list of desired worker second interface ips. Must match master_count"
+}
+
+variable "libvirt_worker_macs" {
+  type        = list(string)
+  description = "the list of the desired macs for worker interface"
 }
 
 variable "api_vip" {


### PR DESCRIPTION
On some occasions, the none-platform environment test is getting into the following situation:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-none-periodic/1474880968832585728

In this case, the libvirt domains have an unintended network device attached, which is of type ``user``. When declaring part of the terraform fields for a network, it seems like it creates those kind of networks of type ``Userspace SLIRP stack``, and it probably adds some flakiness. This yielded the unintended generation of those networks.

This change should only declare whole networks, with the added benefit of being more general and provide ``networks`` (and not ``primary_network`` and ``secondary_network``).