### PR TITLE
Use skipper interactive env-var

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -18,7 +18,7 @@ pipeline {
     }
 
     environment {
-        SKIPPER_PARAMS = " "
+        SKIPPER_INTERACTIVE = "False"
         BASE_DNS_DOMAINS = credentials('route53_dns_domain')
         ROUTE53_SECRET = credentials('route53_secret')
         RUN_ID = UUID.randomUUID().toString().take(8)

--- a/Jenkinsfile.download_all_logs
+++ b/Jenkinsfile.download_all_logs
@@ -8,7 +8,7 @@ pipeline {
     triggers { cron('* * * * *') }
 
     environment {
-        SKIPPER_PARAMS = " "
+        SKIPPER_INTERACTIVE = "False"
 
         LOGS_DEST = "/var/ai-logs"
         ADDITIONAL_PARAMS = "--download-all --update-by-events"

--- a/Jenkinsfile.download_logs
+++ b/Jenkinsfile.download_logs
@@ -9,7 +9,7 @@ pipeline {
     triggers { cron('H/30 * * * *') }
 
     environment {
-        SKIPPER_PARAMS = " "
+        SKIPPER_INTERACTIVE = "False"
 
         LOGS_DEST = "/var/ai-logs/triage_logs"
 

--- a/Jenkinsfile.test
+++ b/Jenkinsfile.test
@@ -6,7 +6,7 @@ pipeline {
     }
 
     environment {
-        SKIPPER_PARAMS = " "
+        SKIPPER_INTERACTIVE = "False"
         NAMESPACE = "assisted-installer"
         E2E_TESTS_MODE="true"
 

--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -141,7 +141,7 @@ else
     fi
 
     skipper run src/update_assisted_service_cm.py
-    (cd assisted-service/ && skipper --env-file ../skipper.env run "make deploy-all" ${SKIPPER_PARAMS} $ENABLE_KUBE_API_CMD DEPLOY_TAG=${DEPLOY_TAG} DEPLOY_MANIFEST_PATH=${DEPLOY_MANIFEST_PATH} DEPLOY_MANIFEST_TAG=${DEPLOY_MANIFEST_TAG} NAMESPACE=${NAMESPACE} AUTH_TYPE=${AUTH_TYPE} ${DEBUG_DEPLOY_AI_PARAMS:-})
+    (cd assisted-service/ && skipper --env-file ../skipper.env run "make deploy-all" $ENABLE_KUBE_API_CMD DEPLOY_TAG=${DEPLOY_TAG} DEPLOY_MANIFEST_PATH=${DEPLOY_MANIFEST_PATH} DEPLOY_MANIFEST_TAG=${DEPLOY_MANIFEST_TAG} NAMESPACE=${NAMESPACE} AUTH_TYPE=${AUTH_TYPE} ${DEBUG_DEPLOY_AI_PARAMS:-})
 
     add_firewalld_port $SERVICE_PORT
 

--- a/scripts/deploy_ui.sh
+++ b/scripts/deploy_ui.sh
@@ -19,7 +19,7 @@ mkdir -p build
 
 print_log "Starting ui"
 if [ "${DEPLOY_TARGET}" == "minikube" ]; then
-    skipper run "make -C assisted-service/ deploy-ui" ${SKIPPER_PARAMS} DEPLOY_TAG=${DEPLOY_TAG} DEPLOY_MANIFEST_PATH=${DEPLOY_MANIFEST_PATH} DEPLOY_MANIFEST_TAG=${DEPLOY_MANIFEST_TAG} NAMESPACE=${NAMESPACE}
+    skipper run "make -C assisted-service/ deploy-ui" DEPLOY_TAG=${DEPLOY_TAG} DEPLOY_MANIFEST_PATH=${DEPLOY_MANIFEST_PATH} DEPLOY_MANIFEST_TAG=${DEPLOY_MANIFEST_TAG} NAMESPACE=${NAMESPACE}
 
     print_log "Wait till ui api is ready"
     wait_for_url_and_run "$(minikube service ${UI_SERVICE_NAME} -n ${NAMESPACE} --url)" "echo \"waiting for ${UI_SERVICE_NAME}\""


### PR DESCRIPTION
Seems like there's a simpler way to make skipper interactive every time it's being called, which is the ``SKIPPER_INTERACTIVE`` environment variable.
It's not enabling to customize skipper params, but I don't really think it's in wide use.
/cc @eliorerz 