### PR TITLE
fix SNO installations always picking OCP 4.8

### DIFF
--- a/src/tests/global_variables/triggers.py
+++ b/src/tests/global_variables/triggers.py
@@ -19,7 +19,6 @@ _default_triggers = frozendict(
             "high_availability_mode": consts.HighAvailabilityMode.NONE,
             "user_managed_networking": True,
             "vip_dhcp_allocation": False,
-            "openshift_version": consts.OpenshiftVersion.VERSION_4_8.value,
             "master_memory": resources.DEFAULT_MASTER_SNO_MEMORY,
             "master_vcpu": resources.DEFAULT_MASTER_SNO_CPU,
         },


### PR DESCRIPTION
Seems like we always override SNO installations with OCP 4.8, instead of going with what the user chose on ``OPENSHIFT_VERSION`` or ``OPENSHIFT_INSTALL_RELEASE_IMAGE``.
/cc @eliorerz 