### PR TITLE
Use interactive mode when running skipper externally

### DIFF
--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -38,8 +38,8 @@ fi
 mkdir -p build
 
 if [ "${OPENSHIFT_INSTALL_RELEASE_IMAGE}" != "" ]; then
-    export RELEASE_IMAGES=$(skipper run ./scripts/override_release_images.py --src ./assisted-service/data/default_release_images.json)
-    export OS_IMAGES=$(skipper run ./scripts/override_os_images.py --src ./assisted-service/data/default_os_images.json)
+    export RELEASE_IMAGES=$(SKIPPER_INTERACTIVE=False skipper run ./scripts/override_release_images.py --src ./assisted-service/data/default_release_images.json)
+    export OS_IMAGES=$(SKIPPER_INTERACTIVE=False skipper run ./scripts/override_os_images.py --src ./assisted-service/data/default_os_images.json)
 
     if [ "${DEPLOY_TARGET}" == "onprem" ]; then
         if [ -x "$(command -v docker)" ]; then


### PR DESCRIPTION
Probably because of #1341, we have the following failures in all periodic jobs:
https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-networking-periodic/1477610760195543040

When calculating overridden ``RELEASE_IMAGES``, it complains with this error:
```
time="2022-01-02T12:21:52Z" level=warning msg="The input device is not a TTY. The --tty and --interactive flags might not work properly"
```

If possibly brings an output will line-break at start:
```
RELEASE_IMAGES='
[{"openshift_version":"4.6","cpu_ ...
```

and when trying to use it, it complains:
```
python3 ./tools/deploy_assisted_installer_configmap.py --target "local" --domain "" \
	--base-dns-domains """" --namespace "assisted-installer" \
	  --auth-type "none"  \
	--os-images '[{\"openshift_version\":\"4.6\",\"cpu_architecture\":\"x86_64\",\"url\":\"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-4.6.8-x86_64-live.x86_64.iso\",\"rootfs_url\":\"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.6/4.6.8/rhcos-live-rootfs.x86_64.img\",\"version\":\"46.82.202012051820-0\"},{\"openshift_version\":\"4.7\",\"cpu_architecture\":\"x86_64\",\"url\":\"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-4.7.33-x86_64-live.x86_64.iso\",\"rootfs_url\":\"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.7/4.7.33/rhcos-live-rootfs.x86_64.img\",\"version\":\"47.84.202109241831-0\"},{\"openshift_version\":\"4.8\",\"cpu_architecture\":\"x86_64\",\"url\":\"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-4.8.14-x86_64-live.x86_64.iso\",\"rootfs_url\":\"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.8/4.8.14/rhcos-live-rootfs.x86_64.img\",\"version\":\"48.84.202109241901-0\"},{\"openshift_version\":\"4.9\",\"cpu_architecture\":\"x86_64\",\"url\":\"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-x86_64-live.x86_64.iso\",\"rootfs_url\":\"https://mirror.openshift.com/pub/openshift-v4/dependencies/rhcos/4.9/4.9.0/rhcos-live-rootfs.x86_64.img\",\"version\":\"49.84.202110081407-0\"},{\"openshift_version\":\"4.9\",\"cpu_architecture\":\"arm64\",\"url\":\"https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-aarch64-live.aarch64.iso\",\"rootfs_url\":\"https://mirror.openshift.com/pub/openshift-v4/aarch64/dependencies/rhcos/4.9/4.9.0/rhcos-4.9.0-aarch64-live-rootfs.aarch64.img\",\"version\":\"49.84.202110080947-0\"}]' --release-images '

/bin/sh: -c: line 3: unexpected EOF while looking for matching `''
```

/cc @eliorerz 
/hold