### PR TITLE
Assign pip packages maintainers when bumping dependencies

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -9,6 +9,9 @@ updates:
     directory: "/"
     schedule:
       interval: "weekly"
+    assignees:
+      - "eliorerz"
+      - "osherdp"
     labels:
       - "approved"
       - "lgtm"


### PR DESCRIPTION
Seems reasonable we're mostly concerned about those packages than others.
/cc @eliorerz 