### PR TITLE
WIP: NO-ISSUE: The Dockerfile has been renamed in a previous commit but `skipper.yaml` not updated

### DIFF
--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -1,6 +1,8 @@
 #!/usr/bin/env bash
 
 set -o nounset
+set -o pipefail
+set -o errexit
 
 export KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
 export NAMESPACE=${NAMESPACE:-assisted-installer}
@@ -9,15 +11,17 @@ function get_namespace_index() {
     namespace=$1
     oc_flag=${2:-}
 
-    index=$(skipper run python3 scripts/indexer.py --action set --namespace $namespace $oc_flag)
-    if [[ -z $index ]]; then
+    index=$(skipper run python3 scripts/indexer.py --action set --namespace "$namespace" "$oc_flag")
+
+    if [[ -z "${index}" ]]; then
         all_namespaces=$(skipper run python3 scripts/indexer.py --action list)
+
         echo "Maximum number of namespaces allowed are currently running: $all_namespaces"
         echo "Please remove an old namespace in order to create a new one"
         exit 1
     fi
 
-    echo $index
+    echo "$index"
 }
 
 function print_log() {


### PR DESCRIPTION
The skipper.yaml file points to the `Dockerfile.test-infra`, but that file has been renamed
in the e0b611d5fed83504e2e6c60cf118c0563a7635ad commit

This commit updates the `skipper.yaml` file to point to the new `Dockerfile.assisted-test-infra`
instead.