### PR TITLE
install assisted-service-build dependencies before using makefile

### DIFF
--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -42,13 +42,7 @@ if [ "${OPENSHIFT_INSTALL_RELEASE_IMAGE}" != "" ]; then
     export OS_IMAGES=$(skipper run ./scripts/override_os_images.py --src ./assisted-service/data/default_os_images.json)
 
     if [ "${DEPLOY_TARGET}" == "onprem" ]; then
-        if [ -x "$(command -v docker)" ]; then
-            make -C assisted-service/ generate-configuration
-        else
-            ln -s $(which podman) /usr/bin/docker
-            make -C assisted-service/ generate-configuration
-            rm -f /usr/bin/docker
-        fi
+        (cd assisted-service; skipper make generate-configuration)
     fi
 fi
 


### PR DESCRIPTION
Before this change, we just tried to use assisted-service's makefile with dependencies installed by assisted-test-infra on the host.
I brought up the following error on [onprem-periodic jobs](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-onprem-periodic/1479975943459049472):
```
make[1]: Leaving directory '/home/assisted/assisted-service'
+ sed -i 's|HW_VALIDATOR_REQUIREMENTS=.*|HW_VALIDATOR_REQUIREMENTS=[{"version":"default","master":{"cpu_cores":4,"ram_mib":16384,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":100,"packet_loss_percentage":0},"worker":{"cpu_cores":2,"ram_mib":8192,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10,"network_latency_threshold_ms":1000,"packet_loss_percentage":10},"sno":{"cpu_cores":8,"ram_mib":32768,"disk_size_gb":120,"installation_disk_speed_threshold_ms":10}}]|' /home/assisted/assisted-service/config/onprem-iso-fcc.yaml
+ butane --pretty --strict /home/assisted/assisted-service/config/onprem-iso-fcc.yaml -o /home/assisted/assisted-service/config/onprem-iso-config.ign
./hack/generate.sh: line 110: butane: command not found
```
/cc @eliorerz 