### PR TITLE
remove overriding ocp version when on ipv6

### DIFF
--- a/src/tests/global_variables/triggers.py
+++ b/src/tests/global_variables/triggers.py
@@ -30,7 +30,6 @@ _default_triggers = frozendict(
             "cluster_networks": consts.DEFAULT_CLUSTER_NETWORKS_IPV6,
             "service_networks": consts.DEFAULT_SERVICE_NETWORKS_IPV6,
             "vip_dhcp_allocation": False,
-            "openshift_version": consts.OpenshiftVersion.VERSION_4_8.value,
             "network_type": consts.NetworkType.OVNKubernetes,
         },
         (("is_ipv4", True), ("is_ipv6", True),): {


### PR DESCRIPTION
Some jobs like ``assisted-ipv6`` or ``assisted-kube-api`` will always choose OCP 4.8 because of the triggering mechanism:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24876/rehearse-24876-pull-ci-openshift-assisted-service-master-e2e-metal-assisted-kube-api/1480177853029945344
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/24876/rehearse-24876-pull-ci-openshift-assisted-service-master-e2e-metal-assisted-ipv6/1480177852476297216

Removing it, since anyway we're using 4.9 by default.

/cc @eliorerz 