### PR TITLE
remove creating tickets based on failed CI tests

### DIFF
--- a/Jenkinsfile.download_logs
+++ b/Jenkinsfile.download_logs
@@ -43,7 +43,6 @@ pipeline {
 
                 dir ('assisted-installer-deployment') {
                     sh "skipper run ./tools/create_triage_tickets.py --jira-access-token ${JIRA_ACCESS_TOKEN} -v"
-                    sh "skipper run ./tools/create_testgrid_tickets.py --jira-access-token ${JIRA_ACCESS_TOKEN} -v"
                 }
             }
         }


### PR DESCRIPTION
It's no longer used, as we have notifications and reports for it.
/cc @mkowalski @eliorerz 