### PR TITLE
MGMT-8670 - Fix deploy_nodes with CLUSTER_ID creates a new InfraEnv.

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/entity.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/entity.py
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from pathlib import Path
 from typing import Optional, Union
 
 from assisted_service_client import models
@@ -13,8 +14,12 @@ class Entity(ABC):
         self._config = config
         self.api_client = api_client
         self.nodes: Nodes = nodes
-        self._infra_env = None
-        self.id = self._create()
+        self._create() if not self.id else self.update_existing()
+
+    @property
+    @abstractmethod
+    def id(self) -> str:
+        pass
 
     @property
     def _entity_class_name(self):
@@ -22,6 +27,14 @@ class Entity(ABC):
 
     @abstractmethod
     def _create(self) -> str:
+        pass
+
+    @abstractmethod
+    def update_existing(self) -> str:
+        pass
+
+    @abstractmethod
+    def download_image(self, iso_download_path: str = None) -> Path:
         pass
 
     def update_config(self, **kwargs):

--- a/src/assisted_test_infra/test_infra/helper_classes/infra_env.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/infra_env.py
@@ -20,6 +20,13 @@ class InfraEnv(Entity):
     def __init__(self, api_client: InventoryClient, config: BaseInfraEnvConfig, nodes: Optional[Nodes] = None):
         super().__init__(api_client, config, nodes)
 
+    @property
+    def id(self):
+        return self._config.infra_env_id
+
+    def update_existing(self) -> str:
+        return self.id
+
     def _create(self):
         if self._config.ignition_config_override:
             ignition_config_override = json.dumps(self._config.ignition_config_override)

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -150,7 +150,7 @@ class InventoryClient(object):
     def clusters_list(self) -> List[Dict[str, Any]]:
         return self.client.v2_list_clusters()
 
-    def infra_envs_list(self) -> List[models.InfraEnv]:
+    def infra_envs_list(self) -> List[Dict[str, Any]]:
         return self.client.list_infra_envs()
 
     def get_all_clusters(self) -> List[Dict[str, Any]]:


### PR DESCRIPTION
When using `make deploy_nodes CLUSTER_ID="<id>"` test-infra is not checking for an existing InfraEnv, and will instead create a new one (per each run).
This PR added infra_env check before creating a new one, and if it is already exists it's using the existing one.

/cc @osherdp 