### PR TITLE
MGMT-9037:  Use a cheaper packet plan for baremetalds-sno-workflow

### DIFF
--- a/src/tests/test_bootstrap_in_place.py
+++ b/src/tests/test_bootstrap_in_place.py
@@ -146,7 +146,7 @@ class TestBootstrapInPlace(BaseTest):
             masters_count=1,
             workers_count=0,
             nodes_count=1,
-            master_memory=45 * 1024,  # in megabytes
+            master_memory=16 * 1024,  # in megabytes
             master_vcpu=16,
             bootstrap_in_place=True,
         )


### PR DESCRIPTION
The purpose of this workflow is to save costs after this change as currently this test demands a 45GB virtual machine.
Coupled with work in [MGMT-8844](https://issues.redhat.com/browse/MGMT-8844) where the SNO validation limit has been reduced to 16GB, it would make sense to reduce this also.
So we have done this.