### PR TITLE
NO-ISSUE: Fix versioning scheme

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -494,7 +494,7 @@ def get_openshift_version(allow_default=True, client=None) -> str:
         with pull_secret_file() as pull_secret:
             stdout, _, _ = run_command(
                 f"oc adm release info '{release_image}' --registry-config '{pull_secret}' -o json |"
-                f" jq -r '.metadata.version' | grep -oP '\\d\\.\\d+'",
+                f" jq -r '.metadata.version'",
                 shell=True,
             )
         return stdout


### PR DESCRIPTION
Since https://github.com/openshift/assisted-service/pull/3219, the API returns the full openshift version, it is not necessary to truncate it anymore.