### PR TITLE
NO-ISSUE: use stream8 distribution as centos 8 is EOL

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -1,6 +1,6 @@
 FROM quay.io/ocpmetal/assisted-service:latest AS service
 
-FROM quay.io/centos/centos:8.3.2011
+FROM quay.io/centos/centos:stream8
 
 RUN dnf -y install \
   make \
@@ -18,7 +18,6 @@ RUN dnf -y install \
   libvirt-client \
   libvirt-devel \
   libguestfs-tools \
-  dnf-plugins-core \
     && dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo \
     && dnf -y install packer \
     && dnf clean all


### PR DESCRIPTION
Seems like starting today we get the following errors:
```
STEP 5: RUN dnf -y install   make   gcc   unzip   wget   curl   git   podman   httpd-tools   jq   nss_wrapper   python39   python39-devel   libvirt-client   libvirt-devel   libguestfs-tools   dnf-plugins-core     && dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo     && dnf -y install packer     && dnf clean all
CentOS Linux 8 - AppStream                      124  B/s |  38  B     00:00    
Error: Failed to download metadata for repo 'appstream': Cannot prepare internal mirrorlist: No URLs in mirrorlist
```

I couldn't find any official message about CentOS deprecation, but either way it's a good idea to do that change.

/cc @eliorerz 