### PR TITLE
[release-ocm-2.4] NO-ISSUE: use stream8 distribution as previous one seems broken

### DIFF
--- a/Dockerfile.test-infra
+++ b/Dockerfile.test-infra
@@ -1,6 +1,6 @@
 FROM quay.io/ocpmetal/assisted-service:latest AS service
 
-FROM quay.io/centos/centos:8.3.2011
+FROM quay.io/centos/centos:stream8
 
 RUN yum -y install \
   make \


### PR DESCRIPTION
Backport of https://github.com/openshift/assisted-test-infra/pull/1410

/cc @osherdp 