### PR TITLE
Supporting arbitrary user ids

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -40,5 +40,8 @@ RUN go get -u github.com/vmware/govmomi/govc
 
 COPY . .
 
+RUN chgrp -R 0 /home/assisted-test-infra && \
+    chmod -R g=u /home/assisted-test-infra
+
 # setting pre-commit env
 ENV PRE_COMMIT_HOME build


### PR DESCRIPTION
Openshift runs containers as root group and assigns user IDs arbitrarily for security reasons.
Since this image has been built as root, the arbitrarily user does not have permission to write to the assisted-test-infra folder.
Allow root group write access to the folder, so that arbitrary users can write there
Please see: https://docs.openshift.com/container-platform/4.9/openshift_images/create-images.html#images-create-guide-openshift_create-images