### PR TITLE
[release-ocm-2.4] MGMT-9102: Fix kubeapi makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -496,3 +496,6 @@ _test_setup:
 
 _test_parallel: $(REPORTS) _test_setup
 	JUNIT_REPORT_DIR=$(REPORTS) python3 -m pytest -n $(or ${TEST_WORKERS_NUM}, '4') $(or ${TEST},discovery-infra/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(REPORTS)/unittest.xml
+
+test_kube_api_parallel:
+	TEST=./src/tests/test_kube_api.py make test_parallel


### PR DESCRIPTION
Backport of:
- https://github.com/openshift/assisted-test-infra/pull/1306

/cc @osherdp 