### PR TITLE
Fixing a conflict with the packer executable

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -20,6 +20,7 @@ RUN dnf -y install \
   libguestfs-tools \
     && dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo \
     && dnf -y install packer \
+    && mv /usr/bin/packer /usr/bin/packer.io \
     && dnf clean all
 
 RUN curl -Lo terraform.zip https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip && unzip terraform.zip -d /usr/bin/ && rm -rf terraform.zip


### PR DESCRIPTION
The Hashicorp Packer tool conflicts with the Arch Linux packer on Centos.
Below are the error messages we are seeing:
/usr/share/cracklib/pw_dict.pwd: Permission denied
/usr/share/cracklib/pw_dict: Permission denied
Due to this error, we are renaming Hashcorp packer to packer.io