### PR TITLE
Fix image_type param in infra_env and adding minimal iso event

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/infra_env.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/infra_env.py
@@ -42,6 +42,7 @@ class InfraEnv(Entity):
             static_network_config=self._config.static_network_config,
             ignition_config_override=ignition_config_override,
             proxy=self._config.proxy,
+            image_type=self._config.iso_image_type,
         )
         self._config.infra_env_id = infra_env.id
         return infra_env.id

--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -206,6 +206,7 @@ class Events:
     GENERATED_IMAGE = "Generated image (SSH public key is set)"
     GENERATED_IMAGE_FULL = 'Generated image (Image type is "full-iso", SSH public key is set)'
     GENERATED_IMAGE_MINIMAL = 'Generated image (Image type is "minimal-iso", SSH public key is set)'
+    REGISTER_IMAGE_MINIMAL = 'Updated image information (Image type is "minimal-iso", SSH public key is set)'
     DOWNLOAD_IMAGE = "Started image download"
     STARTED_DOWNLOAD_IMAGE = 'Started image download (image type is "full-iso")'
     HOST_REGISTERED_TO_CLUSTER = ": registered to cluster"


### PR DESCRIPTION
Added a condition to get either cluster events or infra env events,
In addition - minimal iso flow is broken. Fixed by passing image_type to infra_env creation. 