### PR TITLE
MGMT-9178: single-node CI should use OVNKubernetes as the network type

### DIFF
--- a/src/tests/test_bootstrap_in_place.py
+++ b/src/tests/test_bootstrap_in_place.py
@@ -118,6 +118,7 @@ class TestBootstrapInPlace(BaseTest):
         config["sshKey"] = ssh_pub_key
         config["metadata"]["name"] = cluster_name
         config["networking"]["machineNetwork"][0]["cidr"] = net_asset["machine_cidr"]
+        config["networking"]["networkType"] = "OVNKubernetes"
 
         with open(INSTALL_CONFIG, "w") as _file:
             yaml.dump(config, _file)


### PR DESCRIPTION
Single Node installations in the near future are going to default to
OVNKubernetes, we want to test beforehand that it works as expected.

This commit will make Single Node baremetal CI use OVNKubernetes rather
than OpenShiftSDN.