### PR TITLE
MGMT-9183: capi test fail while waiting for machine controller to setowner ref on agentMachine

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/hypershift.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/hypershift.py
@@ -18,12 +18,14 @@ class HyperShift:
 
     NODEPOOL_NAMESPACE = "clusters"
     NODEPOOL_PLOURAL = "nodepools"
+    HOSTED_CONTROL_PLANE_PLOURAL = "hostedcontrolplanes"
     HYPERSHIFT_API_GROUP = "hypershift.openshift.io"
     HYPERSHIFT_API_VERSION = "v1alpha1"
 
-    def __init__(self, name: str):
+    def __init__(self, name: str, kube_api_client: ApiClient):
         self.name = name
-        self.kubeconfig_path = ""
+        self.management_kube_api_client = kube_api_client
+        self._kubeconfig_path = ""
         self.hypershift_cluster_client = None
 
     def create(self, pull_secret_file: str, agent_namespace: str, provider_image: str = "", ssh_key: str = ""):
@@ -50,29 +52,31 @@ class HyperShift:
             f"--artifact-dir {output_folder}"
         )
 
-    def download_kubeconfig(self, kube_api_client: ApiClient) -> str:
-        log.info(f"Downloading kubeconfig for HyperShift cluster {self.name}")
-        kubeconfig_data = (
-            Secret(
-                kube_api_client=kube_api_client,
-                namespace=f"clusters-{self.name}",
-                name="admin-kubeconfig",
+    @property
+    def kubeconfig_path(self) -> str:
+        if self._kubeconfig_path == "":
+            log.info(f"Downloading kubeconfig for HyperShift cluster {self.name}")
+            kubeconfig_data = (
+                Secret(
+                    kube_api_client=self.management_kube_api_client,
+                    namespace=f"clusters-{self.name}",
+                    name="admin-kubeconfig",
+                )
+                .get()
+                .data["kubeconfig"]
             )
-            .get()
-            .data["kubeconfig"]
-        )
-        hypershift_kubeconfig_path = utils.get_kubeconfig_path(self.name) + "-hypershift"
+            hypershift_kubeconfig_path = utils.get_kubeconfig_path(self.name) + "-hypershift"
 
-        log.info(f"Kubeconfig path {hypershift_kubeconfig_path}")
-        with open(hypershift_kubeconfig_path, "wt") as kubeconfig_file:
-            kubeconfig_file.write(b64decode(kubeconfig_data).decode())
-            kubeconfig_file.flush()
-        self.kubeconfig_path = hypershift_kubeconfig_path
-        return self.kubeconfig_path
+            log.info(f"Kubeconfig path {hypershift_kubeconfig_path}")
+            with open(hypershift_kubeconfig_path, "wt") as kubeconfig_file:
+                kubeconfig_file.write(b64decode(kubeconfig_data).decode())
+                kubeconfig_file.flush()
+            self._kubeconfig_path = hypershift_kubeconfig_path
+        return self._kubeconfig_path
 
-    def set_nodepool_node_count(self, kube_api_client: ApiClient, node_count: int) -> None:
+    def set_nodepool_node_count(self, node_count: int) -> None:
         log.info(f"Setting HyperShift cluster {self.name} node count to: {node_count}")
-        crd_api = CustomObjectsApi(kube_api_client)
+        crd_api = CustomObjectsApi(self.management_kube_api_client)
         node_count = node_count
         body = {"spec": {"nodeCount": node_count}}
         crd_api.patch_namespaced_custom_object(
@@ -82,6 +86,28 @@ class HyperShift:
             name=self.name,
             namespace=HyperShift.NODEPOOL_NAMESPACE,
             body=body,
+        )
+
+    def wait_for_control_plane_ready(self):
+        # This is a workaround is required because to HyperShift
+        # HostedControlPlane Initialized attribute is misleading
+        log.info(f"Waiting for HyperShift cluster {self.name} hosted control plane to be ready")
+        return waiting.wait(
+            lambda: self.get_control_plane().get("status", {}).get("ready"),
+            sleep_seconds=5,
+            timeout_seconds=DEFAULT_WAIT_FOR_NODES_TIMEOUT,
+            waiting_for="hypershift kube-apiserver",
+            expected_exceptions=Exception,
+        )
+
+    def get_control_plane(self):
+        crd_api = CustomObjectsApi(self.management_kube_api_client)
+        return crd_api.get_namespaced_custom_object(
+            group=HyperShift.HYPERSHIFT_API_GROUP,
+            version=HyperShift.HYPERSHIFT_API_VERSION,
+            plural=HyperShift.HOSTED_CONTROL_PLANE_PLOURAL,
+            name=self.name,
+            namespace="-".join([HyperShift.NODEPOOL_NAMESPACE, self.name]),
         )
 
     def get_nodes(self, ready: bool = False) -> V1NodeList:


### PR DESCRIPTION
As a workaround, the test will wait for the hypershift kube-api to return
a response before adding nodes to it