### PR TITLE
Remove set of `bootstrap_in_place` in kubeapi test

### DIFF
--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -141,9 +141,6 @@ class TestKubeAPI(BaseKubeAPI):
         )
         agents = self.start_nodes(nodes, infra_env, cluster_config)
 
-        if len(nodes) == 1:
-            self.set_single_node_ip(cluster_deployment, nodes)
-
         log.info("Waiting for agent status verification")
         Agent.wait_for_agents_to_install(agents)
 


### PR DESCRIPTION
On the new libvirt version we will get error while trying to change the `bootstrap_in_place` variable.
Also we don't need to set bootstrap_in_place in kube-api test flow.

/cc @tsorya 