### PR TITLE
MGMT-9273: allow installation on rocky linux

### DIFF
--- a/create_full_environment.sh
+++ b/create_full_environment.sh
@@ -8,8 +8,8 @@ function error() {
 
 # Check OS
 OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
-if [[ ! ${OS} =~ ^(centos)$ ]] && [[ ! ${OS} =~ ^(rhel)$ ]] && [[ ! ${OS} =~ ^(fedora)$ ]]; then
-    error "\"${OS}\" is an unsupported OS. We support only CentOS, RHEL or FEDORA."
+if [[ ! ${OS} =~ ^(centos)$ ]] && [[ ! ${OS} =~ ^(rhel)$ ]] && [[ ! ${OS} =~ ^(fedora)$ ]] && [[ ! ${OS} =~ ^(rocky)$ ]]; then
+    error "\"${OS}\" is an unsupported OS. We support only CentOS, RHEL, Fedora or Rocky."
     exit 1
 fi
 

--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -17,7 +17,7 @@ function install_libvirt() {
 
     # RHEL and CentOS require epel-release for swtpm and swtpm-tools packages
     case "${PRETTY_NAME}" in
-    "Red Hat Enterprise Linux 8"* | "CentOS Linux 8"*)
+    "Red Hat Enterprise Linux 8"* | "CentOS Linux 8"* | "Rocky Linux 8"*)
         sudo dnf install -y \
             https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
         ;;
@@ -33,11 +33,18 @@ function install_libvirt() {
     echo "Install selinux-policy RPM"
     sudo dnf install -y selinux-policy
 
+    # TODO: support libvirt >= 6.0.0-37-1
+    SPECIFIC_LIBVIRT_VERSION=""
+    if [[ "${PRETTY_NAME}" == "Rocky Linux 8"* ]]; then
+        echo "Installing a downgraded version of libvirt, as we currently don't support the newer one..."
+        SPECIFIC_LIBVIRT_VERSION="-6.0.0-37.module+el8.5.0+670+c4aa478c"
+    fi
+
     echo "Installing libvirt..."
     sudo dnf install -y \
-        libvirt \
-        libvirt-devel \
-        libvirt-daemon-kvm \
+        libvirt${SPECIFIC_LIBVIRT_VERSION} \
+        libvirt-devel${SPECIFIC_LIBVIRT_VERSION} \
+        libvirt-daemon-kvm${SPECIFIC_LIBVIRT_VERSION} \
         qemu-kvm \
         libgcrypt \
         swtpm \


### PR DESCRIPTION
Following [MGMT-9273](https://issues.redhat.com/browse/MGMT-9273), we should first allow installations on Rocky Linux.
This change mainly enables usage and make sure test-infra stay our of the way, but it also does the following temporary hack (and only for Rocky Linux):
```sudo dnf install libvirt-6.0.0-37.module+el8.5.0+670+c4aa478c```

This is because Rocky installs by default a slightly newer version which brings up the following error when deploying the hosts:
```
module.masters[2].libvirt_domain.host: Creating...
module.masters[1].libvirt_domain.host: Creating...
module.masters[0].libvirt_domain.host: Creating...

Warning: Experimental feature "module_variable_optional_attrs" is active

  on ../baremetal_host/main.tf line 9, in terraform:
   9:   experiments = [module_variable_optional_attrs]

Experimental features are subject to breaking changes in future minor or patch
releases, based on feedback.

If you have feedback on the design of this feature, please open a GitHub issue
to discuss it.

(and one more similar warning elsewhere)

 , error
Error: Operation not supported: can't update 'bridge' section of network 'test-infra-net-2e699f9b'

  on ../baremetal_host/main.tf line 19, in resource "libvirt_domain" "host":
  19: resource "libvirt_domain" "host" {



Error: Operation not supported: can't update 'bridge' section of network 'test-infra-net-2e699f9b'

  on ../baremetal_host/main.tf line 19, in resource "libvirt_domain" "host":
  19: resource "libvirt_domain" "host" {



Error: Operation not supported: can't update 'bridge' section of network 'test-infra-net-2e699f9b'

  on ../baremetal_host/main.tf line 19, in resource "libvirt_domain" "host":
  19: resource "libvirt_domain" "host" {
```