### PR TITLE
NO-ISSUE: Fix make all target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -142,7 +142,7 @@ endif
 # General #
 ###########
 
-all: setup run_full_flow_with_install
+all: setup run deploy_nodes_with_install
 
 destroy: destroy_nodes delete_minikube kill_port_forwardings destroy_onprem stop_load_balancer
 


### PR DESCRIPTION
Fixes the `all` target by replacing `full_flow_with_install` with  `deploy_nodes_with_install` target as it is documented in the [README.md](https://github.com/openshift/assisted-test-infra/blob/master/README.md#run-full-flow-with-install), since the `run_full_flow_with_install` no longer exists due to this [PR](https://github.com/openshift/assisted-test-infra/commit/87ef5d0e1492a69e975419e165f73ae0afbdb234#diff-76ed074a9305c04054cdebb9e9aad2d818052b07091de1f20cad0bbac34ffb52L252).

@osherdp can you take a look at your convenience? 