### PR TITLE
Replace occurrences of ocpmetal with edge-infrastructure

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -1,4 +1,4 @@
-FROM quay.io/ocpmetal/assisted-service:latest AS service
+FROM quay.io/edge-infrastructure/assisted-service:latest AS service
 
 FROM quay.io/centos/centos:stream8
 

--- a/Makefile
+++ b/Makefile
@@ -31,9 +31,9 @@ LINT_CODE_STYLING_DIRS := src/tests src/assisted_test_infra/test_infra src/assis
 SERVICE_BRANCH := $(or $(SERVICE_BRANCH), "master")
 SERVICE_BASE_REF := $(or $(SERVICE_BASE_REF), "master")
 SERVICE_REPO := $(or $(SERVICE_REPO), "https://github.com/openshift/assisted-service")
-SERVICE := $(or $(SERVICE), quay.io/ocpmetal/assisted-service:latest)
+SERVICE := $(or $(SERVICE), quay.io/edge-infrastructure/assisted-service:latest)
 SERVICE_NAME := $(or $(SERVICE_NAME),assisted-service)
-INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/ocpmetal/assisted-service-index:latest)
+INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/edge-infrastructure/assisted-service-index:latest)
 
 # ui service
 UI_SERVICE_NAME := $(or $(UI_SERVICE_NAME),assisted-installer-ui)


### PR DESCRIPTION
Continuing https://github.com/openshift/release/pull/26294, replacing usage of images with docker images from quay.io/edge-infrastructure, as ocpmetal is deprecated.
/cc @eliorerz 