### PR TITLE
NO-ISSUE: allow usage of Rocky Linux OS

### DIFF
--- a/create_full_environment.sh
+++ b/create_full_environment.sh
@@ -8,8 +8,8 @@ function error() {
 
 # Check OS
 OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
-if [[ ! ${OS} =~ ^(centos)$ ]] && [[ ! ${OS} =~ ^(rhel)$ ]] && [[ ! ${OS} =~ ^(fedora)$ ]]; then
-    error "\"${OS}\" is an unsupported OS. We support only CentOS, RHEL or FEDORA."
+if [[ ! ${OS} =~ ^(centos)$ ]] && [[ ! ${OS} =~ ^(rhel)$ ]] && [[ ! ${OS} =~ ^(fedora)$ ]] && [[ ! ${OS} =~ ^(rocky)$ ]]; then
+    error "\"${OS}\" is an unsupported OS. We support only CentOS, RHEL, FEDORA or Rocky."
     exit 1
 fi
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,7 +11,7 @@ Jinja2===3.0.2
 jira==3.0.1
 junit-report==0.1.42
 kubernetes==18.20.0
-libvirt-python==7.8.0
+libvirt-python==8.0.0
 munch==2.5.0
 netaddr==0.8.0
 netifaces==0.11.0

--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -13,8 +13,23 @@ function version_is_greater() {
 }
 
 function install_libvirt() {
+    source /etc/os-release  # This should set `PRETTY_NAME` as environment variable
+
+    # TODO: support libvirt >= 6.0.0-37-1
+    SPECIFIC_LIBVIRT_VERSION=""
+    if [[ "${PRETTY_NAME}" == "Rocky Linux 8"* ]]; then
+        echo "Installing a downgraded version of libvirt, as we currently don't support the newer one..."
+        SPECIFIC_LIBVIRT_VERSION="-6.0.0-37.module+el8.5.0+670+c4aa478c"
+    fi
+
     echo "Installing libvirt..."
-    sudo dnf install -y libvirt libvirt-devel libvirt-daemon-kvm qemu-kvm libgcrypt
+    sudo dnf install -y \
+        libvirt${SPECIFIC_LIBVIRT_VERSION} \
+        libvirt-devel${SPECIFIC_LIBVIRT_VERSION} \
+        libvirt-daemon-kvm${SPECIFIC_LIBVIRT_VERSION} \
+        qemu-kvm \
+        libgcrypt
+
     sudo systemctl enable libvirtd
 
     current_version="$(libvirtd --version | awk '{print $3}')"


### PR DESCRIPTION
Since https://github.com/openshift/release/pull/25960, we provision Rocky Linux in our CI workflows.
This is a manual backport of #1462, which is required for test-infra to allow Rocky Linux OS to be used, and to install the specific libvirt version we need in that OS.

/cc @eliorerz @michaellevy101 