### PR TITLE
NO-ISSUE - Fix missing default version on specific openshift version

### DIFF
--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -17,7 +17,6 @@ def api_client():
 
 def get_available_openshift_versions() -> List[str]:
     openshift_versions = global_variables.get_api_client().get_openshift_versions()
-    default_version = [k for k, v in openshift_versions.items() if "default" in v and v["default"]].pop()
     available_versions = list(openshift_versions.keys())
     override_version = utils.get_openshift_version(allow_default=False)
 
@@ -31,7 +30,7 @@ def get_available_openshift_versions() -> List[str]:
             f"{available_versions + [consts.OpenshiftVersion.MULTI_VERSION.value]}"
         )
 
-    return [default_version]
+    return [k for k, v in openshift_versions.items() if "default" in v and v["default"]]
 
 
 @pytest.hookimpl(tryfirst=True, hookwrapper=True)


### PR DESCRIPTION
 https://github.com/openshift/assisted-service/pull/3380 caused KeyError when trying to get the default version (if `OPENSHIFT_VERSION` is set to version different than the default version). 
In that case we tried to get the default version even if it's not exists in the service. 
The solution to this issue is: moving the `default_version` after the 'override_version' (`OPENSHIFT_VERSION`). 

/cc @osherdp