### PR TITLE
NO-ISSUE - Remove arkade dependency

### DIFF
--- a/scripts/install_minikube.sh
+++ b/scripts/install_minikube.sh
@@ -2,41 +2,24 @@
 set -euxo pipefail
 export SUDO=$(if [ -x "$(command -v sudo)" ]; then echo "sudo"; else echo ""; fi)
 
+
 function install_minikube() {
-    if [ "${DEPLOY_TARGET}" != "minikube" ]; then
-        echo "Skips installing minikube when deployment target is ${DEPLOY_TARGET}..."
-        return
-    fi
-
-    minikube_version=v1.23.2
-    if ! [ -x "$(command -v minikube)" ]; then
-        echo "Installing minikube..."
-        download_minikube $minikube_version
-        ${SUDO} mv -f ${HOME}/.arkade/bin/minikube /usr/local/bin/
-    elif [ "$(minikube version | grep version | awk -F'version: *' '{print $2}')" != "$minikube_version" ]; then
-        echo "Upgrading minikube..."
-        download_minikube $minikube_version
-        ${SUDO} mv -f ${HOME}/.arkade/bin/minikube $(command -v minikube)
-    else
-        echo "minikube is already installed and up-to-date"
-    fi
+    minikube_version=v1.25.2
+    curl --retry 3 -Lo minikube https://storage.googleapis.com/minikube/releases/${minikube_version}/minikube-linux-amd64
+    ${SUDO} install minikube /usr/local/bin/
+    minikube version
 }
 
-function download_minikube() {
-    for i in {1..4}; do
-        arkade get minikube --version=$1 && break
-        echo "minikube installation failed. Retrying again in 5 seconds..."
-        sleep 5
-    done
-}
 function install_kubectl() {
-    if ! [ -x "$(command -v kubectl)" ]; then
-        echo "Installing kubectl..."
-        arkade get kubectl --version=v1.22.0
-        ${SUDO} mv ${HOME}/.arkade/bin/kubectl /usr/local/bin/
-    else
-        echo "kubectl is already installed"
-    fi
+    kubectl_version=v1.23.0
+    curl --retry 3 -LO https://dl.k8s.io/release/${kubectl_version}/bin/linux/amd64/kubectl
+    chmod +x kubectl
+
+    curl -LO https://dl.k8s.io/${kubectl_version}/bin/linux/amd64/kubectl.sha256
+    echo "$(<kubectl.sha256)  kubectl" | sha256sum --check
+    rm -f kubectl.sha256
+    ${SUDO} install kubectl /usr/local/bin/
+    kubectl
 }
 
 function install_oc() {
@@ -52,22 +35,7 @@ function install_oc() {
     fi
 }
 
-function install_arkade() {
-    if ! [ -x "$(command -v arkade)" ]; then
-        echo "Installing arkade..."
-        for i in {1..4}; do
-            curl --retry 3 -sLS https://get.arkade.dev | ${SUDO} sh && break
-            echo "arkade installation failed. Retrying again in 5 seconds..."
-            sleep 5
-        done
-        arkade version # Fail installation if not exist
-        echo "successfully installed arkade!"
-    else
-        echo "arkade is already installed"
-    fi
-}
 
-install_arkade
 install_minikube
 install_kubectl
 install_oc


### PR DESCRIPTION
Currently we are using `arkade` to install minikube and kubectl during environment setup.
After the change of `arkade` domains (that caused our CI to fail), we reconsidered the usage in this tool.

This PR also upgrade:
- `minikube` - from v1.20.0 to latest (v1.25.2)
- `kubectl` - from v1.20.1 to latest (v1.22.0)

/cc @osherdp 