### PR TITLE
NO-ISSUE: fix arkade DNS to the updated one

### DIFF
--- a/scripts/install_minikube.sh
+++ b/scripts/install_minikube.sh
@@ -9,7 +9,7 @@ function install_minikube() {
 
     minikube_version=v1.20.0
     minikube_path=$(command -v minikube)
-    if ! [ -x "$minikube_path" ]; then 
+    if ! [ -x "$minikube_path" ]; then
         echo "Installing minikube..."
         arkade get minikube --version=$minikube_version
         ${SUDO} mv -f ${HOME}/.arkade/bin/minikube /usr/local/bin/
@@ -48,7 +48,7 @@ function install_oc() {
 function install_arkade() {
     if ! [ -x "$(command -v arkade)" ]; then
         echo "Installing arkade..."
-        curl -sLS https://dl.get-arkade.dev | ${SUDO} sh
+        curl -sLS https://get.arkade.dev | ${SUDO} sh
     else
         echo "arkade is already installed"
     fi


### PR DESCRIPTION
Update arkade domain due to changes made on
https://github.com/alexellis/arkade/commit/d7d1e59e18663c74ae538270cc3b4d9b3a637c24

This is a backport of #1487, as it happens for this branch as well:
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-service/2961/pull-ci-openshift-assisted-service-release-ocm-2.4-e2e-metal-assisted/1498302543682342912