### PR TITLE
NO-ISSUE - Always clone assisted-service repository on bring_assisted_service Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -203,7 +203,7 @@ run: validate_namespace deploy_assisted_service deploy_ui
 set_dns:
 	scripts/assisted_deployment.sh set_dns $(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE) $(OC_FLAG))
 
-deploy_ui: start_minikube
+deploy_ui: start_minikube bring_assisted_service
 	NAMESPACE_INDEX=$(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE) $(OC_FLAG)) scripts/deploy_ui.sh
 
 deploy_prometheus_ui:
@@ -289,9 +289,8 @@ deploy_assisted_service: start_minikube bring_assisted_service
 	DEPLOY_TAG=$(DEPLOY_TAG) CONTAINER_COMMAND=$(CONTAINER_COMMAND) NAMESPACE_INDEX=$(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE) $(OC_FLAG)) AUTH_TYPE=$(AUTH_TYPE) scripts/deploy_assisted_service.sh
 
 bring_assisted_service:
-	@if ! cd assisted-service >/dev/null 2>&1; then \
-		git clone $(SERVICE_REPO); \
-	fi
+	rm -rf assisted-service
+    git clone $(SERVICE_REPO); \
 
 ifeq ($(shell [[ $(OPENSHIFT_CI) == "true" && $(REPO_NAME) == "assisted-service" && $(JOB_TYPE) == "presubmit" ]] && echo true),true)
 	@echo "Running in assisted-service pull request"


### PR DESCRIPTION
Force cloning `assisted-service` on `bring_assisted_service` Makefile target - Preventing issue with  deploying the UI


```
Traceback (most recent call last):                  
  File "./tools/deploy_ui.py", line 75, in <module>            
    main()                                                       
  File "./tools/deploy_ui.py", line 40, in main              
    utils.check_output(cmd)                                                                 
  File "/home/test/assisted-test-infra/assisted-service/tools/utils.py", line 75, in check_output
    raise RuntimeError(f'command={command} exited with an error={err if err else out} code={process.returncode}')
RuntimeError: command=cd /home/test/assisted-test-infra/assisted-service/build/assisted-installer-ui && git pull && deploy/deploy_config.sh -t /home/test/assisted-test-infra/assisted-service/
build/assisted-installer-ui/deploy/ui-deployment-template.yaml -i quay.io/edge-infrastructure/assisted-installer-ui:latest -n assisted-installer > /home/test/assisted-test-infra/assisted-serv
ice/build/assisted-installer/deploy_ui.yaml exited with an error=error: Pulling is not possible because you have unmerged files.
hint: Fix them up in the work tree, and then use 'git add/rm <file>'          
```

/cc @tsorya 