### PR TITLE
Use hypershift-operator image for installing hypershift

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -378,7 +378,7 @@ _test_parallel: $(REPORTS) _test_setup
 # Capi #
 ########
 deploy_capi_env: start_minikube
-	skipper run scripts/setup_capi_env.sh
+	scripts/setup_capi_env.sh
 
 
 #########

--- a/scripts/setup_capi_env.sh
+++ b/scripts/setup_capi_env.sh
@@ -2,59 +2,35 @@
 set -euo pipefail
 set -o xtrace
 
-PROVIDER_REPO="${PROVIDER_REPO:-https://github.com/openshift/cluster-api-provider-agent.git}"
-PROVIDER_BRANCH="${PROVIDER_BRANCH:-master}"
-PROVIDER_IMAGE="${PROVIDER_IMAGE:-quay.io/edge-infrastructure/cluster-api-provider-agent:latest}"
-HYPERSHIFT_REPO="${HYPERSHIFT_REPO:-https://github.com/openshift/hypershift}"
-HYPERSHIFT_BRANCH="${HYPERSHIFT_BRANCH:-main}"
-HYPERSHIFT_IMAGE="${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:latest}"
-DEPLOY_CAPI_PROVIDER="${DEPLOY_CAPI_PROVIDER:-false}"
-BASE_DIR=build
-
-function clone_repo() {
-  if [[ ! -d "$BASE_DIR/$2" ]]; then
-    echo "Cloning $1."
-    git clone $1 $BASE_DIR/$2
-  fi
-}
-
-function checkout_branch() {
-  (
-    cd $BASE_DIR/$1
-    git fetch
-    git checkout -B $2 origin/$2
-  )
-}
+export HYPERSHIFT_IMAGE="${HYPERSHIFT_IMAGE:-quay.io/hypershift/hypershift-operator:latest}"
+export KUBECONFIG=${KUBECONFIG:-$HOME/.kube/config}
+export CONTAINER_COMMAND=${CONTAINER_COMMAND:-podman}
+export BASE_DIR=build
 
 function waitForPodsReadyStatus(){
   while [[ $(kubectl get pods -n $1 -o 'jsonpath={..status.conditions[?(@.type=="Ready")].status}'| tr ' ' '\n'  | sort -u) != "True" ]]; do
     echo "Waiting for pods in namespace $1 to be ready"
-    kubectl get pods -n $1 -o 'jsonpath={..status.containerStatuses}' | jq
+    kubectl get pods -n $1 -o 'jsonpath={..status.containerStatuses}' | jq "."
     sleep 5;
   done
   echo "Pods in namespace $1 are ready"
 }
 
-deploy_provider() {
-  clone_repo "$PROVIDER_REPO" provider
-  checkout_branch provider "$PROVIDER_BRANCH"
-  make -C $BASE_DIR/provider deploy IMG="$PROVIDER_IMAGE"
-}
-
 deploy_hypershift() {
   kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.51.1/bundle.yaml || true
-  clone_repo $HYPERSHIFT_REPO hypershift
-  checkout_branch hypershift "$HYPERSHIFT_BRANCH"
-  make -C $BASE_DIR/hypershift build
-  $BASE_DIR/hypershift/bin/hypershift install --hypershift-image "$HYPERSHIFT_IMAGE"
+  HYPERSHIFT_BIN_DIR=$BASE_DIR/hypershift/bin
+  mkdir -p $HYPERSHIFT_BIN_DIR
+  echo "Copy the binary from the image"
+  # The same binary is later used by the hypershift helper class
+  ${CONTAINER_COMMAND} run -it \
+  -v $(pwd)/$HYPERSHIFT_BIN_DIR:/root/hypershift_bin \
+  --entrypoint cp \
+  "$HYPERSHIFT_IMAGE" \
+  /usr/bin/hypershift /root/hypershift_bin
+
+  $HYPERSHIFT_BIN_DIR/hypershift install --hypershift-image "$HYPERSHIFT_IMAGE"
   waitForPodsReadyStatus hypershift
 }
-
-mkdir -p $BASE_DIR
-if [ "${DEPLOY_CAPI_PROVIDER}" == "true" ]; then
-  echo "Deploying Cluster API Provider Agent"
-  deploy_provider
-fi
 
 echo "Deploying HyperShift"
 deploy_hypershift


### PR DESCRIPTION
This should allow the capi jobs to run without cloning and building the hypershift repo