### PR TITLE
NO-ISSUE: Improve .flake8 rules and documentation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,5 +1,12 @@
 [flake8]
-ignore = E203, F403, W503, FS003
+ignore =
+    # E203 and W503 are rules that conflict with Black
+    E203,
+    W503,
+
+    # FS003 weirdly thinks things are supposed to be f-strings? Seems completely broken
+    FS003,
+
 max-line-length = 120
 max-complexity = 18
 select = B,C,E,F,W,T4,B9


### PR DESCRIPTION
See comments in diff for more information

F403 (https://www.flake8rules.com/rules/F403.html) was removed because
we don't seem to be violate it anywhere anyway