### PR TITLE
MGMT-8859: The creation of cluster deployment depends on the control plane so the test should wait for thee control plane first

### DIFF
--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -198,6 +198,8 @@ class TestKubeAPI(BaseKubeAPI):
                     ssh_key=ssh_public_key_file,
                 )
 
+        hypershift.wait_for_control_plane_ready()
+
         cluster_deployment = ClusterDeployment(api_client, cluster_name, f"clusters-{cluster_name}")
 
         def _cluster_deployment_installed() -> bool:


### PR DESCRIPTION
This should solve the failing tests due to ` Timeout of 60 seconds expired waiting for clusterDeployment to get created`
e.g.
https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_assisted-service/3406/pull-ci-openshift-assisted-service-master-e2e-metal-assisted-capi/1498926596482928640/artifacts/e2e-metal-assisted-capi/assisted-baremetal-setup/build-log.txt