### PR TITLE
MGMT-9471: fix sosreport gathering on BIP test

### DIFF
--- a/src/tests/test_bootstrap_in_place.py
+++ b/src/tests/test_bootstrap_in_place.py
@@ -190,7 +190,7 @@ class TestBootstrapInPlace(BaseTest):
 
         with SuppressAndLog(Exception):
             log.info("Gathering sosreport data from host...")
-            gather_sosreport_data(log, output_dir=IBIP_DIR)
+            gather_sosreport_data(output_dir=IBIP_DIR)
 
         with SuppressAndLog(Exception):
             log.info("Gathering information via installer-gather...")


### PR DESCRIPTION
Seems like #1452 broken sosreport gathering by passing in a non-existing log parameter to this function.

/cc @eliorerz 
/hold