### PR TITLE
NO-ISSUE: Fix boolean var check not adhering to the default true|false in Makefile rule

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -233,7 +233,7 @@ install_cluster:
 #########
 
 deploy_nodes_with_install: start_load_balancer
-	@if [ "$(ENABLE_KUBE_API)" = "no"  ]; then \
+	@if [ "$(ENABLE_KUBE_API)" = "false"  ]; then \
 		TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_install_with_deploy_nodes $(MAKE) test; \
 	else \
 		TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_kubeapi_install_with_deploy_nodes $(MAKE) test; \


### PR DESCRIPTION
This PR fixes the boolean variable `ENABLE_KUBE_API` check in the `deploy_nodes_with_install` Makefile rule. 

The default value of `ENABLE_KUBE_API` is ["false"](https://github.com/openshift/assisted-test-infra/blob/master/Makefile#L98), but we were checking for ["no"](https://github.com/openshift/assisted-test-infra/blob/master/Makefile#L236).