### PR TITLE
Ignore kubectl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,3 +11,4 @@ minikube
 *~
 .env
 capi
+kubectl


### PR DESCRIPTION
Why? Because `kubectl` gets overwritten every time we run `make setup`.