### PR TITLE
MGMT-9549:Trigger for remote deploy HW specs

### DIFF
--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -128,6 +128,15 @@ REQUIRED_ASSET_FIELDS = (
     *IP_NETWORK_ASSET_FIELDS,
 )
 
+# DISK SIZES
+DISK_SIZE_120GB = 120 * 2**30
+
+
+class RemoteEnvironment:
+    PRODUCTION = "https://api.openshift.com"
+    STAGING = "https://api.stage.openshift.com"
+    INTEGRATION = "https://api.integration.openshift.com"
+
 
 class ImageType:
     FULL_ISO = "full-iso"

--- a/src/tests/global_variables/default_variables.py
+++ b/src/tests/global_variables/default_variables.py
@@ -1,4 +1,5 @@
 from contextlib import suppress
+from dataclasses import dataclass
 from typing import Any, ClassVar
 
 from assisted_test_infra.test_infra.helper_classes.config.base_config import Triggerable
@@ -8,6 +9,7 @@ from tests.global_variables.env_variables_defaults import _EnvVariables
 from triggers import Trigger, get_default_triggers
 
 
+@dataclass(frozen=True)
 class DefaultVariables(_EnvVariables, Triggerable):
     __instance: ClassVar = None
 
@@ -43,7 +45,7 @@ class DefaultVariables(_EnvVariables, Triggerable):
         if not hasattr(self, key):
             raise AttributeError(f"Invalid key {key}")
 
-        _EnvVariables.__setattr__(key, value)
+        object.__setattr__(self, key, value)
 
     def _get_data_pool(self) -> object:
         return self

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -8,6 +8,15 @@ from triggers.olm_operators_trigger import OlmOperatorsTrigger
 
 _default_triggers = frozendict(
     {
+        "production": Trigger(
+            condition=("remote_service_url", consts.RemoteEnvironment.PRODUCTION), worker_disk=consts.DISK_SIZE_120GB
+        ),
+        "staging": Trigger(
+            condition=("remote_service_url", consts.RemoteEnvironment.STAGING), worker_disk=consts.DISK_SIZE_120GB
+        ),
+        "integration": Trigger(
+            condition=("remote_service_url", consts.RemoteEnvironment.INTEGRATION), worker_disk=consts.DISK_SIZE_120GB
+        ),
         "none_platform": Trigger(
             ("platform", consts.Platforms.NONE), user_managed_networking=True, vip_dhcp_allocation=False
         ),


### PR DESCRIPTION
It has been observed that while testing against production, there is an
issue with disk validation on workers. It has been found that setting
the disk size of a worker to 128GB resolves the issue. This trigger has
been added to ensure that this happens.