### PR TITLE
MGMT-9470: Use edge-infrastructure index

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -33,7 +33,7 @@ SERVICE_BASE_REF := $(or $(SERVICE_BASE_REF), "master")
 SERVICE_REPO := $(or $(SERVICE_REPO), "https://github.com/openshift/assisted-service")
 SERVICE := $(or $(SERVICE), quay.io/edge-infrastructure/assisted-service:latest)
 SERVICE_NAME := $(or $(SERVICE_NAME),assisted-service)
-INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/ocpmetal/assisted-service-index:latest)
+INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/edge-infrastructure/assisted-service-index:latest)
 REMOTE_SERVICE_URL := $(or $(REMOTE_SERVICE_URL), "")
 
 # ui service


### PR DESCRIPTION
With https://github.com/openshift/release/pull/26831 we now publish a
valid index in edge-infrastructure.

This reverts commit f132534d550239d7fb59f80c90c1396654dd2756.
