### PR TITLE
MGMT-9558: Adding the custom fixtures to pytest.ini file.

### DIFF
--- a/src/tests/pytest.ini
+++ b/src/tests/pytest.ini
@@ -1,3 +1,6 @@
 [pytest]
 markers =
     kube_api: mark test as part of kube api tests.
+    override_controller_configuration: mark for overriding the controller configuration fixture
+    override_cluster_configuration: mark for overriding the cluster configuration fixture
+    override_infra_env_configuration: mark for overriding the cluster infra_env fixture


### PR DESCRIPTION
- Prevent from pytest to log warning at the end of the test.

e.g.
```
src/tests/test_kube_api.py:336
  /home/assisted/src/tests/test_kube_api.py:336: PytestUnknownMarkWarning: Unknown pytest.mark.override_controller_configuration - is this a typo?
```

/cc @osherdp 