### PR TITLE
Fixup on PR 1393

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,17 +217,6 @@ kill_all_port_forwardings:
 	scripts/utils.sh kill_port_forwardings '$(SERVICE_NAME) $(UI_SERVICE_NAME)'
 	scripts/utils.sh kill_port_forwardings '$(SERVICE_NAME) $(PROMETHEUS_SERVICE_NAME)'
 
-###########
-# Cluster #
-###########
-
-_install_cluster:
-	src/install_cluster.py -id $(CLUSTER_ID) -ps '$(PULL_SECRET)' --service-name $(SERVICE_NAME) $(OC_PARAMS) -ns $(NAMESPACE) -cn $(CLUSTER_NAME)
-
-install_cluster:
-	skipper make $(SKIPPER_PARAMS) _install_cluster
-
-
 #########
 # Nodes #
 #########

--- a/README.md
+++ b/README.md
@@ -121,7 +121,7 @@ Check the [Install Guide](GUIDE.md) for installation instructions.
 |     |     |
 | --- | --- |
 | `BASE_DOMAIN`                 | base domain, needed for DNS name, default: redhat.com |
-| `CLUSTER_ID`                  | cluster id , used for install_cluster command, default: the last spawned cluster |
+| `CLUSTER_ID`                  | cluster id, used for already existing cluster, e.g. after the deploy_nodes command |
 | `CLUSTER_NAME`                | cluster name, used as prefix for virsh resources, default: test-infra-cluster |
 | `HTTPS_PROXY_URL`             | A proxy URL to use for creating HTTPS connections outside the cluster |
 | `HTTP_PROXY_URL`              | A proxy URL to use for creating HTTP connections outside the cluster |
@@ -253,14 +253,6 @@ Sometimes you may need to delete all libvirt resources
 
 ```bash
 make delete_all_virsh_resources
-```
-
-### Install cluster
-
-Install cluster after nodes were deployed. Can take ClusterId as OS environment
-
-```bash
-make install_cluster
 ```
 
 ### Create cluster and download ISO


### PR DESCRIPTION
This PR removes the deprecated/broken Makefile rule `install_cluster`, introduced in PR #1393.