### PR TITLE
NO-ISSUE: RHCOS ISO download links sometimes have a 302 redirect, handle it with curl

### DIFF
--- a/src/tests/test_bootstrap_in_place.py
+++ b/src/tests/test_bootstrap_in_place.py
@@ -84,7 +84,9 @@ class TestBootstrapInPlace(BaseTest):
             return
 
         log.info("Downloading iso to %s", download_path)
-        utils.run_command(f"curl {rhcos_url} --retry 10 --retry-connrefused -o {download_path} --continue-at -")
+        utils.run_command(
+            f"curl --location {rhcos_url} --retry 10 --retry-connrefused -o {download_path} --continue-at -"
+        )
 
     @staticmethod
     @retry.retry(exceptions=Exception, tries=5, delay=30)


### PR DESCRIPTION
The curl `-L/--redirect` flag tells curl it should follow HTTP 302
redirect responses. Without it, the ISO file we get is invalid:

```
$ cat installer-image.iso
<html>
<head><title>302 Found</title></head>
<body>
<center><h1>302 Found</h1></center>
<hr><center>nginx/1.16.1</center>
</body>
</html>
```

During single-node-bootstrap-in-place tests, we download the RHCOS image
corresponding to the openshift release we're testing.

Looks like recently the ISO file corresponding to the 4.9 release image
we're testing is behind a redirect, which caused all single-node 4.9
live-iso jobs to fail.

This should fix that