### PR TITLE
Use pypi's assisted-service-client

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -1,5 +1,3 @@
-FROM quay.io/edge-infrastructure/assisted-service:latest AS service
-
 FROM quay.io/centos/centos:stream8
 
 RUN dnf -y install \
@@ -31,10 +29,8 @@ RUN curl -Lo - "https://github.com/vmware/govmomi/releases/latest/download/govc_
 WORKDIR /home/assisted-test-infra
 
 COPY requirements.txt requirements-dev.txt ./
-COPY --from=service /clients/assisted-service-client-*.tar.gz /build/pip/
 RUN pip3 install --upgrade pip && \
-      pip3 install --no-cache-dir -I -r ./requirements.txt -r ./requirements-dev.txt && \
-      pip3 install --upgrade /build/pip/*
+      pip3 install --no-cache-dir -I -r ./requirements.txt -r ./requirements-dev.txt
 
 RUN curl -s https://storage.googleapis.com/golang/go1.17.4.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV GOPATH=/go

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,4 @@
+assisted-service-client>=2.0.0
 boto3==1.21.13
 debugpy==1.5.1
 dnspython==2.2.0


### PR DESCRIPTION
Now that the assisted-service-client is published in the Python Package
Index, it makes sense to use that instead of copying it from the
assisted-service image.

Additionally, this should make it easier once we branch out to get the
matching assisted-service-client for specific branches rather than the
latest upstream. Though the assisted-service-client should be backwards
compatible, so it is not a big deal