### PR TITLE
NO-ISSUE - Add python client version validation before running test suite

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -379,3 +379,7 @@ test_kube_api_parallel:
 cli:
 	$(MAKE) start_load_balancer START_LOAD_BALANCER=true
 	TEST_TEARDOWN=false JUNIT_REPORT_DIR=$(REPORTS) LOGGING_LEVEL="error" skipper run -i "python3 ${DEBUG_FLAGS} -m src.cli"
+
+
+validate_client:
+	skipper run "python3 ${DEBUG_FLAGS} src/service_client/client_validator.py"

--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -296,3 +296,9 @@ class BaseAsset:
     PROVISIONING_CIDR6 = DEFAULT_MACHINE_NETWORKS_IPV6[1].cidr
     NETWORK_IF = "tt1"
     SECONDARY_NETWORK_IF = "stt1"
+
+
+class DeployTargets:
+    ONPREM = "onprem"
+    MINIKUBE = "minikube"
+    ASSISTED_OPERATOR = "operator"

--- a/src/service_client/client_validator.py
+++ b/src/service_client/client_validator.py
@@ -1,0 +1,61 @@
+import json
+import re
+from importlib import metadata
+from subprocess import PIPE, CalledProcessError, check_output
+
+from consts import consts
+from service_client.logger import log
+from tests.global_variables import DefaultVariables
+
+global_variables = DefaultVariables()
+
+
+def _get_service_container(namespace: str):
+    res = check_output(["kubectl", "get", "pods", "-n", namespace, "--output=json"])
+    data = json.loads(res)
+    containers = [item["metadata"]["name"] for item in data["items"] if item and item["metadata"]]
+    service_containers = [container for container in containers if container.startswith("assisted-service")]
+
+    return service_containers[0] if service_containers else ""
+
+
+def _get_service_version(service_container_name: str, namespace: str) -> str:
+    try:
+        cmd = f"kubectl exec -it --namespace={namespace} {service_container_name} -- bash -c 'ls /clients/*.tar.gz'"
+        src_client_file = check_output(cmd, shell=True, stderr=PIPE)
+        version = re.findall(r"assisted-service-client-(.*).tar.gz", src_client_file.decode())[0]
+        return version.strip()
+    except (CalledProcessError, KeyError):
+        return ""
+
+
+def verify_client_version(namespace="assisted-installer"):
+    """Check if the client artifact that exists on the service instance equal to the installed client version
+    on test-infra image"""
+
+    if global_variables.deploy_target == consts.DeployTargets.ONPREM:
+        log.info("Onprem environment assisted-python-client validation is currently not supported")
+        return
+
+    try:
+        service = _get_service_container(namespace)
+        service_version = _get_service_version(service, namespace)
+        client_installed_version = metadata.version("assisted-service-client")
+        if service_version == client_installed_version:
+            log.info(
+                f"Assisted python client versions match! Version on {service}={service_version} == "
+                f"installed_version={client_installed_version}"
+            )
+        else:
+            log.warning(
+                f"Mismatch client versions found! Version on {service}={service_version} != "
+                f"installed_version={client_installed_version}"
+            )
+
+    except BaseException as e:
+        # best effort
+        log.info(f"Failed to validate assisted-python-client version, {e}")
+
+
+if __name__ == "__main__":
+    verify_client_version()

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -6,12 +6,15 @@ from _pytest.nodes import Item
 import consts
 from assisted_test_infra.test_infra import utils
 from service_client import log
+from service_client.client_validator import verify_client_version
 from tests.config import global_variables
 
 
 @pytest.fixture(scope="session")
 def api_client():
     log.info("--- SETUP --- api_client\n")
+    verify_client_version()
+
     yield global_variables.get_api_client()
 
 


### PR DESCRIPTION
Validating that the client version exists on the assisted-service deployment is equal to the version that is used by out tests (installed in assisted-test-infra image)


Failure warning will be similar to:

```bash
2022-03-14 21:17:01,194 WARNING    - 139723800326400 - Mismatch client versions found! Version on assisted-service-54764b758b-78v9v=v2.1.0-132-g8c54328 != installed_version=v2.1.0-163-gfade32b
```

Note: It looks like that we sometimes have mismatch versions (test-infra client is always more updated than the client on the service deployment) on existing environments

/cc @osherdp 