### PR TITLE
Improve IBM provision script to support RHEL

### DIFF
--- a/scripts/ibmcloud_post_install.sh
+++ b/scripts/ibmcloud_post_install.sh
@@ -24,7 +24,8 @@ log "Starting ibmcloud-post-install.sh"
 
 {
 echo "Install base prerequisites"
-dnf install -y git
+dnf install -y https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm
+dnf install -y git make
 
 echo "Get AI repo"
 mkdir -p /home/test


### PR DESCRIPTION
With CentOS being deprecated, we need to install epel-release from
Fedora repositories so that when using RHEL, we have access to all the
required packages.