### PR TITLE
MGMT-9691: Allow overriding hypershift control plane operator image

### DIFF
--- a/scripts/download_logs.sh
+++ b/scripts/download_logs.sh
@@ -65,7 +65,8 @@ function download_capi_logs() {
   collect_kube_api_resources "${CAPI_PROVIDER_CRS[@]}"
   # get hypershfit CRs and logs
   collect_kube_api_resources "${HYPERSHIFT_CRS[@]}"
-  ${KUBECTL} logs deployment/operator -n hypershift
+  mkdir -p ${LOGS_DEST}/hypershift
+  ${KUBECTL} logs deployment/operator -n hypershift > ${LOGS_DEST}/hypershift/logs_operator_${DEPLOY_TARGET}.log
   # The pod name is capi-provider in case it's deployed by hypershift
   NAMESPACE=$(get_pod_namespace "capi-provider|cluster-api-provider-agent")
   mkdir ${LOGS_DEST}/${NAMESPACE}

--- a/src/assisted_test_infra/test_infra/helper_classes/hypershift.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/hypershift.py
@@ -28,7 +28,14 @@ class HyperShift:
         self._kubeconfig_path = ""
         self.hypershift_cluster_client = None
 
-    def create(self, pull_secret_file: str, agent_namespace: str, provider_image: str = "", ssh_key: str = ""):
+    def create(
+        self,
+        pull_secret_file: str,
+        agent_namespace: str,
+        provider_image: str = "",
+        hypershift_cpo_image: str = "",
+        ssh_key: str = "",
+    ):
         log.info(f"Creating HyperShift cluster {self.name}")
         cmd = (
             f"./bin/hypershift create cluster agent --pull-secret {pull_secret_file} --name {self.name}"
@@ -37,6 +44,9 @@ class HyperShift:
         if provider_image:
             log.info(f"Using provider image {provider_image}")
             cmd += f" --annotations hypershift.openshift.io/capi-provider-agent-image={provider_image}"
+        if hypershift_cpo_image:
+            log.info(f"Using hypershift control-plane-operator image {hypershift_cpo_image}")
+            cmd += f" --control-plane-operator-image={hypershift_cpo_image}"
         if ssh_key:
             cmd += f" --ssh-key {ssh_key}"
         utils.run_command_with_output(cmd, cwd=HYPERSHIFT_DIR)

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -195,6 +195,7 @@ class TestKubeAPI(BaseKubeAPI):
                     pull_secret_file=ps,
                     agent_namespace=spoke_namespace,
                     provider_image=os.environ.get("PROVIDER_IMAGE", ""),
+                    hypershift_cpo_image=os.environ.get("HYPERSHIFT_IMAGE", ""),
                     ssh_key=ssh_public_key_file,
                 )
 
@@ -396,9 +397,7 @@ class TestLateBinding(BaseKubeAPI):
 
     @JunitTestSuite()
     @pytest.mark.kube_api
-    def test_prepare_late_binding_kube_api_ipv4_highly_available(
-            self, unbound_highly_available_infraenv
-    ):
+    def test_prepare_late_binding_kube_api_ipv4_highly_available(self, unbound_highly_available_infraenv):
         infra_env, nodes = unbound_highly_available_infraenv
         agents: List[Agent] = infra_env.wait_for_agents(len(nodes))
         assert len(agents) == len(nodes), f"Expected {len(nodes)} agents, found {len(agents)}"

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -394,6 +394,15 @@ class TestLateBinding(BaseKubeAPI):
 
         self._late_binding_install(cluster_deployment, agent_cluster_install, agents, nodes)
 
+    @JunitTestSuite()
+    @pytest.mark.kube_api
+    def test_prepare_late_binding_kube_api_ipv4_highly_available(
+            self, unbound_highly_available_infraenv
+    ):
+        infra_env, nodes = unbound_highly_available_infraenv
+        agents: List[Agent] = infra_env.wait_for_agents(len(nodes))
+        assert len(agents) == len(nodes), f"Expected {len(nodes)} agents, found {len(agents)}"
+
     @JunitTestCase()
     def prepare_late_binding_cluster(
         self,


### PR DESCRIPTION
 [MGMT-9691](https://issues.redhat.com/browse/MGMT-9691): CAPI e2e test is failing due to hypershift control plane operator image mismatch
 
 [MGMT-9213](https://issues.redhat.com/browse/MGMT-9213): Add test_prepare_late_binding_kube_api_ipv4_highly_available to test_kube_api
 This can be used by capi test for setting up the env

Save hypershift logs to file
