### PR TITLE
MGMT-9726: Ensure an exception is raised when download ISO failed

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -538,6 +538,7 @@ def get_assisted_controller_status(kubeconfig):
 
 def download_iso(image_url, image_path):
     with requests.get(image_url, stream=True, verify=False) as image, open(image_path, "wb") as out:
+        image.raise_for_status()
         for chunk in image.iter_content(chunk_size=1024):
             out.write(chunk)
 


### PR DESCRIPTION
The late binding job sometimes tries to boot on an invalid ISO image
because the assisted-image-service is not accessible. Making this issue
visible will help the debugging.
