### PR TITLE
MGMT-9822 - Fix test-infra test failure when trigger is applied twice to the same variable

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/env_var.py
+++ b/src/assisted_test_infra/test_infra/utils/env_var.py
@@ -52,3 +52,11 @@ class EnvVar:
                 value = self.__loader(env) if self.__loader else env
                 break
         return value
+
+    def copy(self, value=None) -> "EnvVar":
+        """Get EnvVar copy, if value is different than None it will set the old EnvVar value"""
+        env = EnvVar(self.__var_keys, loader=self.__loader, default=self.__default)
+        env.__is_user_set = self.__is_user_set
+        env.__value = value if value else self.__value
+
+        return env

--- a/src/tests/global_variables/default_variables.py
+++ b/src/tests/global_variables/default_variables.py
@@ -38,7 +38,7 @@ class DefaultVariables(_EnvVariables, Triggerable):
         if not hasattr(self, key):
             raise AttributeError(f"Invalid key {key}")
 
-        object.__setattr__(self, key, value)
+        object.__setattr__(self, key, self.get_env(key).copy(value))  # create a new env-var with the new value
 
     def _get_data_pool(self) -> object:
         return self


### PR DESCRIPTION

```
...
2022-03-30 21:36:32,300  root DEBUG      - 139625652396288 - DefaultVariables - Trigger set vip_dhcp_allocation to False, Condition: ('masters_count', 1)     (/assisted-test-infra/src/triggers/env_trigger.py:36)
...
2022-03-30 21:41:53,580  root INFO       - 139625652396288 - Handling ipv6_required_configurations trigger     (/assisted-test-infra/src/triggers/env_trigger.py:78)
ImportError while loading conftest '/assisted-test-infra/src/tests/conftest.py'.
src/tests/conftest.py:9: in <module>
    from service_client.client_validator import verify_client_version
src/service_client/client_validator.py:10: in <module>
    global_variables = DefaultVariables()
src/tests/global_variables/default_variables.py:32: in __post_init__
    Trigger.trigger_configurations([self], get_default_triggers())
src/triggers/env_trigger.py:79: in trigger_configurations
    trigger.handle_trigger(config)
src/triggers/env_trigger.py:60: in handle_trigger
    config.handle_trigger(self._conditions, self._variables_to_set)
src/triggers/env_trigger.py:35: in handle_trigger
    if not self.is_user_set(k):
src/tests/global_variables/default_variables.py:35: in is_user_set
    return self.get_env(item).is_user_set
E   AttributeError: 'bool' object has no attribute 'is_user_set'
```

/cc @osherdp 