### PR TITLE
MGMT-9770: Fix issue with Hashicorp RPM during test-infra image build

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -18,13 +18,9 @@ RUN dnf -y install \
   libvirt-client \
   libvirt-devel \
   libguestfs-tools \
-    && dnf config-manager --add-repo https://rpm.releases.hashicorp.com/RHEL/hashicorp.repo \
-    && dnf -y install packer \
-    && mv /usr/bin/packer /usr/bin/packer.io \
-    && dnf -y install epel-release \
-    && dnf -y install ansible \
-    && dnf clean all
+   && dnf clean all
 
+RUN curl --retry 5 -Lo packer.zip https://releases.hashicorp.com/packer/1.8.0/packer_1.8.0_linux_386.zip && unzip packer.zip -d /usr/bin/ && mv /usr/bin/packer /usr/bin/packer.io && rm -rf packer.zip
 RUN curl --retry 5 -Lo terraform.zip https://releases.hashicorp.com/terraform/0.14.11/terraform_0.14.11_linux_amd64.zip && unzip terraform.zip -d /usr/bin/ && rm -rf terraform.zip
 RUN curl --retry 5 -Lo - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | tar -C /usr/local/bin -xvzf - govc
 


### PR DESCRIPTION
Looks like Hashcorp rpm repo isn't stable we are getting
Removing ansible from the image since we use dev-scripts image for ansible Hashicorp Stable.

Partial backport of https://github.com/openshift/assisted-test-infra/pull/1558

/cc @osherdp @michaellevy101 