### PR TITLE
MGMT-9852 - Fix image build failed during CI job

### DIFF
--- a/create_full_environment.sh
+++ b/create_full_environment.sh
@@ -31,6 +31,8 @@ scripts/install_environment.sh
 echo "Done installing"
 
 echo "Creating image"
+make bring_assisted_service
+scripts/pull_dockerfile_images.sh
 make image_build
 echo "Done creating image"
 

--- a/scripts/pull_dockerfile_images.sh
+++ b/scripts/pull_dockerfile_images.sh
@@ -1,0 +1,22 @@
+#!/bin/bash
+
+export CONTAINER_COMMAND=${CONTAINER_COMMAND:-podman}
+
+images=$(cat Dockerfile.* ./*/Dockerfile.* | grep FROM | awk '{print $2}')
+echo "### Attempting to download assisted dockerfile images (best effort) ###"
+echo "Images found: ${images}"
+
+for image in ${images}; do
+  if [[ ${image} =~ (.*:.*) ]]; then
+      for i in {1..5}; do
+        echo "Image ${image} ${i} download attempt ${image}"
+        podman pull "${image}" || rc=$?
+
+        if [[ "${rc}" -eq 0 ]]; then
+          break
+        fi
+
+        echo "Failed to download image ${image}, retrying ..."
+      done
+  fi
+done


### PR DESCRIPTION
Add `best-effort script` for pulling all the images that exists in test-infra and assisted-service Dockerfiles (prevent CI jobs to fail due to networking issue)

/cc @adriengentil 