### PR TITLE
MGMT-9213: add ingress_dns option to terraform_controller

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -162,6 +162,11 @@ class TerraformController(LibvirtController):
         tfvars["libvirt_worker_ips"] = self._create_address_list(
             self.params.worker_count, starting_ip_addr=worker_starting_ip
         )
+        if self._config.ingress_dns:
+            for service in ["console-openshift-console", "canary-openshift-ingress", "oauth-openshift"]:
+                self.params["libvirt_dns_records"][
+                    ".".join([service, "apps", self._config.cluster_name, self._entity_config.base_dns_domain])
+                ] = tfvars["libvirt_worker_ips"][0][0]
         tfvars["machine_cidr_addresses"] = self.get_all_machine_addresses()
         tfvars["provisioning_cidr_addresses"] = self.get_all_provisioning_addresses()
         tfvars["bootstrap_in_place"] = self._config.bootstrap_in_place

--- a/src/assisted_test_infra/test_infra/helper_classes/config/nodes_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/nodes_config.py
@@ -21,7 +21,7 @@ class BaseTerraformConfig(BaseNodeConfig, ABC):
     libvirt_secondary_master_ips: List[str] = None
     libvirt_worker_ips: List[str] = None
     libvirt_secondary_worker_ips: List[str] = None
-
+    ingress_dns: bool = False
     net_asset: Munch = None
     tf_folder: str = None
     network_name: str = None

--- a/src/tests/base_kubeapi_test.py
+++ b/src/tests/base_kubeapi_test.py
@@ -95,7 +95,9 @@ class BaseKubeAPI(BaseTest):
         terraform_config.masters_count = 0
         terraform_config.workers_count = 2
         terraform_config.worker_vcpu = 4
-        terraform_config.workerr_memory = 17920
+        terraform_config.worker_memory = 17920
+        terraform_config.ingress_dns = True
+        terraform_config.cluster_name = global_variables.cluster_name
 
     @classmethod
     def _bind_all(cls, cluster_deployment: ClusterDeployment, agents: List[Agent]):

--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -18,6 +18,7 @@ class _EnvVariables(DataPool, ABC):
     offline_token: EnvVar = EnvVar(["OFFLINE_TOKEN"])
     openshift_version: EnvVar = EnvVar(["OPENSHIFT_VERSION"], default=consts.OpenshiftVersion.VERSION_4_10.value)
     base_dns_domain: EnvVar = EnvVar(["BASE_DOMAIN"], default=env_defaults.DEFAULT_BASE_DNS_DOMAIN)
+    cluster_name: EnvVar = EnvVar(["CLUSTER_NAME"], default="")
     masters_count: EnvVar = EnvVar(
         ["MASTERS_COUNT", "NUM_MASTERS"], loader=int, default=env_defaults.DEFAULT_NUMBER_OF_MASTERS
     )


### PR DESCRIPTION
This should allow users to get route for cluster ingress configured to one of the workers
(users can pass CLUSTER_NAME and CLUSTER_BASE_DOMAIN)
This is useful for late binding tests that don't use Baremetal platform (e.g. None, HyperShift)