### PR TITLE
NO-ISSUE - Fix fetching pull-request when running `bring_assisted_service` twice

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -283,7 +283,7 @@ bring_assisted_service:
 ifeq ($(shell [[ $(OPENSHIFT_CI) == "true" && $(REPO_NAME) == "assisted-service" && $(JOB_TYPE) == "presubmit" ]] && echo true),true)
 	@echo "Running in assisted-service pull request"
 	@cd assisted-service && \
-	git fetch origin pull/$(PULL_NUMBER)/head:assisted-service-pr-$(PULL_NUMBER) && \
+	git fetch --update-head-ok origin pull/$(PULL_NUMBER)/head:assisted-service-pr-$(PULL_NUMBER) && \
 	git checkout assisted-service-pr-$(PULL_NUMBER)
 else
 	@cd assisted-service && \


### PR DESCRIPTION
Allow git fetch to update the head which corresponds to the given PULL_NUMBER. Adding the `--update-head-ok` flag disables the check.

/cc @osherdp 