### PR TITLE
NO-ISSUE: Use unix socket in libvirt_uri

### DIFF
--- a/terraform_files/baremetal/terraform.tfvars.json
+++ b/terraform_files/baremetal/terraform.tfvars.json
@@ -8,7 +8,7 @@
   "master_disk_count": "1",
   "worker_disk_count": "1",
   "image_path": "tmp",
-  "libvirt_uri": "qemu+tcp://192.168.122.1/system",
+  "libvirt_uri": "qemu+unix:///system",
   "libvirt_network_if": "tt0",
   "libvirt_secondary_network_if": "stt0",
   "libvirt_master_ips": [["192.168.126.10"], ["192.168.126.11"], ["192.168.126.12"]],

--- a/terraform_files/baremetal_infra_env/terraform.tfvars.json
+++ b/terraform_files/baremetal_infra_env/terraform.tfvars.json
@@ -7,7 +7,7 @@
   "master_disk_count": "1",
   "worker_disk_count": "1",
   "image_path": "tmp",
-  "libvirt_uri": "qemu+tcp://192.168.122.1/system",
+  "libvirt_uri": "qemu+unix:///system",
   "libvirt_network_if": "tt0",
   "libvirt_secondary_network_if": "stt0",
   "libvirt_master_ips": [["192.168.126.10"], ["192.168.126.11"], ["192.168.126.12"]],

--- a/terraform_files/none/terraform.tfvars.json
+++ b/terraform_files/none/terraform.tfvars.json
@@ -6,7 +6,7 @@
   "master_count": "3",
   "worker_count": "0",
   "image_path": "tmp",
-  "libvirt_uri": "qemu+tcp://192.168.122.1/system",
+  "libvirt_uri": "qemu+unix:///system",
   "libvirt_secondary_network_if": "stt0",
   "libvirt_master_ips": [["192.168.126.10"], ["192.168.126.11"], ["192.168.126.12"]],
   "libvirt_secondary_master_ips": [["192.168.140.10"], ["192.168.140.11"], ["192.168.140.12"]],


### PR DESCRIPTION
192.168.122.0/24 is the default network that libvirt creates to spawn
VMs in it... except when the machine is already on this network
(e.g.: nested virtualization).

Use the unix socket instead because skipper is configured to mount it
from the host.
