### PR TITLE
MGMT-9909: Use centos stream 9 in Dockerfile

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -1,23 +1,25 @@
 FROM quay.io/edge-infrastructure/assisted-service:latest AS service
 
-FROM quay.io/centos/centos:stream8
+FROM quay.io/centos/centos:stream9
 
-RUN dnf -y install \
+# CRB repo is required for libvirt-devel
+RUN dnf -y install --enablerepo=crb \
   make \
   gcc \
   unzip \
   wget \
-  curl \
+  curl-minimal \
   git \
   podman \
   httpd-tools \
   jq \
   nss_wrapper \
-  python39 \
-  python39-devel \
+  python3 \
+  python3-devel \
   libvirt-client \
   libvirt-devel \
   libguestfs-tools \
+  libxslt \
    && dnf clean all
 
 RUN curl --retry 5 -Lo packer.zip https://releases.hashicorp.com/packer/1.8.0/packer_1.8.0_linux_386.zip && unzip packer.zip -d /usr/bin/ && mv /usr/bin/packer /usr/bin/packer.io && rm -rf packer.zip


### PR DESCRIPTION
Use centos stream 9 in infra test Dockerfile, it has the benefits to
bring an updated version of dracut that stop polluting the logs when it
tries to build the initramfs from inside a container.
