### PR TITLE
Handle forward-compatibility with 'setup' target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,7 +155,7 @@ endif
 # General #
 ###########
 
-all: create_full_environment run_full_flow_with_install
+all: setup run_full_flow_with_install
 
 
 destroy: destroy_nodes kill_port_forwardings delete_podman_localhost stop_load_balancer
@@ -163,8 +163,10 @@ destroy: destroy_nodes kill_port_forwardings delete_podman_localhost stop_load_b
 ###############
 # Environment #
 ###############
-create_full_environment:
+setup:
 	./create_full_environment.sh
+
+create_full_environment: setup  # handling backwards-compaibility
 
 create_environment: image_build bring_assisted_service start_minikube
 


### PR DESCRIPTION
Back in https://github.com/openshift/assisted-test-infra/pull/1442, we've had changed our makefile targets to remove some of
the redundancy. Most important one to handle is the ``create_full_environment`` -> ``setup`` change, because ``create_full_environment`` is heavily referenced in CI.

This PR introduce ``setup`` target so that we can use it in cross-branches places, e.g. assisted-baremetal-setup step.