### PR TITLE
Revert "MGMT-9909: Use centos stream 9 in Dockerfile"

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -1,25 +1,23 @@
 FROM quay.io/edge-infrastructure/assisted-service:latest AS service
 
-FROM quay.io/centos/centos:stream9
+FROM quay.io/centos/centos:stream8
 
-# CRB repo is required for libvirt-devel
-RUN dnf -y install --enablerepo=crb \
+RUN dnf -y install \
   make \
   gcc \
   unzip \
   wget \
-  curl-minimal \
+  curl \
   git \
   podman \
   httpd-tools \
   jq \
   nss_wrapper \
-  python3 \
-  python3-devel \
+  python39 \
+  python39-devel \
   libvirt-client \
   libvirt-devel \
   libguestfs-tools \
-  libxslt \
    && dnf clean all
 
 RUN curl --retry 5 -Lo packer.zip https://releases.hashicorp.com/packer/1.8.0/packer_1.8.0_linux_386.zip && unzip packer.zip -d /usr/bin/ && mv /usr/bin/packer /usr/bin/packer.io && rm -rf packer.zip


### PR DESCRIPTION
Reverts openshift/assisted-test-infra#1603

Using stream9 somehow caused docker/podman to fail during image build.

```
STEP 2: FROM quay.io/centos/centos:stream9
STEP 3: RUN dnf -y install --enablerepo=crb   make   gcc   unzip   wget   curl-minimal   git   podman   httpd-tools   jq   nss_wrapper   python3   python3-devel   libvirt-client   libvirt-devel   libguestfs-tools   libxslt    && dnf clean all
CentOS Stream 9 - BaseOS                        0.0  B/s |   0  B     00:00    
Errors during downloading metadata for repository 'baseos':
  - Curl error (6): Couldn't resolve host name for https://mirrors.centos.org/metalink?repo=centos-baseos-9-stream&arch=x86_64&protocol=https,http [getaddrinfo() thread failed to start]
```

/cc @osherdp 
