### PR TITLE
Gather release-image.service log

### DIFF
--- a/src/assisted_test_infra/download_logs/resources/man_sosreport.sh
+++ b/src/assisted_test_infra/download_logs/resources/man_sosreport.sh
@@ -119,6 +119,7 @@ cp -a /etc/*syslog.conf ./etc/ 2>> error_log
 journalctl -u kubelet.service > ./var/log/kubelet.log 2>> error_log
 journalctl -u bootkube.service > ./var/log/bootkube.log 2>> error_log
 journalctl -u crio.service > ./var/log/crio.log 2>> error_log
+journalctl -u release-image.service > ./var/log/release-image.log 2>> error_log
 journalctl TAG=agent > ./var/log/agent_next_step_runner.log 2>> error_log
 journalctl -u agent > ./var/log/agent.log 2>> error_log
 


### PR DESCRIPTION
In addition to bootkube, kubelet and crio, the release-image service is the first one to start by pulling the relevant OCP image.
This is important to gather especially on IPv6 tests (where IPv6 connectivity depends on proxy or an internal registry and might not work properly).

/cc @eliorerz @eranco74 
/hold