### PR TITLE
MGMT-9840 - assisted-test-infra doesn't rebase assisted-service in PRs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -23,6 +23,7 @@ OPENSHIFT_CI := $(or ${OPENSHIFT_CI}, "false")
 JOB_TYPE := $(or ${JOB_TYPE}, "")
 REPO_NAME := $(or ${REPO_NAME}, "")
 PULL_NUMBER := $(or ${PULL_NUMBER}, "")
+PULL_BASE_REF := $(or ${PULL_BASE_REF}, "")
 
 # lint
 LINT_CODE_STYLING_DIRS := src/tests src/triggers src/assisted_test_infra/test_infra src/assisted_test_infra/download_logs src/service_client src/consts src/virsh_cleanup src/cli
@@ -285,6 +286,7 @@ ifeq ($(shell [[ $(OPENSHIFT_CI) == "true" && $(REPO_NAME) == "assisted-service"
 	@cd assisted-service && \
 	git fetch origin pull/$(PULL_NUMBER)/head:assisted-service-pr-$(PULL_NUMBER) && \
 	git checkout assisted-service-pr-$(PULL_NUMBER)
+	git rebase origin/$(PULL_BASE_REF)
 else
 	@cd assisted-service && \
 	git fetch --force origin $(SERVICE_BASE_REF):FETCH_BASE $(SERVICE_BRANCH) && \


### PR DESCRIPTION
We have the following scenario:

- A commit is pushed to master that updates the 'deploy/' directory (e.g., RBAC) as well as updates code that relies on those changes.
- A PR is submitted that isn't rebased on the above change

The PR won't pass tests because:

- When building the service image, the repo is rebased and therefore includes the code changes
- Assisted-test-infra doesn't rebase and therefore the 'deploy/' changes won't be applied
- The test is using rebased code without rebased deploy, and therefore the service will fail


/cc @osherdp 