### PR TITLE
Revert "MGMT-9840 - assisted-test-infra doesn't rebase assisted-service in PRs"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -22,7 +22,6 @@ OPENSHIFT_CI := $(or ${OPENSHIFT_CI}, "false")
 JOB_TYPE := $(or ${JOB_TYPE}, "")
 REPO_NAME := $(or ${REPO_NAME}, "")
 PULL_NUMBER := $(or ${PULL_NUMBER}, "")
-PULL_BASE_REF := $(or ${PULL_BASE_REF}, "")
 
 # lint
 LINT_CODE_STYLING_DIRS := src/tests src/triggers src/assisted_test_infra/test_infra src/assisted_test_infra/download_logs src/service_client src/consts src/virsh_cleanup src/cli
@@ -285,7 +284,6 @@ ifeq ($(shell [[ $(OPENSHIFT_CI) == "true" && $(REPO_NAME) == "assisted-service"
 	@cd assisted-service && \
 	git fetch --update-head-ok origin pull/$(PULL_NUMBER)/head:assisted-service-pr-$(PULL_NUMBER) && \
 	git checkout assisted-service-pr-$(PULL_NUMBER)
-	git rebase origin/$(PULL_BASE_REF)
 else
 	@cd assisted-service && \
 	git fetch --force origin $(SERVICE_BASE_REF):FETCH_BASE $(SERVICE_BRANCH) && \


### PR DESCRIPTION
Reverts openshift/assisted-test-infra#1611

Seems like it doesn't work:
```
From https://github.com/openshift/assisted-service
 * [new ref]           refs/pull/3674/head -> assisted-service-pr-3674
Switched to branch 'assisted-service-pr-3674'
git rebase origin/master
fatal: invalid upstream 'origin/master'
make[1]: Leaving directory '/home/assisted'
make[1]: *** [Makefile:282: bring_assisted_service] Error 128
```

Taken from [this job](https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-service/3674/pull-ci-openshift-assisted-service-master-e2e-metal-assisted-onprem/1516019380054396928)

/cc @eliorerz 