### PR TITLE
Fix errors when test-infra tries to access data/

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -150,7 +150,7 @@ delete_minikube:
 ####################
 
 destroy_onprem:
-	make -C assisted-service/ clean-onprem || true
+	ROOT_DIR=$(realpath assisted-service/) make -C assisted-service/ clean-onprem || true
 
 ####################
 # Load balancer    #
@@ -292,7 +292,7 @@ else
 endif
 
 deploy_monitoring: bring_assisted_service
-	make -C assisted-service/ deploy-monitoring
+	ROOT_DIR=$(realpath assisted-service/) make -C assisted-service/ deploy-monitoring
 	make deploy_prometheus_ui
 
 delete_all_virsh_resources: destroy_nodes delete_minikube kill_all_port_forwardings

--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -71,7 +71,7 @@ if [ "${DEPLOY_TARGET}" == "onprem" ]; then
     HW_VALIDATOR_REQUIREMENTS_LOW_DISK=$(echo $validator_requirements | jq '(.[].worker.disk_size_gb, .[].master.disk_size_gb, .[].sno.disk_size_gb) |= 20' | tr -d "\n\t ")
     sed -i "s|HW_VALIDATOR_REQUIREMENTS:.*|HW_VALIDATOR_REQUIREMENTS: '${HW_VALIDATOR_REQUIREMENTS_LOW_DISK}'|" assisted-service/deploy/podman/configmap.yml
 
-    make -C assisted-service/ deploy-onprem
+    ROOT_DIR=$(realpath assisted-service/) make -C assisted-service/ deploy-onprem
 elif [ "${DEPLOY_TARGET}" == "operator" ]; then
     # This nginx would listen to http on OCP_SERVICE_PORT and it would proxy_pass it to the actual route.
     export SERVICE_BASE_URL=http://${SERVICE_URL}:${OCP_SERVICE_PORT}


### PR DESCRIPTION
For some targets, we see those kind of errors:
```
make[1]: Entering directory
'/mnt/nvme/assisted-test-infra/assisted-service'
/bin/sh: /mnt/nvme/assisted-test-infra/data/default_must_gather_versions.json: No such file or directory
cat: /mnt/nvme/assisted-test-infra/data/default_hw_requirements.json: No such file or directory
/bin/sh: /mnt/nvme/assisted-test-infra/data/default_release_images.json: No such file or directory
/bin/sh: /mnt/nvme/assisted-test-infra/data/default_os_images.json: No such file or directory
```

It turns out that assisted-service uses ``MAKEFILE_LIST`` in order to determine the relevant Makefile root-dir, taking into account cases like ``make -f <file>`` and ``include`` statements in makefiles. Outcome of that actually makes it take the path of assisted-test-infra instead.

This change will set root-dir from outside, as test-infra is totally aware of the location of the assisted-service root-dir.

/cc @osherdp 
/hold