### PR TITLE
MGMT-9840 - Move bring_assisted_service Makefile target to bash script

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -27,9 +27,6 @@ PULL_NUMBER := $(or ${PULL_NUMBER}, "")
 LINT_CODE_STYLING_DIRS := src/tests src/triggers src/assisted_test_infra/test_infra src/assisted_test_infra/download_logs src/service_client src/consts src/virsh_cleanup src/cli
 
 # assisted-service
-SERVICE_BRANCH := $(or $(SERVICE_BRANCH), "master")
-SERVICE_BASE_REF := $(or $(SERVICE_BASE_REF), "master")
-SERVICE_REPO := $(or $(SERVICE_REPO), "https://github.com/openshift/assisted-service")
 SERVICE := $(or $(SERVICE), quay.io/edge-infrastructure/assisted-service:latest)
 SERVICE_NAME := $(or $(SERVICE_NAME),assisted-service)
 INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/edge-infrastructure/assisted-service-index:latest)
@@ -275,21 +272,7 @@ deploy_assisted_service: start_minikube bring_assisted_service
 	DEPLOY_TAG=$(DEPLOY_TAG) CONTAINER_COMMAND=$(CONTAINER_COMMAND) NAMESPACE_INDEX=$(shell bash scripts/utils.sh get_namespace_index $(NAMESPACE) $(OC_FLAG)) AUTH_TYPE=$(AUTH_TYPE) scripts/deploy_assisted_service.sh
 
 bring_assisted_service:
-	@if ! cd assisted-service >/dev/null 2>&1; then \
-		git clone $(SERVICE_REPO); \
-	fi
-
-ifeq ($(shell [[ $(OPENSHIFT_CI) == "true" && $(REPO_NAME) == "assisted-service" && $(JOB_TYPE) == "presubmit" ]] && echo true),true)
-	@echo "Running in assisted-service pull request"
-	@cd assisted-service && \
-	git fetch --update-head-ok origin pull/$(PULL_NUMBER)/head:assisted-service-pr-$(PULL_NUMBER) && \
-	git checkout assisted-service-pr-$(PULL_NUMBER)
-else
-	@cd assisted-service && \
-	git fetch --force origin $(SERVICE_BASE_REF):FETCH_BASE $(SERVICE_BRANCH) && \
-	git reset --hard FETCH_HEAD && \
-	git rebase FETCH_BASE
-endif
+	./scripts/bring_assisted_service.sh
 
 deploy_monitoring: bring_assisted_service
 	make -C assisted-service/ deploy-monitoring

--- a/scripts/bring_assisted_service.sh
+++ b/scripts/bring_assisted_service.sh
@@ -1,0 +1,43 @@
+#!/bin/bash
+
+set -o nounset
+set -o errexit
+set -o pipefail
+set -o xtrace
+
+export SERVICE_REPO=${SERVICE_REPO:-https://github.com/openshift/assisted-service}
+export SERVICE_BRANCH=${SERVICE_BRANCH:-master}
+export SERVICE_BASE_REF=${SERVICE_BASE_REF:-master}
+export OPENSHIFT_CI=${OPENSHIFT_CI:-false}
+export REPO_NAME=${REPO_NAME:-assisted-service}
+export JOB_TYPE=${JOB_TYPE:-}
+export PULL_BASE_REF=${PULL_BASE_REF:-master}
+
+if ! [[ -d "assisted-service" ]]; then
+  echo "Can't find assisted-service source locally, cloning ${SERVICE_REPO}"
+  git clone "${SERVICE_REPO}"
+fi
+
+service_active_branch=$(cd assisted-service/ && git rev-parse --abbrev-ref HEAD)
+pr_branch_name=assisted-service-pr-${PULL_NUMBER}
+
+if [[ "${OPENSHIFT_CI}" == "true" && "${REPO_NAME}" == "assisted-service" && "${JOB_TYPE}" == "presubmit" ]]; then
+  if [[ "${service_active_branch}" == "${pr_branch_name}" ]]; then
+    # Assisted-Service source code is already updated and rebased with PULL_BASE_REF.
+    # git fetch cannot be called twice after rebase so if the PR branch already exist the assumption is that it was
+    # already fetched and rebased on another call of this target
+    echo "Nothing to update. ${REPO_NAME} is already updated, branch: ${pr_branch_name}"
+    exit 0
+  fi
+
+  echo "Running in assisted-service pull request"
+  cd assisted-service
+  git fetch -v origin "pull/${PULL_NUMBER}/head:${pr_branch_name}"
+  git checkout "${pr_branch_name}"
+  git rebase -v "origin/${PULL_BASE_REF}"
+else
+  cd assisted-service
+  git fetch --force origin "${SERVICE_BASE_REF}:FETCH_BASE" "${SERVICE_BRANCH}"
+  git reset --hard FETCH_HEAD
+  git rebase FETCH_BASE
+fi

--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -135,7 +135,6 @@ function install_packages() {
 
     echo "Installing python packages"
     sudo pip3 install aicli
-
 }
 
 function install_skipper() {


### PR DESCRIPTION
On assisted-service, when opening a new PR, on some cases (e.g. change on  the `deploy/` directory) the test is using rebased code without rebased all the service code, and therefore the service will fail.
This PR moves the `bring_assisted_service` target code from Makefile to a new bsah script and rebase assisted-service with `PULL_BASE_REF` after checking out the PR branch