### PR TITLE
NO-ISSUE: Remove cluster ID suffix from cluster_event junit tests

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -7,7 +7,7 @@ ipdb==0.13.9
 ipython==8.2.0
 jedi==0.18.1
 Jinja2===3.1.1
-junit-report==0.2.6
+junit-report==0.2.7
 kubernetes==23.3.0
 libvirt-python==8.2.0
 munch==2.5.0

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -36,7 +36,9 @@ class InventoryClient(object):
         self.operators = api.OperatorsApi(api_client=self.api)
         self.manifest = api.ManifestsApi(api_client=self.api)
 
-        fmt = CaseFormatKeys(case_name="cluster_id", severity_key="severity", case_timestamp="event_time")
+        fmt = CaseFormatKeys(
+            case_name="cluster-event-test", static_case_name=True, severity_key="severity", case_timestamp="event_time"
+        )
         self._events_junit_exporter = JsonJunitExporter(fmt)
 
     def get_host(self, configs: Configuration) -> str:


### PR DESCRIPTION
This ensures "cluster_events" test name is static, so that test name would be persistent across runs.