### PR TITLE
assisted_service_api: get_api_vip should work when API VIP is not set

### DIFF
--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -440,7 +440,7 @@ class InventoryClient(object):
 
     def get_api_vip(self, cluster_info: dict, cluster_id: str = None):
         cluster = cluster_info or self.cluster_get(cluster_id)
-        api_vip = cluster["api_vip"]
+        api_vip = cluster.get("api_vip")
 
         if not api_vip and cluster.user_managed_networking:
             log.info("API VIP is not set, searching for api ip on masters")


### PR DESCRIPTION
For user managed networking API VIP may not be set, so api_vip may not be set in cluster info.

This should fix failing `download_logs` test in https://testgrid.k8s.io/redhat-assisted-installer#periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-none-periodic