### PR TITLE
Adding a cluster method to set encryption params

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -242,6 +242,14 @@ class Cluster(Entity):
     def select_installation_disk(self, host_id: str, disk_paths: List[dict]) -> None:
         self._infra_env.select_host_installation_disk(host_id=host_id, disk_paths=disk_paths)
 
+    def set_disk_encryption(self, mode, roles):
+        disk_encryption_params = models.DiskEncryption(
+            enable_on=roles,
+            mode=mode,
+        )
+        disk_encryption = {"disk_encryption": disk_encryption_params}
+        self.api_client.update_cluster(self.id, disk_encryption)
+
     def set_ocs(self, properties=None):
         self.set_olm_operator(consts.OperatorType.OCS, properties=properties)
 


### PR DESCRIPTION
To support a scenario where disk encryption turned on while not set on the node's BIOS, and for other cases, added a method to set  disk_encryption params
Corresponding e2e test: https://gitlab.cee.redhat.com/ocp-edge-qe/kni-assisted-installer-auto/-/merge_requests/763/diffs