### PR TITLE
NO-ISSUE: get_api_vip: allow unset user_managed_networking

### DIFF
--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -445,7 +445,8 @@ class InventoryClient(object):
 
         if not api_vip and user_managed_networking:
             log.info("API VIP is not set, searching for api ip on masters")
-            masters = self.get_hosts_by_role(cluster["id"], consts.NodeRoles.MASTER, hosts=cluster.to_dict()["hosts"])
+            hosts = cluster.get("hosts") or cluster.to_dict()["hosts"]
+            masters = self.get_hosts_by_role(cluster["id"], consts.NodeRoles.MASTER, hosts=hosts)
             api_vip = self._wait_for_api_vip(masters)
 
         log.info("api vip is %s", api_vip)

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -441,8 +441,9 @@ class InventoryClient(object):
     def get_api_vip(self, cluster_info: dict, cluster_id: str = None):
         cluster = cluster_info or self.cluster_get(cluster_id)
         api_vip = cluster.get("api_vip")
+        user_managed_networking = cluster.get("user_managed_networking")
 
-        if not api_vip and cluster.user_managed_networking:
+        if not api_vip and user_managed_networking:
             log.info("API VIP is not set, searching for api ip on masters")
             masters = self.get_hosts_by_role(cluster["id"], consts.NodeRoles.MASTER, hosts=cluster.to_dict()["hosts"])
             api_vip = self._wait_for_api_vip(masters)


### PR DESCRIPTION
If user_managed_networking is not set in cluster info it should default to False

This should fix failing download_logs test in testgrid.k8s.io/redhat-assisted-installer#periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-none-periodic, follow-up for #1619