### PR TITLE
NO-ISSUE: Set global git user & email address when running in CI

### DIFF
--- a/scripts/bring_assisted_service.sh
+++ b/scripts/bring_assisted_service.sh
@@ -21,6 +21,19 @@ fi
 service_active_branch=$(cd assisted-service/ && git rev-parse --abbrev-ref HEAD)
 pr_branch_name=assisted-service-pr-${PULL_NUMBER}
 
+if [[ "${OPENSHIFT_CI}" == "true" ]]; then
+    # Some git commands require user/email to be set, use a dummy global
+    # user/email for CI if one is not already configured
+
+    if ! git config --global --get user.name; then
+        git config --global user.name 'OpenShift CI'
+    fi
+
+    if ! git config --global --get user.email; then
+        git config --global user.email 'fakeciemail@example.com'
+    fi
+fi
+
 if [[ "${OPENSHIFT_CI}" == "true" && "${REPO_NAME}" == "assisted-service" && "${JOB_TYPE}" == "presubmit" ]]; then
   if [[ "${service_active_branch}" == "${pr_branch_name}" ]]; then
     # Assisted-Service source code is already updated and rebased with PULL_BASE_REF.


### PR DESCRIPTION
Some git commands require user/email to be set, use a dummy global
user/email for CI if one is not already configured

This should fix CI failures such as https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-service/3705/pull-ci-openshift-assisted-service-master-e2e-metal-assisted/1519244251358040064