### PR TITLE
MGMT-9179 - Single node bootstrap-in-place flow should use OVNKubernetes

### DIFF
--- a/src/assisted_test_infra/resources/bootstrap_in_place/install-config.yaml
+++ b/src/assisted_test_infra/resources/bootstrap_in_place/install-config.yaml
@@ -21,7 +21,7 @@ networking:
     hostPrefix: 23
   machineNetwork:
   - cidr: 192.168.126.0/24
-  networkType: OpenShiftSDN
+  networkType: OVNKubernetes
   serviceNetwork:
   - 172.30.0.0/16
 platform:


### PR DESCRIPTION
In recent versions of OCP `OVNKubernetes` replaced `OpenShiftSDN` as the
default network type for Single Node clusters (currently just in
Assisted Installer's default configuration, in the future it would be
the default for the regular installer / OCP documentation). Later SNO
OpenShiftSDN would be completely forbidden.

We want our BIP flow in this repo to also use OVNKubernetes so we'll
be testing the default network type customers are likely to use in the
future and not the older default OpenShiftSDN.