### PR TITLE
Log hosts' statuses while waiting for the cluster status update

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -476,7 +476,7 @@ class Cluster(Entity):
     def start_install(self, retries: int = consts.DEFAULT_INSTALLATION_RETRIES_ON_FALLBACK):
         self.api_client.install_cluster(cluster_id=self.id)
 
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.INSTALLING, consts.ClusterStatus.READY],
@@ -548,7 +548,7 @@ class Cluster(Entity):
         )
 
     def wait_for_cluster_in_error_status(self):
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.ERROR],
@@ -556,7 +556,7 @@ class Cluster(Entity):
         )
 
     def wait_for_pending_for_input_status(self):
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.PENDING_FOR_INPUT],
@@ -696,7 +696,7 @@ class Cluster(Entity):
         )
 
     def wait_for_ready_to_install(self):
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.READY],
@@ -704,7 +704,7 @@ class Cluster(Entity):
         )
         # This code added due to BZ:1909997, temporarily checking if help to prevent unexpected failure
         time.sleep(10)
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.READY],
@@ -786,7 +786,7 @@ class Cluster(Entity):
         )
 
     def wait_for_install(self, timeout=consts.CLUSTER_INSTALLATION_TIMEOUT):
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.INSTALLED],
@@ -962,7 +962,7 @@ class Cluster(Entity):
             log.exception("Failed to get cluster %s validation info", self.id)
 
     def wait_for_cluster_to_be_in_installing_pending_user_action_status(self):
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.INSTALLING_PENDING_USER_ACTION],
@@ -970,7 +970,7 @@ class Cluster(Entity):
         )
 
     def wait_for_cluster_to_be_in_installing_status(self):
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.INSTALLING],
@@ -978,7 +978,7 @@ class Cluster(Entity):
         )
 
     def wait_for_cluster_to_be_in_finalizing_status(self):
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=[consts.ClusterStatus.FINALIZING, consts.ClusterStatus.INSTALLED],
@@ -987,7 +987,7 @@ class Cluster(Entity):
         )
 
     def wait_for_cluster_to_be_in_status(self, statuses, timeout=consts.ERROR_TIMEOUT):
-        utils.wait_till_cluster_is_in_status(
+        utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             statuses=statuses,

--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -23,7 +23,6 @@ from typing import List, Tuple, Union
 
 import filelock
 import requests
-import waiting
 from requests import Session
 from requests.adapters import HTTPAdapter, Retry
 from requests.exceptions import RequestException
@@ -133,33 +132,6 @@ def are_host_progress_in_stage(hosts, stages, nodes_count=1):
         f"hosts statuses are {host_info}"
     )
     return False
-
-
-def wait_till_cluster_is_in_status(
-    client,
-    cluster_id,
-    statuses: List[str],
-    timeout=consts.NODES_REGISTERED_TIMEOUT,
-    interval=30,
-    break_statuses: List[str] = None,
-):
-    log.info("Wait till cluster %s is in status %s", cluster_id, statuses)
-    try:
-        if break_statuses:
-            statuses += break_statuses
-        waiting.wait(
-            lambda: is_cluster_in_status(client=client, cluster_id=cluster_id, statuses=statuses),
-            timeout_seconds=timeout,
-            sleep_seconds=interval,
-            waiting_for=f"Cluster to be in status {statuses}",
-        )
-        if break_statuses and is_cluster_in_status(client, cluster_id, break_statuses):
-            raise BaseException(
-                f"Stop installation process, " f"cluster is in status {client.cluster_get(cluster_id).status}"
-            )
-    except BaseException:
-        log.error("Cluster status is: %s", client.cluster_get(cluster_id).status)
-        raise
 
 
 def is_cluster_in_status(client, cluster_id, statuses):


### PR DESCRIPTION
Sometimes a host has issues and blocks the installation, but this information is not logged
DNS errors, for instance, prevent the cluster from becoming ready