### PR TITLE
revert libvirt downgrade on Rocky Linux

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -39,18 +39,11 @@ function install_libvirt() {
         sudo dnf install -y selinux-policy
     fi
 
-    # TODO: support libvirt >= 6.0.0-37-1
-    SPECIFIC_LIBVIRT_VERSION=""
-    if [[ "${PRETTY_NAME}" == "Rocky Linux 8"* ]]; then
-        echo "Installing a downgraded version of libvirt, as we currently don't support the newer one..."
-        SPECIFIC_LIBVIRT_VERSION="-6.0.0-37.module+el8.5.0+670+c4aa478c"
-    fi
-
     echo "Installing libvirt..."
     sudo dnf install -y \
-        libvirt${SPECIFIC_LIBVIRT_VERSION} \
-        libvirt-devel${SPECIFIC_LIBVIRT_VERSION} \
-        libvirt-daemon-kvm${SPECIFIC_LIBVIRT_VERSION} \
+        libvirt \
+        libvirt-devel \
+        libvirt-daemon-kvm \
         qemu-kvm \
         libgcrypt
 


### PR DESCRIPTION
On Rocky (and some RHEL releases) we used to need to install a downgraded libvirt version, because of a malformed version which is the latest available in the relevant registries. Seems like they've updated the registries, so we no longer need to do that.