### PR TITLE
Always pulling referenced service image

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -121,6 +121,7 @@ create_full_environment: setup  # TODO: remove. only here for compatibility reas
 create_environment: image_build bring_assisted_service start_minikube
 
 image_build:
+	scripts/pull_dockerfile_images.sh
 	sed 's/^FROM .*assisted-service.*:latest/FROM $(subst /,\/,${SERVICE})/' Dockerfile.assisted-test-infra | \
 	 $(CONTAINER_COMMAND) build --network=host -t $(IMAGE_NAME) -f- .
 

--- a/create_full_environment.sh
+++ b/create_full_environment.sh
@@ -32,7 +32,6 @@ echo "Done installing"
 
 echo "Creating image"
 make bring_assisted_service
-scripts/pull_dockerfile_images.sh
 make image_build
 echo "Done creating image"
 


### PR DESCRIPTION
Seems like since openshift/assisted-test-infra#1595 we no longer trying to pull the assisted-service base image in assisted-test-infra Dockerfile. This is true anytime someone does ``make image_build``
without doing ``make setup`` before.

To make it more convenient, I moved this part to the former target which either way seems like the right place for it.