### PR TITLE
NO-ISSUE: extend the timeout while waiting for clusterDeployment to get created

### DIFF
--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -211,7 +211,7 @@ class TestKubeAPI(BaseKubeAPI):
         waiting.wait(
             _cluster_deployment_installed,
             sleep_seconds=1,
-            timeout_seconds=60,
+            timeout_seconds=600,
             waiting_for="clusterDeployment to get created",
             expected_exceptions=Exception,
         )


### PR DESCRIPTION
It seems that hypershift takes a while longer to add the kubeadminPassword to the hostedControlPlane status
Since the capi provider agent wait for that kubeadminPassword before
creating the cluster deployment the test timeout while waiting for
clusterDeployment.