### PR TITLE
NO-ISSUE: Fixing capi test by adding label worker to minikube

### DIFF
--- a/scripts/setup_capi_env.sh
+++ b/scripts/setup_capi_env.sh
@@ -19,11 +19,16 @@ function waitForPodsReadyStatus(){
 deploy_hypershift() {
   kubectl apply -f https://raw.githubusercontent.com/prometheus-operator/prometheus-operator/v0.51.1/bundle.yaml || true
   HYPERSHIFT_BIN_DIR=$BASE_DIR/hypershift/bin
+
+  if [[ "$(${CONTAINER_COMMAND} images -q $HYPERSHIFT_IMAGE 2> /dev/null)" != "" ]]; then
+    echo "Deleting old hypershift image"
+    ${CONTAINER_COMMAND} rmi $HYPERSHIFT_IMAGE -f
+  fi
   mkdir -p $HYPERSHIFT_BIN_DIR
   echo "Copy the binary from the image"
   # The same binary is later used by the hypershift helper class
-  ${CONTAINER_COMMAND} run -it \
-  -v $(pwd)/$HYPERSHIFT_BIN_DIR:/root/hypershift_bin \
+  ${CONTAINER_COMMAND} run -it --rm\
+  -v $(pwd)/$HYPERSHIFT_BIN_DIR:/root/hypershift_bin:Z \
   --entrypoint cp \
   "$HYPERSHIFT_IMAGE" \
   /usr/bin/hypershift /root/hypershift_bin
@@ -36,3 +41,5 @@ echo "Deploying HyperShift"
 deploy_hypershift
 echo "Alow route to minikube network - required for hosts to pull ignition"
 iptables -D LIBVIRT_FWI -o virbr1 -j REJECT --reject-with icmp-port-unreachable || true
+echo "Set worker label for minikube"
+kubectl get nodes minikube && kubectl label node minikube node-role.kubernetes.io/worker="" --overwrite

--- a/src/assisted_test_infra/test_infra/helper_classes/hypershift.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/hypershift.py
@@ -123,7 +123,7 @@ class HyperShift:
             version=HyperShift.HYPERSHIFT_API_VERSION,
             plural=HyperShift.HOSTED_CONTROL_PLANE_PLOURAL,
             name=self.name,
-            namespace="-".join([HyperShift.NODEPOOL_NAMESPACE, self.name]),
+            namespace=self.namespace,
         )
 
     def get_nodes(self, ready: bool = False) -> V1NodeList:
@@ -149,6 +149,10 @@ class HyperShift:
             timeout_seconds=DEFAULT_WAIT_FOR_NODES_TIMEOUT,
             waiting_for="nodes to join the hypershift cluster",
         )
+
+    @property
+    def namespace(self):
+        return "-".join([HyperShift.NODEPOOL_NAMESPACE, self.name])
 
 
 def filterNodeByReadyStatus(nodes: V1NodeList) -> V1NodeList:

--- a/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/secret.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/secret.py
@@ -36,6 +36,19 @@ class Secret(BaseResource):
 
         log.info("created secret %s", self.ref)
 
+    def create_with_data(self, secret_data: dict):
+        self.v1_api.create_namespaced_secret(
+            body={
+                "apiVersion": "v1",
+                "kind": "Secret",
+                "metadata": self.ref.as_dict(),
+                "stringData": secret_data,
+            },
+            namespace=self.ref.namespace,
+        )
+
+        log.info("created secret %s", self.ref)
+
     def delete(self) -> None:
         self.v1_api.delete_namespaced_secret(name=self.ref.name, namespace=self.ref.namespace)
 

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -202,8 +202,11 @@ class TestKubeAPI(BaseKubeAPI):
                     ssh_key=ssh_public_key_file,
                 )
 
-        hypershift.wait_for_control_plane_ready()
+        # WORKAROUND for ovn on minikube
+        secret = Secret(api_client, "ovn-master-metrics-cert", hypershift.namespace)
+        secret.create_with_data(secret_data={"ca_cert": "dummy data, we only need this secret to exists"})
 
+        hypershift.wait_for_control_plane_ready()
         cluster_deployment = ClusterDeployment(api_client, cluster_name, f"clusters-{cluster_name}")
 
         def _cluster_deployment_installed() -> bool:


### PR DESCRIPTION
NO-ISSUE: Fixing capi test by adding label worker to minikube
In 4.11 ovn is a default network for hypershift cluster and it requires
worker label to run
NO-ISSUE: small improvements to case deploy scripts to cleanup
hypershift image locally before pulling