### PR TITLE
MGMT-10775: Trying some stuff

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -230,7 +230,7 @@ class TerraformController(LibvirtController):
 
     def get_ingress_and_api_vips(self):
         network_subnet_starting_ip = str(
-            ipaddress.ip_address(ipaddress.ip_network(self.get_primary_machine_cidr()).network_address) + 100
+            ipaddress.ip_address(ipaddress.ip_network(self.get_primary_machine_cidr()).network_address) + 50
         )
         ips = utils.create_ip_address_list(2, starting_ip_addr=str(ipaddress.ip_address(network_subnet_starting_ip)))
         return {"api_vip": ips[0], "ingress_vip": ips[1]}


### PR DESCRIPTION
/hold

For a sample libvirt network the configuration looks as follows

```
  <ip address='192.168.122.1' netmask='255.255.255.0'>
    <dhcp>
      <range start='192.168.122.100' end='192.168.122.254'/>
    </dhcp>
  </ip>
```

I want to see if this is prone to collide when we want to manually reserve 2 IPs in the block, but at the same time there are VM resources created which also consume IP addresses from that pool.