### PR TITLE
MGMT-10717: set OCP-4.10 as the default ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE

### DIFF
--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -196,7 +196,11 @@ class TestKubeAPI(BaseKubeAPI):
                     agent_namespace=spoke_namespace,
                     provider_image=os.environ.get("PROVIDER_IMAGE", ""),
                     hypershift_cpo_image=os.environ.get("HYPERSHIFT_IMAGE", ""),
-                    release_image=os.environ.get("ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE", ""),
+                    # This is the default that hypershift should use in ocm-2.5
+                    release_image=os.environ.get(
+                        "ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE",
+                        "quay.io/openshift-release-dev/ocp-release:4.10.9-x86_64",
+                    ),
                     ssh_key=ssh_public_key_file,
                 )
 

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -196,7 +196,7 @@ class TestKubeAPI(BaseKubeAPI):
                     agent_namespace=spoke_namespace,
                     provider_image=os.environ.get("PROVIDER_IMAGE", ""),
                     hypershift_cpo_image=os.environ.get("HYPERSHIFT_IMAGE", ""),
-                    release_image=os.environ.get("OPENSHIFT_INSTALL_RELEASE_IMAGE", ""),
+                    release_image=os.environ.get("ASSISTED_OPENSHIFT_INSTALL_RELEASE_IMAGE", ""),
                     ssh_key=ssh_public_key_file,
                 )
 


### PR DESCRIPTION
This should allow this branch to pass this release image to hypershift instead of letting hypershift defaulting to 4.11