### PR TITLE
NO-ISSUE: Don't assume all resources have a status

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/oc_utils.py
+++ b/src/assisted_test_infra/test_infra/utils/oc_utils.py
@@ -177,7 +177,7 @@ def _has_condition(resource: str, type: str, status: str) -> bool:
     """
     return any(
         condition["status"] == status
-        for condition in resource["status"].get("conditions", [])
+        for condition in resource.get("status", {}).get("conditions", [])
         if condition["type"] == type
     )
 


### PR DESCRIPTION
Apparently sometimes resources don't have a "status", this is probably
rare and only happens for a brief period after a resource is created.

Anyway, we should handle it more gracefully.

See:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-test-infra/1653/pull-ci-openshift-assisted-test-infra-master-e2e-metal-single-node-live-iso/1537022236752351232

```
[0;34m2022-06-15 11:12:20,434  root DEBUG      - 140053192167680 - List of operators seems to still be empty... Retrying 	(/home/sno/src/tests/test_bootstrap_in_place.py:210)[0m
[1;31m2022-06-15 11:12:40,467  root ERROR      - 140053192167680 - An unexpected error has occurred while waiting for installation to complete 	(/home/sno/src/tests/test_bootstrap_in_place.py:273)
Traceback (most recent call last):
  File "/home/sno/src/tests/test_bootstrap_in_place.py", line 265, in waiting_for_installation_completion
    waiting.wait(
  File "/usr/local/lib/python3.9/site-packages/waiting/__init__.py", line 18, in wait
    for x in iterwait(result=result, *args, **kwargs):
  File "/usr/local/lib/python3.9/site-packages/waiting/__init__.py", line 44, in iterwait
    result.result = predicate()
  File "/home/sno/src/tests/test_bootstrap_in_place.py", line 204, in all_operators_available
    operator_statuses = get_clusteroperators_status(KUBE_CONFIG)
  File "/home/sno/src/assisted_test_infra/test_infra/utils/oc_utils.py", line 191, in get_clusteroperators_status
    return {
  File "/home/sno/src/assisted_test_infra/test_infra/utils/oc_utils.py", line 192, in <dictcomp>
    clusteroperator["metadata"]["name"]: _has_condition(resource=clusteroperator, type="Available", status="True")
  File "/home/sno/src/assisted_test_infra/test_infra/utils/oc_utils.py", line 180, in _has_condition
    for condition in resource["status"].get("conditions", [])
KeyError: 'status'[0m
```