### PR TITLE
MGMT-9378 - Bug fixes to make day-2 Assisted REST flow support SNO

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -227,12 +227,11 @@ class Day2Cluster(ABC):
 
     def are_libvirt_nodes_in_cluster_hosts(self) -> bool:
         try:
-            hosts_macs = self.api_client.get_hosts_id_with_macs(self.config.cluster_id)
-        except BaseException:
-            log.error("Failed to get nodes macs for cluster: %s", self.config.cluster_id)
+            hosts = self.api_client.get_cluster_hosts(self.config.cluster_id)
+        except Exception:
+            log.exception("Failed to get cluster hosts: %s", self.config.cluster_id)
             return False
-        num_macs = len([mac for mac in hosts_macs if mac != ""])
-        return num_macs >= self.config.day2_workers_count
+        return len(hosts) >= self.config.day2_workers_count
 
     def set_nodes_hostnames_if_needed(self, network_name: str):
         if self.config.is_ipv6 or self.config.is_static_ip:

--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -152,8 +152,8 @@ data "libvirt_network_dns_host_template" "api" {
 }
 
 data "libvirt_network_dns_host_template" "api-int" {
-  count    = var.bootstrap_in_place ? 1 : 0
-  ip       = var.single_node_ip
+  count    = 1
+  ip       = var.bootstrap_in_place ? var.single_node_ip : var.api_vip
   hostname = "api-int.${var.cluster_name}.${var.cluster_domain}"
 }
 


### PR DESCRIPTION
# Background

Starting OCP 4.11 there is a requirement to support day-2 installation
of worker nodes on SNO clusters as opposed to just multi-node clusters.
We want Assisted REST to support it as well, so we want to run periodic
tests to make sure it works.

The existing Day2Cluster test flow first installs OpenShift using the
REST assisted-installer and then attempts to add worker nodes to the
resulting cluster. It worked fine in multi-node clusters but had some
bugs for single-node clusters (NUM_MASTERS=1 and NUM_WORKERS=0) which
this commit aims to solve.

# DNS Fix

The first bug is the missing `api-int.` DNS entry in the terraform
libvirt dnsmasq configuration. Only the `api.` entry was present. Since
multi-node clusters use the baremetal platform rather than the "none"
platform, this wasn't a problem for them as DNS is taken care of in that
platform automatically. But single-node clusters use the "none" platform
and so require DNS to be manually configured. This has been solved by
enabling the `api-int.` DNS configuration in terraform.

# `are_libvirt_nodes_in_cluster_hosts` Fix

The second bug was trouble with the `are_libvirt_nodes_in_cluster_hosts`
implementation. It was, for some reason, failing to run on the Assisted
cluster when its in "adding-hosts" mode. Not really sure why because the
previous implementation hid the exception, but I've reimplemented it
without the unnecessary inventory/mac stuff that wasn't really used
anyway, and it works fine now.