### PR TITLE
MGMT-10830 - Create base class for test-infra containerized controllers

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/containerized_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/containerized_controller.py
@@ -1,0 +1,46 @@
+from abc import ABC
+from typing import List, Optional
+
+from assisted_test_infra.test_infra.utils import utils
+from service_client import log
+
+
+class ContainerizedController(ABC):
+    def __init__(self, name: str, port: int, image: str, extra_flags: Optional[List[str]] = None) -> None:
+        self._name = name
+        self._port = port
+        self._image = image
+        self._extra_flags = [] if not extra_flags else extra_flags
+        self._is_running = False
+
+    def run(self, **kwargs):
+        if self._is_running:
+            log.info(f"{self.__class__.__name__} server is already running...")
+            return
+        log.info(f"Running {self.__class__.__name__} Server {self._name}")
+
+        self._on_container_start(**kwargs)
+        base_run_flags = [
+            "-d",
+            "--restart=always",
+            "--network=host",
+            f"--publish {self._port}:{self._port}",
+        ]
+
+        utils.run_container(container_name=self._name, image=self._image, flags=base_run_flags + self._extra_flags)
+        self._is_running = True
+
+    def remove(self):
+        if self._is_running:
+            log.info(f"Removing Proxy Server {self._name}")
+            utils.remove_running_container(container_name=self._name)
+            self._on_container_removed()
+            self._is_running = False
+
+    def _on_container_removed(self):
+        """Can be overridden to clear configurations after the controller container was removed"""
+        pass
+
+    def _on_container_start(self, **kwargs):
+        """Can be overridden to run some logic before the container started"""
+        pass

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -346,7 +346,7 @@ class BaseTest:
         if global_variables.ipxe_boot:
             infra_env = cluster.generate_infra_env()
             ipxe_server_controller = ipxe_server(name="ipxe_controller", api_client=cluster.api_client)
-            ipxe_server_controller.start(infra_env_id=infra_env.id, cluster_name=cluster.name)
+            ipxe_server_controller.run(infra_env_id=infra_env.id, cluster_name=cluster.name)
 
             ipxe_server_url = f"http://{consts.DEFAULT_IPXE_SERVER_IP}:{consts.DEFAULT_IPXE_SERVER_PORT}/{cluster.name}"
             network_name = cluster.nodes.get_cluster_network()
@@ -378,10 +378,8 @@ class BaseTest:
         new_tang_server = tang_server(
             name=server_name, port=consts.DEFAULT_TANG_SERVER_PORT, pull_secret=cluster_configuration.pull_secret
         )
-        new_tang_server.run_tang_server()
+        new_tang_server.run()
         new_tang_server.set_thumbprint()
-        cluster_configuration.disk_encryption_roles = consts.DiskEncryptionRoles.ALL
-        cluster_configuration.disk_encryption_mode = consts.DiskEncryptionMode.TANG
         cluster_configuration.tang_servers = (
             f'[{{"url":"{new_tang_server.address}","thumbprint":"{new_tang_server.thumbprint}"}}]'
         )
@@ -585,7 +583,7 @@ class BaseTest:
 
         machine_cidr = nodes.controller.get_primary_machine_cidr()
         host_ip = str(IPNetwork(machine_cidr).ip + 1)
-        return proxy_server(name=proxy_name, port=port, dir=proxy_name, host_ip=host_ip, is_ipv6=nodes.is_ipv6)
+        return proxy_server(name=proxy_name, port=port, host_ip=host_ip, is_ipv6=nodes.is_ipv6)
 
     @classmethod
     def get_proxy(
@@ -708,8 +706,9 @@ class BaseTest:
 
         def start_proxy_server(**kwargs):
             proxy_server = ProxyController(**kwargs)
-            proxy_servers.append(proxy_server)
+            proxy_server.run()
 
+            proxy_servers.append(proxy_server)
             return proxy_server
 
         yield start_proxy_server


### PR DESCRIPTION
Join base logic for test-infra containerized controllers
After adding tang support to test-infra we have 3 duplicated code/behaviors on the containerized controller: ipxe_controller, tang_controller, and on proxy_controller. This PR move the base controller behavior under new base class.

/cc @osherdp 