### PR TITLE
NO-ISSUE: Remove Fedora support, add warning about this repo

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. Only usage of CentOS8 / RHEL8 / Fedora on the assisted installer host<sup id="a1">[1](#f1)</sup> is supported
+1. Only usage of CentOS8 / RHEL8 / Rocky8 on the assisted installer host<sup id="a1">[1](#f1)</sup> is supported
    - This host will run minikube and the UI for deploying OpenShift on Bare Metal
 1. Setup DHCP/DNS records for the following OpenShift nodes and VIPs. List includes
    - Master nodes
@@ -125,7 +125,7 @@ As `$USER` user with `sudo` privileges,
 
         sshpass -p '*****' ssh root@<iDRAC-IP> racadm remoteimage -d
 
-1.  The `live.iso` should reboot the nodes and boot them into a Fedora Live image. Once it has done this, shortly you will notice the nodes becoming discoverable for your cluster via the `http://<host-ip>:6008/clusters/<cluster-id>` dashboard.
+1.  The `live.iso` should reboot the nodes and boot them into an RHCOS Live image. Once it has done this, shortly you will notice the nodes becoming discoverable for your cluster via the `http://<host-ip>:6008/clusters/<cluster-id>` dashboard.
 
 1.  Once the nodes are now available on the dashboard, select the appropriate role for each OpenShift cluster node.
 

--- a/README.md
+++ b/README.md
@@ -1,3 +1,9 @@
+# !! Warning !!
+
+It's not recommended to run the code in this repo locally on your personal
+machine, as it makes some opinionated configuration changes to the machine it's
+running on
+
 # Test-Infra
 
 This project deploys the OpenShift Assisted Installer in Minikube and spawns libvirt VMs that represent bare metal hosts.
@@ -49,7 +55,7 @@ This project deploys the OpenShift Assisted Installer in Minikube and spawns lib
 
 ## Prerequisites
 
-- CentOS 8 or RHEL 8 host
+- CentOS 8, RHEL 8 or Rocky 8 host
 - File system that supports d_type
 - Ideally on a bare metal host with at least 64G of RAM.
 - Run as a user with password-less `sudo` access or be ready to enter `sudo` password for prepare phase.

--- a/scripts/create_full_environment.sh
+++ b/scripts/create_full_environment.sh
@@ -8,8 +8,9 @@ function error() {
 
 # Check OS
 OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
-if [[ ! ${OS} =~ ^(centos)$ ]] && [[ ! ${OS} =~ ^(rhel)$ ]] && [[ ! ${OS} =~ ^(fedora)$ ]] && [[ ! ${OS} =~ ^(rocky)$ ]]; then
-    error "\"${OS}\" is an unsupported OS. We support only CentOS, RHEL, Fedora or Rocky."
+if [[ ! ${OS} =~ ^(centos)$ ]] && [[ ! ${OS} =~ ^(rhel)$ ]] && [[ ! ${OS} =~ ^(rocky)$ ]]; then
+    error "\"${OS}\" is an unsupported OS. We support only CentOS, RHEL or Rocky."
+    error "It's not recommended to run the code in this repo locally on your personal machine, as it makes some opinionated configuration changes to the machine it's running on"
     exit 1
 fi
 
@@ -24,7 +25,6 @@ elif [[ ${OS} =~ ^(rhel)$ && ${VER} -ne ${VER_SUPPORTED} ]]; then
     error "RHEL version ${VER_SUPPORTED} is required."
     exit 1
 fi
-# TODO add minimum version fedora validation
 
 echo "Installing environment"
 scripts/install_environment.sh


### PR DESCRIPTION
Users are not recommended to run the code in this repo on their local
machine, as it makes some surprising opinionated configuration changes
that users might not expect (installing packages, configuring libvirt,
etc). We should give a clear warning about that in the README.

Also since we don't support Fedora, our `create_full_environment.sh`
should be modified to reflect that and block users trying to install
on Fedora. If we detect an OS we don't support, on top of saying we
don't support it, we give the same warning as in the README.