### PR TITLE
MGMT-10913: Use our fork of dmacvicar/terraform-provider-libvirt

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -37,6 +37,11 @@ ENV GOPATH=/go
 ENV GOCACHE=/go/.cache
 ENV PATH=$PATH:/usr/local/go/bin:/go/bin
 
+COPY Makefile.terraform_fork .
+
+ENV TERRAFORM_PROVIDER_LIBVIRT_FORK_GIT_REVISION=734281d20f9c50da411cf2d7db1aa4303746b3f2
+RUN make -f Makefile.terraform_fork install
+
 COPY . .
 
 RUN chgrp -R 0 /home/assisted-test-infra && \

--- a/Makefile.terraform_fork
+++ b/Makefile.terraform_fork
@@ -1,0 +1,43 @@
+TF_LIBVIRT_PROJECT = terraform-provider-libvirt
+TF_LIBVIRT_BINARY = terraform-provider-libvirt
+TF_LIBVIRT_FORK_URL = https://github.com/openshift-assisted/$(TF_LIBVIRT_PROJECT)
+TF_LIBVIRT_FORK_DIR = /opt/$(TF_LIBVIRT_PROJECT)
+TF_LIBVIRT_LOCAL_REGISTRY = /usr/share/terraform/plugins/assisted-test-infra-registry.local/openshift-assisted/libvirt/9.9.9/linux_amd64
+
+# Allows users to specify the git revision that will be switched to before building the fork
+# Only git commit hashes are allowed. It must be an ancestor of the main branch.
+TERRAFORM_PROVIDER_LIBVIRT_FORK_GIT_REVISION := $(or ${TERRAFORM_PROVIDER_LIBVIRT_FORK_GIT_REVISION},"")
+
+.PHONY: install
+install: $(TF_LIBVIRT_LOCAL_REGISTRY)/$(TF_LIBVIRT_BINARY)
+
+# A folder containing a clone of our fork of the libvirt terraform provider
+$(TF_LIBVIRT_FORK_DIR):
+	git clone $(TF_LIBVIRT_FORK_URL) $@ 
+
+# A folder acting as local registry of libvirt providers
+# (See https://www.terraform.io/language/providers/requirements#in-house-providers)
+$(TF_LIBVIRT_LOCAL_REGISTRY):
+	mkdir -p $@
+
+# .PHONY because we can't know whether it's stale or not, we always want to git pull
+# and run the build, the go toolchain will decide if anything needs rebuilding in practice,
+# we should not leave it up to make.
+.PHONY: $(TF_LIBVIRT_FORK_DIR)/$(TF_LIBVIRT_BINARY)
+
+# Create the actual binary by building. Requires Go.
+$(TF_LIBVIRT_FORK_DIR)/$(TF_LIBVIRT_BINARY): $(TF_LIBVIRT_FORK_DIR)
+	git -C $(TF_LIBVIRT_FORK_DIR) fetch origin main
+	if [ "$(TERRAFORM_PROVIDER_LIBVIRT_FORK_GIT_REVISION)" = "" ]; then\
+		# User didn't ask for any particular revision, so use the tip of the main branch\
+		git -C $(TF_LIBVIRT_FORK_DIR) switch --detach origin/main;\
+	else \
+		# User asked for a particular revision, switch to it before building\
+		git -C $(TF_LIBVIRT_FORK_DIR) switch --detach "$(TERRAFORM_PROVIDER_LIBVIRT_FORK_GIT_REVISION)";\
+	fi;
+	make -C $(TF_LIBVIRT_FORK_DIR)
+
+# Copy the build binary into our local "terraform registry"
+$(TF_LIBVIRT_LOCAL_REGISTRY)/$(TF_LIBVIRT_BINARY): $(TF_LIBVIRT_FORK_DIR)/$(TF_LIBVIRT_BINARY) $(TF_LIBVIRT_LOCAL_REGISTRY) 
+	cp -r $< $@
+

--- a/skipper.yaml
+++ b/skipper.yaml
@@ -1,6 +1,5 @@
 registry: quay.io
-build-container-image: test-infra
-build-container-tag: latest
+build-container-image: assisted-test-infra
 
 volumes:
   # programs
@@ -40,4 +39,6 @@ volumes:
   - /etc/NetworkManager/dnsmasq.d:/etc/NetworkManager/dnsmasq.d
 env_file:
   - skipper.env
+env:
+  GOCACHE: "/go/pkg/mod"
 

--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     libvirt = {
-      source = "dmacvicar/libvirt"
-      version = "0.6.12"
+      source = "assisted-test-infra-registry.local/openshift-assisted/libvirt"
+      version = "9.9.9"
     }
   }
 }

--- a/terraform_files/baremetal_host/main.tf
+++ b/terraform_files/baremetal_host/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     libvirt = {
-      source = "dmacvicar/libvirt"
-      version = "0.6.12"
+      source = "assisted-test-infra-registry.local/openshift-assisted/libvirt"
+      version = "9.9.9"
     }
   }
 

--- a/terraform_files/baremetal_infra_env/main.tf
+++ b/terraform_files/baremetal_infra_env/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     libvirt = {
-      source = "dmacvicar/libvirt"
-      version = "0.6.12"
+      source = "assisted-test-infra-registry.local/openshift-assisted/libvirt"
+      version = "9.9.9"
     }
   }
 }

--- a/terraform_files/none/main.tf
+++ b/terraform_files/none/main.tf
@@ -1,8 +1,8 @@
 terraform {
   required_providers {
     libvirt = {
-      source = "dmacvicar/libvirt"
-      version = "0.6.12"
+      source = "assisted-test-infra-registry.local/openshift-assisted/libvirt"
+      version = "9.9.9"
     }
   }
 }


### PR DESCRIPTION
https://github.com/dmacvicar/terraform-provider-libvirt is recently
unmaintained and doesn't seem to be merging pull requests.

There are some changes we wanted to make in the project but couldn't
because the maintainer haven't merged our pull requests for a while now,
so we decided we should [fork it](https://github.com/openshift-assisted/terraform-provider-libvirt) instead for now.

Changes include:
- Race condition when creating two libvirt networks at the same time
- Some missing ARM support (@tsorya can elaborate)
- Like three other bugs / issues mentioned in our code if you grep for dmacvicar

This pull request makes it so that when running tests, the fork will be
cloned, built, and installed. All terraform files have been modified
to use the fork.

We always use pull and build the latest version of our fork (master
branch).
