### PR TITLE
Fix disk size calculation when formatting disks.

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -1,3 +1,4 @@
+import json
 import os
 import re
 import secrets
@@ -252,13 +253,9 @@ class LibvirtController(NodeController, ABC):
             log.info("Path to %s disk not exists. Skipping", disk_path)
             return
 
-        command = f"qemu-img info {disk_path} | grep 'virtual size'"
-        output = utils.run_command(command, shell=True)
-        image_size = output[0].split(" ")[2]
-        # Fix for libvirt 6.0.0
-        if image_size.isdigit():
-            image_size += "G"
-
+        command = f"qemu-img info {disk_path} --output json"
+        output, _, _ = utils.run_command(command, shell=True)
+        image_size = json.loads(output)["virtual-size"]
         cls.create_disk(disk_path, image_size)
 
     @classmethod


### PR DESCRIPTION
Since we moved to 100GB disk limitation, we get a different output for
the used disk. This leads to the following error:
```
E           RuntimeError: command: qemu-img create -f qcow2
/home/test/assisted-test-infra/storage_pool/test-infra-cluster-742fe912/test-infra-cluster-742fe912-master-2-disk-
0 93.1 exited with an error: qemu-img: Invalid image size specified. You
  may use k, M, G, T, P or E suffixes for
E           qemu-img: kilobytes, megabytes, gigabytes, terabytes,
petabytes and exabytes. code: 1
```

This changes how we get the existing disk size by using ``--output
json`` that returns a nicer format for being able to parse the disk
size. ``qemu-img create`` command is capable of getting disk sizes
either in bytes or with quantifiers like G/M/K/etc. so we should stay
compatible with this change.