### PR TITLE
additional parameter(timeout) for method wait_for_specific_host_status  and new host event parameter DISCONNECTED

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -537,13 +537,16 @@ class Cluster(Entity):
             fall_on_error_status=fall_on_error_status,
         )
 
-    def wait_for_specific_host_status(self, host, statuses, nodes_count: int = MINIMUM_NODES_TO_WAIT):
+    def wait_for_specific_host_status(
+        self, host, statuses, nodes_count: int = MINIMUM_NODES_TO_WAIT, timeout: int = consts.NODES_REGISTERED_TIMEOUT
+    ):
         utils.waiting.wait_till_specific_host_is_in_status(
             client=self.api_client,
             cluster_id=self.id,
             host_name=host.get("requested_hostname"),
             statuses=statuses,
             nodes_count=nodes_count,
+            timeout=timeout,
         )
 
     def wait_for_specific_host_stage(self, host: dict, stage: str, inclusive: bool = True):

--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -278,6 +278,7 @@ class HostEvents:
     JOINED = "reached installation stage Joined"
     DONE = "reached installation stage Done"
     INSTALLED = "updated status from installing-in-progress to installed"
+    DISCONNECTED = "validation 'connected' that used to succeed is now failing"
 
 
 class HostStatusInfo:


### PR DESCRIPTION
@eliorerz @lalon4
Function wait_for_specific_host_status , will have a new parameter (timeout) 
new Parameter in host events : DISCONNECTED

change is needed to support kni test , which validate that cluster installation is timeout after 3 min when a host which already reached the state "write to disk" is now disconnected for 3 min+ 