### PR TITLE
Delete tfstate file during destroy nodes

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -309,6 +309,11 @@ class TerraformController(LibvirtController):
         self._delete_virsh_resources(
             self._entity_name.get(), self.params.libvirt_network_name, self.params.libvirt_secondary_network_name
         )
+        tfstate_path = f"{self.tf_folder}/{self.tf.STATE_FILE}"
+        if os.path.exists(tfstate_path):
+            log.info(f"Deleting tf state file: {tfstate_path}")
+            os.remove(tfstate_path)
+
         if delete_tf_folder:
             log.info("Deleting %s", self.tf_folder)
             shutil.rmtree(self.tf_folder)


### PR DESCRIPTION
Since recently one of our e2e test is failing (test_unique_vip_hostname). 
The test create cluster and nodes, and than delete created cluster and nodes, and create another set of cluster and nodes. Issue is that lately it is failing to create the second set of nodes - tf apply get an error: 
"Storage pool not found: no storage pool with matching name".
Turns out that whenever we clear the nodes we use libvirt cleanup (instead of tf) so tf state assume disks are already exists, while in reality they were cleaned by delete all virsh resources.
This PR clean tf state file to avoid this failure.