### PR TITLE
MGMT-11109 - Prepare nodes only after having an infra_env

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -211,3 +211,6 @@ class NodeController(ABC):
 
     def set_dns_for_user_managed_network(self) -> None:
         pass
+
+    def set_ipxe_url(self, network_name: str, ipxe_url: str):
+        pass

--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -845,7 +845,7 @@ class Cluster(Entity):
 
     @JunitTestCase()
     def prepare_for_installation(self, **kwargs):
-        super(Cluster, self).prepare_for_installation(**kwargs)
+        super(Cluster, self).prepare_for_installation(is_static_ip=self._infra_env_config.is_static_ip, **kwargs)
 
         self.nodes.wait_for_networking()
         self._set_hostnames_and_roles()

--- a/src/assisted_test_infra/test_infra/helper_classes/cluster_host.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster_host.py
@@ -23,7 +23,10 @@ class ClusterHost:
         )
 
     def has_hostname(self) -> bool:
-        return self.get_hostname() != DEFAULT_HOSTNAME
+        hostname = self.get_hostname()
+        if not hostname or hostname.startswith(DEFAULT_HOSTNAME):
+            return False
+        return True
 
     def interfaces(self) -> List[Interface]:
         return [Interface(**interface) for interface in self.__inventory.interfaces]

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_entity_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_entity_config.py
@@ -16,14 +16,14 @@ class BaseEntityConfig(BaseConfig, ABC):
     user_managed_networking: bool = None
     high_availability_mode: str = None
     hyperthreading: str = None
-    iso_download_path: str = None
+    iso_download_path: str = None  # TODO Needed only on infra env. Remove from here and move to BaseInfraEnvConfig
     worker_iso_download_path: str = None
     iso_image_type: str = None
     download_image: bool = None
     platform: str = None
-    is_static_ip: bool = None
     is_ipv4: bool = None
     is_ipv6: bool = None
     base_dns_domain: str = None
     entity_name: BaseName = None
     proxy: models.Proxy = None
+    ipxe_boot: bool = None

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_infra_env_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_infra_env_config.py
@@ -17,3 +17,4 @@ class BaseInfraEnvConfig(BaseEntityConfig, ABC):
     static_network_config: List[dict] = None
     ignition_config_override: str = None
     verify_download_iso_ssl: bool = None
+    is_static_ip: bool = None

--- a/src/assisted_test_infra/test_infra/helper_classes/config/cluster_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/cluster_config.py
@@ -30,4 +30,3 @@ class BaseClusterConfig(BaseEntityConfig, ABC):
     disk_encryption_mode: str = None
     disk_encryption_roles: str = None
     tang_servers: str = None
-    ipxe_boot: bool = None

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -10,7 +10,7 @@ from typing import Any
 import waiting
 
 import consts
-from assisted_test_infra.test_infra import utils
+from assisted_test_infra.test_infra import BaseInfraEnvConfig, utils
 from assisted_test_infra.test_infra.controllers import NodeController
 from assisted_test_infra.test_infra.helper_classes.config.day2_cluster_config import BaseDay2ClusterConfig
 from assisted_test_infra.test_infra.tools import static_network
@@ -20,9 +20,12 @@ from service_client.assisted_service_api import InventoryClient
 
 
 class Day2Cluster(ABC):
-    def __init__(self, api_client: InventoryClient, config: BaseDay2ClusterConfig):
+    def __init__(
+        self, api_client: InventoryClient, config: BaseDay2ClusterConfig, infra_env_config: BaseInfraEnvConfig
+    ):
         self.config = config
         self.api_client = api_client
+        self._infra_env_config = infra_env_config
 
     def prepare_for_installation(self, iso_download_path: str = None):
         utils.recreate_folder(consts.IMAGE_FOLDER, force_recreate=False)
@@ -50,7 +53,7 @@ class Day2Cluster(ABC):
         self.configure_terraform(self.config.tf_folder, self.config.day2_workers_count, api_vip_ip)
 
         static_network_config = None
-        if self.config.is_static_ip:
+        if self._infra_env_config.is_static_ip:
             static_network_config = static_network.generate_day2_static_network_data_from_tf(
                 self.config.tf_folder, self.config.day2_workers_count
             )
@@ -230,7 +233,7 @@ class Day2Cluster(ABC):
         return len(hosts) >= self.config.day2_workers_count
 
     def set_nodes_hostnames_if_needed(self, network_name: str):
-        if self.config.is_ipv6 or self.config.is_static_ip:
+        if self.config.is_ipv6 or self._infra_env_config.is_static_ip:
             tf = utils.TerraformUtils(working_dir=self.config.tf_folder)
             libvirt_nodes = utils.extract_nodes_from_tf_state(tf.get_state(), network_name, consts.NodeRoles.WORKER)
             log.info(

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -24,7 +24,7 @@ class Day2Cluster(ABC):
         self.config = config
         self.api_client = api_client
 
-    def prepare_for_installation(self):
+    def prepare_for_installation(self, iso_download_path: str = None):
         utils.recreate_folder(consts.IMAGE_FOLDER, force_recreate=False)
 
         cluster = self.api_client.cluster_get(cluster_id=self.config.day1_cluster_id)
@@ -67,9 +67,9 @@ class Day2Cluster(ABC):
         self.config.infra_env_id = infra_env.id
         # Download image
         iso_download_url = infra_env.download_url
-        image_path = os.path.join(consts.IMAGE_FOLDER, f"{self.config.day1_cluster_name}-installer-image.iso")
-        log.info(f"Downloading image {iso_download_url} to {image_path}")
-        utils.download_file(iso_download_url, image_path, False)
+        log.info(f"Downloading image {iso_download_url} to {iso_download_path}")
+
+        utils.download_file(iso_download_url, iso_download_path, False)
 
     def start_install_and_wait_for_installed(self, libvirt_controller: NodeController):
         cluster_name = self.config.day1_cluster_name

--- a/src/assisted_test_infra/test_infra/helper_classes/entity.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/entity.py
@@ -56,8 +56,9 @@ class Entity(ABC):
                 raise KeyError(f"The key {k} is not present in {self._config.__class__.__name__}")
             setattr(self._config, k, v)
 
-    def prepare_for_installation(self, **kwargs):
+    def prepare_for_installation(self, is_static_ip: bool = False, **kwargs):
         self.update_config(**kwargs)
+
         log.info(
             f"Preparing for installation with {self._entity_class_name} configurations: "
             f"{self._entity_class_name}_config={self._config}"
@@ -65,11 +66,11 @@ class Entity(ABC):
 
         self.nodes.controller.log_configuration()
 
-        if self._config.download_image and not self._config.is_static_ip:
+        if self._config.download_image and not is_static_ip:
             self.download_image()
 
         self.nodes.prepare_nodes()
-        if self._config.is_static_ip:
+        if is_static_ip:
             # On static IP installation re-download the image after preparing nodes and setting the
             # static IP configurations
             if self._config.download_image:
@@ -80,7 +81,7 @@ class Entity(ABC):
         if self._config.ipxe_boot:
             self._set_ipxe_url()
 
-        self.nodes.start_all(check_ips=not (self._config.is_static_ip and self._config.is_ipv6))
+        self.nodes.start_all(check_ips=not (is_static_ip and self._config.is_ipv6))
         self.wait_until_hosts_are_discovered(allow_insufficient=True)
 
     def _set_ipxe_url(self):

--- a/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/infraenv.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/infraenv.py
@@ -1,7 +1,7 @@
 import re
 import warnings
 from pprint import pformat
-from typing import List, Optional, Union
+from typing import Dict, List, Optional, Union
 
 import waiting
 import yaml
@@ -67,6 +67,7 @@ class InfraEnv(BaseCustomResource):
     ):
         super().__init__(name, namespace)
         self.crd_api = CustomObjectsApi(kube_api_client)
+        self._iso_download_path = None
 
     def create_from_yaml(self, yaml_data: dict) -> None:
         self.crd_api.create_namespaced_custom_object(
@@ -88,7 +89,7 @@ class InfraEnv(BaseCustomResource):
         nmstate_label: Optional[str] = None,
         ssh_pub_key: Optional[str] = None,
         **kwargs,
-    ) -> None:
+    ) -> Dict:
         body = {
             "apiVersion": f"{consts.CRD_API_GROUP}/{consts.CRD_API_VERSION}",
             "kind": "InfraEnv",
@@ -113,7 +114,7 @@ class InfraEnv(BaseCustomResource):
             spec["sshAuthorizedKey"] = ssh_pub_key
 
         spec.update(kwargs)
-        self.crd_api.create_namespaced_custom_object(
+        infraenv = self.crd_api.create_namespaced_custom_object(
             group=consts.CRD_API_GROUP,
             version=consts.CRD_API_VERSION,
             plural=self._plural,
@@ -122,6 +123,7 @@ class InfraEnv(BaseCustomResource):
         )
 
         log.info("created infraEnv %s: %s", self.ref, pformat(body))
+        return infraenv
 
     def patch(
         self,

--- a/src/assisted_test_infra/test_infra/helper_classes/nodes.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/nodes.py
@@ -26,6 +26,11 @@ class Nodes:
         self.controller = node_controller
         self._nodes = None
         self._nodes_as_dict = None
+        self.__is_prepared = False
+
+    @property
+    def is_prepared(self) -> bool:
+        return self.__is_prepared
 
     @property
     def masters_count(self):
@@ -115,9 +120,12 @@ class Nodes:
 
     def destroy_all_nodes(self):
         self.controller.destroy_all_nodes()
+        self.__is_prepared = False
 
     def prepare_nodes(self):
-        self.controller.prepare_nodes()
+        if not self.__is_prepared:
+            self.controller.prepare_nodes()
+            self.__is_prepared = True
 
     def reboot_all(self):
         self.run_for_all_nodes("restart")

--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -225,7 +225,7 @@ def get_remote_assisted_service_url(oc, namespace, service, scheme):
         if is_assisted_service_reachable(url):
             return url
 
-    raise RuntimeError(f"could not find any reachable url to {service} service " f"in {namespace} namespace")
+    raise RuntimeError(f"could not find any reachable url to {service} service in {namespace} namespace")
 
 
 def get_local_assisted_service_url(namespace, service, deploy_target):
@@ -592,3 +592,11 @@ def get_kubeapi_protocol_options() -> List[Tuple[bool, bool]]:
         return [(False, True)]
 
     return [(False, True), (True, False)]
+
+
+def get_iso_download_path(entity_name: str):
+    return str(
+        Path(consts.env_defaults.DEFAULT_IMAGE_FOLDER).joinpath(
+            f"{entity_name}-{consts.env_defaults.DEFAULT_IMAGE_FILENAME}"
+        )
+    ).strip()

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -161,9 +161,9 @@ class InventoryClient(object):
     def cluster_get(self, cluster_id: str) -> models.cluster.Cluster:
         return self.client.v2_get_cluster(cluster_id=cluster_id)
 
-    def get_infra_env_by_cluster_id(self, cluster_id: str) -> List[models.infra_env.InfraEnv]:
+    def get_infra_env_by_cluster_id(self, cluster_id: str) -> List[Union[models.infra_env.InfraEnv, Dict[str, Any]]]:
         infra_envs = self.infra_envs_list()
-        return filter(lambda infra_env: infra_env["cluster_id"] == cluster_id, infra_envs)
+        return [infra_env for infra_env in infra_envs if infra_env["cluster_id"] == cluster_id]
 
     def update_infra_env(self, infra_env_id: str, infra_env_update_params):
         log.info("Updating infra env %s with values %s", infra_env_id, infra_env_update_params)

--- a/src/tests/base_kubeapi_test.py
+++ b/src/tests/base_kubeapi_test.py
@@ -141,7 +141,9 @@ class BaseKubeAPI(BaseTest):
         assert os.path.isfile(iso_download_path)
 
     @classmethod
-    def start_nodes(cls, nodes: Nodes, infra_env: InfraEnv, entity_config: BaseEntityConfig) -> List[Agent]:
+    def start_nodes(
+        cls, nodes: Nodes, infra_env: InfraEnv, entity_config: BaseEntityConfig, is_static_ip: bool
+    ) -> List[Agent]:
         infra_env.status()  # wait until install-env will have status (i.e until resource will be processed).
         cls.download_iso_from_infra_env(infra_env, entity_config.iso_download_path)
 
@@ -149,7 +151,7 @@ class BaseKubeAPI(BaseTest):
         nodes.controller.log_configuration()
         log.info(f"Entity configuration {entity_config}")
 
-        nodes.start_all(check_ips=not (entity_config.is_static_ip and entity_config.is_ipv6))
+        nodes.start_all(check_ips=not (is_static_ip and entity_config.is_ipv6))
 
         log.info("waiting for host agent")
         agents = infra_env.wait_for_agents(len(nodes))

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -388,11 +388,13 @@ class BaseTest:
         api_client: InventoryClient,
         request: FixtureRequest,
         day2_cluster_configuration: Day2ClusterConfig,
+        infra_env_configuration: InfraEnvConfig,
     ):
         log.debug(f"--- SETUP --- Creating Day2 cluster for test: {request.node.name}\n")
         cluster = Day2Cluster(
             api_client=api_client,
             config=day2_cluster_configuration,
+            infra_env_config=infra_env_configuration,
         )
 
         yield cluster

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -261,7 +261,6 @@ class BaseTest:
     @JunitFixtureTestCase()
     def prepare_nodes(self, nodes: Nodes, cluster_configuration: ClusterConfig) -> Nodes:
         try:
-            nodes.prepare_nodes()
             yield nodes
         finally:
             if global_variables.test_teardown:
@@ -275,7 +274,6 @@ class BaseTest:
     @JunitFixtureTestCase()
     def prepare_infraenv_nodes(self, infraenv_nodes: Nodes, infra_env_configuration: InfraEnvConfig) -> Nodes:
         try:
-            infraenv_nodes.prepare_nodes()
             yield infraenv_nodes
         finally:
             if global_variables.test_teardown:
@@ -348,11 +346,9 @@ class BaseTest:
             infra_env = cluster.generate_infra_env()
             ipxe_server_controller = ipxe_server(name="ipxe_controller", api_client=cluster.api_client)
             ipxe_server_controller.run(infra_env_id=infra_env.id, cluster_name=cluster.name)
-
-            ipxe_server_url = f"http://{consts.DEFAULT_IPXE_SERVER_IP}:{consts.DEFAULT_IPXE_SERVER_PORT}/{cluster.name}"
-            network_name = cluster.nodes.get_cluster_network()
-            libvirt_controller = LibvirtController(config=cluster.nodes.controller, entity_config=cluster_configuration)
-            libvirt_controller.set_ipxe_url(network_name=network_name, ipxe_url=ipxe_server_url)
+            cluster_configuration.iso_download_path = utils.get_iso_download_path(
+                infra_env_configuration.entity_name.get()
+            )
 
         yield cluster
 
@@ -449,8 +445,6 @@ class BaseTest:
             nodes = Nodes(controller)
             nodes_data["nodes"] = nodes
 
-            nodes.prepare_nodes()
-
             interfaces = self.nat_interfaces(tf_config)
             nat = NatController(interfaces, NatController.get_namespace_index(interfaces[0]))
             nat.add_nat_rules()
@@ -498,8 +492,6 @@ class BaseTest:
             controller = TerraformController(tf_config, entity_config=infraenv_config)
             nodes = Nodes(controller)
             nodes_data["nodes"] = nodes
-
-            nodes.prepare_nodes()
 
             interfaces = self.nat_interfaces(tf_config)
             nat = NatController(interfaces, NatController.get_namespace_index(interfaces[0]))
@@ -576,7 +568,7 @@ class BaseTest:
 
     @staticmethod
     def _does_need_proxy_server(nodes: Nodes):
-        return nodes and nodes.is_ipv6 and not nodes.is_ipv4
+        return nodes is not None and nodes.is_ipv6 and not nodes.is_ipv4
 
     @staticmethod
     def get_proxy_server(nodes: Nodes, cluster_config: ClusterConfig, proxy_server: Callable) -> ProxyController:

--- a/src/tests/config/global_configs.py
+++ b/src/tests/config/global_configs.py
@@ -1,5 +1,4 @@
 from dataclasses import dataclass
-from pathlib import Path
 
 from assisted_test_infra.test_infra import (
     BaseClusterConfig,
@@ -11,7 +10,6 @@ from assisted_test_infra.test_infra import (
     InfraEnvName,
     utils,
 )
-from consts import env_defaults
 from tests.global_variables import DefaultVariables
 
 global_variables = DefaultVariables()
@@ -20,12 +18,6 @@ global_variables = DefaultVariables()
 def reset_global_variables():
     global global_variables
     global_variables = DefaultVariables()
-
-
-def _get_iso_download_path(entity_name: str):
-    return str(
-        Path(env_defaults.DEFAULT_IMAGE_FOLDER).joinpath(f"{entity_name}-{env_defaults.DEFAULT_IMAGE_FILENAME}")
-    ).strip()
 
 
 @dataclass
@@ -42,8 +34,6 @@ class ClusterConfig(BaseClusterConfig):
         self.entity_name = self.cluster_name
         if self.kubeconfig_path is None:
             self.kubeconfig_path = utils.get_kubeconfig_path(self.cluster_name.get())
-        if self.iso_download_path is None:
-            self.iso_download_path = _get_iso_download_path(self.cluster_name.get())
 
 
 @dataclass
@@ -58,7 +48,7 @@ class InfraEnvConfig(BaseInfraEnvConfig):
         if self.entity_name is None or isinstance(self.entity_name, str):
             self.entity_name = InfraEnvName()
         if self.iso_download_path is None:
-            self.iso_download_path = _get_iso_download_path(self.entity_name.get())
+            self.iso_download_path = utils.get_iso_download_path(self.entity_name.get())
 
 
 @dataclass
@@ -67,6 +57,15 @@ class Day2ClusterConfig(BaseDay2ClusterConfig):
 
     def _get_data_pool(self):
         return global_variables
+
+    def __post_init__(self):
+        super().__post_init__()
+
+        if self.cluster_name is None or isinstance(self.cluster_name, str):
+            self.cluster_name = ClusterName()  # todo rm cluster_name after removing config.cluster_name dependencies
+        self.entity_name = self.cluster_name
+        if self.iso_download_path is None:
+            self.iso_download_path = utils.get_iso_download_path(self.entity_name.get())
 
 
 @dataclass

--- a/src/tests/test_day2.py
+++ b/src/tests/test_day2.py
@@ -15,5 +15,5 @@ class TestDay2(BaseTest):
             cluster.start_install_and_wait_for_installed()
 
         day2_cluster.config.day1_cluster_id = cluster.id
-        day2_cluster.prepare_for_installation()
+        day2_cluster.prepare_for_installation(iso_download_path=cluster.get_iso_download_path())
         day2_cluster.start_install_and_wait_for_installed(controller)

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -9,7 +9,7 @@ import pytest
 import waiting
 from junit_report import JunitFixtureTestCase, JunitTestCase, JunitTestSuite
 
-from assisted_test_infra.test_infra import Nodes, utils
+from assisted_test_infra.test_infra import BaseInfraEnvConfig, Nodes, utils
 from assisted_test_infra.test_infra.helper_classes.config import BaseNodeConfig
 from assisted_test_infra.test_infra.helper_classes.hypershift import HyperShift
 from assisted_test_infra.test_infra.helper_classes.kube_helpers import (
@@ -52,20 +52,26 @@ class TestKubeAPI(BaseKubeAPI):
         prepare_nodes_network: Nodes,
         is_ipv4: bool,
         is_ipv6: bool,
+        infra_env_configuration: BaseInfraEnvConfig,
     ):
         self.kube_api_test(
             kube_api_context,
             prepare_nodes_network,
             cluster_configuration,
             prepared_controller_configuration,
+            infra_env_configuration,
             proxy_server if cluster_configuration.is_ipv6 else None,
         )
 
     @JunitTestSuite()
     @pytest.mark.kube_api
     @pytest.mark.override_controller_configuration(highly_available_controller_configuration.__name__)
-    def test_capi_provider(self, cluster_configuration, kube_api_context, prepare_nodes_network):
-        self.capi_test(kube_api_context, prepare_nodes_network, cluster_configuration)
+    def test_capi_provider(
+        self, cluster_configuration, kube_api_context, prepare_nodes_network, infra_env_configuration
+    ):
+        self.capi_test(
+            kube_api_context, prepare_nodes_network, cluster_configuration, infra_env_configuration.is_static_ip
+        )
 
     @JunitTestCase()
     def kube_api_test(
@@ -74,6 +80,7 @@ class TestKubeAPI(BaseKubeAPI):
         nodes: Nodes,
         cluster_config: ClusterConfig,
         prepared_controller_configuration: BaseNodeConfig,
+        infra_env_configuration: BaseInfraEnvConfig,
         proxy_server: Optional[Callable] = None,
         *,
         is_disconnected: bool = False,
@@ -126,10 +133,10 @@ class TestKubeAPI(BaseKubeAPI):
 
         agent_cluster_install.wait_to_be_ready(ready=False)
 
-        if cluster_config.is_static_ip:
+        if infra_env_configuration.is_static_ip:
             self.apply_static_network_config(kube_api_context, nodes, cluster_name)
 
-        agents = self.start_nodes(nodes, infra_env, cluster_config)
+        agents = self.start_nodes(nodes, infra_env, cluster_config, infra_env_configuration.is_static_ip)
 
         if len(nodes) == 1:
             # for single node set the cidr and take the actual ip from the host
@@ -159,6 +166,7 @@ class TestKubeAPI(BaseKubeAPI):
         kube_api_context: KubeAPIContext,
         nodes: Nodes,
         cluster_config: ClusterConfig,
+        is_static_ip: bool,
         proxy_server: Optional[Callable] = None,
         *,
         is_disconnected: bool = False,
@@ -189,7 +197,7 @@ class TestKubeAPI(BaseKubeAPI):
             proxy=proxy,
             ssh_pub_key=cluster_config.ssh_public_key,
         )
-        self.start_nodes(nodes, infra_env, cluster_config)
+        self.start_nodes(nodes, infra_env, cluster_config, is_static_ip)
         hypershift = HyperShift(name=cluster_name, kube_api_client=api_client)
 
         with utils.pull_secret_file() as ps:
@@ -512,7 +520,7 @@ class TestLateBinding(BaseKubeAPI):
             ssh_pub_key=infraenv_config.ssh_public_key,
         )
 
-        agents = self.start_nodes(nodes, infra_env, infraenv_config)
+        agents = self.start_nodes(nodes, infra_env, infraenv_config, infraenv_config.is_static_ip)
 
         log.info("Waiting for agent status verification")
         Agent.wait_for_agents_to_be_ready_for_install(agents)


### PR DESCRIPTION
- Do not prepare nodes before infraenv is being created.
- Create infraenv and get iso_download_path prepering the nodes.
- Remove the const iso_download_path from cluster configuration.

/cc @lalon4 @tsorya @osherdp 