### PR TITLE
Allow usage of AlmaLinux OS in assisted-test-infra

### DIFF
--- a/GUIDE.md
+++ b/GUIDE.md
@@ -2,7 +2,7 @@
 
 ## Prerequisites
 
-1. Only usage of CentOS8 / RHEL8 / Rocky8 on the assisted installer host<sup id="a1">[1](#f1)</sup> is supported
+1. Only usage of CentOS8 / RHEL8 / Rocky8 / AlmaLinux on the assisted installer host<sup id="a1">[1](#f1)</sup> is supported
    - This host will run minikube and the UI for deploying OpenShift on Bare Metal
 1. Setup DHCP/DNS records for the following OpenShift nodes and VIPs. List includes
    - Master nodes
@@ -159,7 +159,7 @@ As `$USER` user with `sudo` privileges,
 
 - Before starting, note that test infra is written in python (>= 3.9) and uses [pytest](https://docs.pytest.org/en/6.2.x/contents.html) and [pytest fixtures](https://docs.pytest.org/en/6.2.x/fixture.html) for running all of our e2e test flows.
 - Set up test-infra test environment ([assisted-installer-install-guide](GUIDE.md#assisted-installer-unofficial-install-guide))
-- Make sure that the assisted-service is supporting the tested feature 
+- Make sure that the assisted-service is supporting the tested feature
   - For customizing tested components, take a look at [components deployment parameters](README.md#components)
   - The changes are already on assisted-service master branch
 - Make sure to test the changes for both CI-compatible distro (Rocky Linux 8) and QE's compatible environment (RHEL 8.5).

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This project deploys the OpenShift Assisted Installer in Minikube and spawns lib
   - [Instructions](#instructions)
     - [Host preparation](#host-preparation)
   - [Usage](#usage)
-  - [Adding a new e2e flow](#new-e2e-flow)  
+  - [Adding a new e2e flow](#new-e2e-flow)
   - [Full flow cases](#full-flow-cases)
     - [Run full flow with install](#run-full-flow-with-install)
     - [Run full flow without install](#run-full-flow-without-install)
@@ -55,7 +55,7 @@ This project deploys the OpenShift Assisted Installer in Minikube and spawns lib
 
 ## Prerequisites
 
-- CentOS 8, RHEL 8 or Rocky 8 host
+- CentOS 8 / RHEL 8 / Rocky 8 / AlmaLinux 8 host
 - File system that supports d_type
 - Ideally on a bare metal host with at least 64G of RAM.
 - Run as a user with password-less `sudo` access or be ready to enter `sudo` password for prepare phase.

--- a/scripts/create_full_environment.sh
+++ b/scripts/create_full_environment.sh
@@ -8,8 +8,8 @@ function error() {
 
 # Check OS
 OS=$(awk -F= '/^ID=/ { print $2 }' /etc/os-release | tr -d '"')
-if [[ ! ${OS} =~ ^(centos)$ ]] && [[ ! ${OS} =~ ^(rhel)$ ]] && [[ ! ${OS} =~ ^(rocky)$ ]]; then
-    error "\"${OS}\" is an unsupported OS. We support only CentOS, RHEL or Rocky."
+if [[ ! ${OS} =~ ^(centos)$ ]] && [[ ! ${OS} =~ ^(rhel)$ ]] && [[ ! ${OS} =~ ^(rocky)$ ]] && [[ ! ${OS} =~ ^(almalinux)$ ]]; then
+    error "\"${OS}\" is an unsupported OS. We support only CentOS, RHEL, Rocky or AlmaLinux."
     error "It's not recommended to run the code in this repo locally on your personal machine, as it makes some opinionated configuration changes to the machine it's running on"
     exit 1
 fi


### PR DESCRIPTION
This allows AlmaLinux as a backup plan so that we'll be able to use it if Rocky fails us as a CI candidate.
I tested full installation with AlmaLinux 8 via Equinix, it passed successfully.