### PR TITLE
MGMT-11319 - Remove redundant `destroy_nodes` when preparing nodes

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -318,7 +318,6 @@ class TerraformController(LibvirtController):
 
     def prepare_nodes(self):
         log.info("Preparing nodes")
-        self.destroy_all_nodes()
         if not os.path.exists(self._entity_config.iso_download_path):
             utils.recreate_folder(os.path.dirname(self._entity_config.iso_download_path), force_recreate=False)
             # if file not exist lets create dummy

--- a/src/tests/test_day2.py
+++ b/src/tests/test_day2.py
@@ -11,6 +11,8 @@ class TestDay2(BaseTest):
     @JunitTestSuite()
     def test_deploy_day2_nodes_cloud(self, cluster, day2_cluster, controller):
         if not global_variables.cluster_id:
+            cluster.nodes.destroy_all_nodes()
+            cluster.nodes.prepare_nodes()
             cluster.prepare_for_installation()
             cluster.start_install_and_wait_for_installed()
 


### PR DESCRIPTION
Currently we are running the "nodes  cleanup" on every test regardless the nodes status.
Each cluster name is unique so as the terraform configuration folder so there shouldn't be a case where a cluster is created with the same name.
Furthermore, we should not prepare the nodes twice in the same test. If for some reason we want to do it, we can always do it manually, e.g.

```python
...
nodes.prepare_nodes()
...
nodes.destroy_all_nodes()
nodes.prepare_nodes()
...
```

/cc @osherdp 