### PR TITLE
Do not pull images from Dockerfile.*.ocp files

### DIFF
--- a/scripts/pull_dockerfile_images.sh
+++ b/scripts/pull_dockerfile_images.sh
@@ -2,7 +2,8 @@
 
 export CONTAINER_COMMAND=${CONTAINER_COMMAND:-podman}
 
-images=$(cat Dockerfile.* ./*/Dockerfile.* | grep -i FROM | awk '{print $2}')
+dockerfiles=$(find . -name "Dockerfile.*" -not -name "*.ocp")
+images=$(cat ${dockerfiles} | grep -i FROM | awk '{print $2}')
 images=${images//--from=}
 
 echo "### Attempting to pull assisted dockerfile images (best effort) ###"


### PR DESCRIPTION
assisted-service has now a Dockerfile for building it's content for OCP
payload, and it references images that require authentication against
registry.ci (e.g. ``registry.ci.openshift.org/ocp/4.11:cli``).

This change omits those kind of files so that we won't pull for nothing.