### PR TITLE
NO-ISSUE - Allow KeyboardInterrupt during download logs

### DIFF
--- a/src/assisted_test_infra/download_logs/__main__.py
+++ b/src/assisted_test_infra/download_logs/__main__.py
@@ -56,7 +56,6 @@ def main():
             args.dest,
             args.must_gather,
             args.update_by_events,
-            pull_secret=args.pull_secret,
         )
     else:
         clusters = get_clusters(client, args.download_all)
@@ -67,9 +66,7 @@ def main():
 
         for cluster in clusters:
             if args.download_all or should_download_logs(cluster):
-                download_cluster_logs(
-                    client, cluster, args.dest, args.must_gather, args.update_by_events, pull_secret=args.pull_secret
-                )
+                download_cluster_logs(client, cluster, args.dest, args.must_gather, args.update_by_events)
 
         log.info("Cluster installation statuses: %s", dict(Counter(cluster["status"] for cluster in clusters).items()))
 

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -805,7 +805,6 @@ class BaseTest:
                 cluster_details,
                 log_dir_name,
                 self._is_test_failed(request),
-                pull_secret=global_variables.pull_secret,
             )
 
         if isinstance(nodes.controller, LibvirtController):


### PR DESCRIPTION
Allow the user to skip on the download logs part using KeyboardInterrupt signal.
At the current situation, the test is to trying to download the logs 3 times with 300 seconds sleep between them. Pressing sending KeyboardInterrupt signal is not always working (on sleep) and the test is exit without a proper cleanup.
Also removing the unused `pull_secret` field from `download_logs` function.

/cc @osherdp 