### PR TITLE
Fix swtpm installation not being idempotent

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -55,8 +55,15 @@ function install_libvirt() {
         make
 
     echo "Install swtpm v0.7.1 from source"
-    git clone --depth 1 --branch v0.7.1 https://github.com/stefanberger/swtpm.git
-    pushd swtpm
+    swtpm_dir=$(mktemp -d -t swtpm-dir-XXXXXX)
+    function cleanup {
+        echo "deleting ${swtpm_dir}..."
+        rm -rf "${swtpm_dir}"
+    }
+    trap cleanup EXIT
+
+    git clone --depth 1 --branch v0.7.1 https://github.com/stefanberger/swtpm.git ${swtpm_dir}
+    pushd ${swtpm_dir}
     ./autogen.sh --with-openssl --prefix=/usr
     make -j4
     make install


### PR DESCRIPTION
When doing ``make setup`` twice, it fails on the ``swtpm`` dir already existing:
```
Install swtpm v0.7.1 from source
fatal: destination path 'swtpm' already exists and is not an empty
directory.
make: *** [Makefile:128: setup] Error 128
```

In addition, it leaves unstaged files in the repo that are not ignored by git.

This change will use a temporary dir from ``/tmp``, and will cleanup afterwards with a bash trap.