### PR TITLE
MGMT-11491: kubeAPI flow should work with no default OCP version

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -459,8 +459,8 @@ def get_default_openshift_version(client=None) -> str:
 
     log.info(f"Default openshift version found {versions}")
 
-    assert len(versions) == 1, f"There should be exactly one default version {versions}"
-    return versions[0]
+    assert len(versions) <= 1, f"There should be no more than one default version - {versions}"
+    return versions[0] if versions else None
 
 
 def get_openshift_version(allow_default=True, client=None) -> str:


### PR DESCRIPTION
As detailed in Jira, the lack of a default OCP version fails this flow.