### PR TITLE
MGMT-11449: govc installation from GitHub gets rate-limiter failures

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -28,7 +28,6 @@ RUN dnf -y install --enablerepo=crb \
 
 RUN curl --retry 5 -Lo packer.zip https://releases.hashicorp.com/packer/1.8.0/packer_1.8.0_linux_386.zip && unzip packer.zip -d /usr/bin/ && mv /usr/bin/packer /usr/bin/packer.io && rm -rf packer.zip
 RUN curl --retry 5 -Lo terraform.zip https://releases.hashicorp.com/terraform/1.2.2/terraform_1.2.2_linux_amd64.zip && unzip terraform.zip -d /usr/bin/ && rm -rf terraform.zip
-RUN curl --retry 5 -Lo - "https://github.com/vmware/govmomi/releases/latest/download/govc_$(uname -s)_$(uname -m).tar.gz" | tar -C /usr/local/bin -xvzf - govc
 RUN curl --retry 5 -L https://github.com/containers/podman/releases/download/v3.4.4/podman-remote-static.tar.gz -o "/tmp/podman-remote3.tar.gz" && \
     tar -zxvf /tmp/podman-remote3.tar.gz && \
     mv podman-remote-static /tools/podman-remote3 && \
@@ -37,6 +36,8 @@ RUN curl --retry 5 -L https://github.com/containers/podman/releases/download/v3.
     tar -zxvf /tmp/podman-remote4.tar.gz && \
     mv podman-remote-static /tools/podman-remote4 && \
     rm -f /tmp/podman-remote4.tar.gz
+
+COPY --from=quay.io/ocp-splat/govc:v0.29.0 /govc /usr/local/bin
 
 WORKDIR /home/assisted-test-infra
 


### PR DESCRIPTION
Install govc from the container registry instead of relying on github.
