### PR TITLE
MGMT-11415: add platform support to kubeapi test

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,4 @@
 storage_pool
 **/*.iso
+**/minikube*
 

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
@@ -1,3 +1,4 @@
+import os
 import time
 from builtins import list
 from typing import Any, Callable, Dict, List, Tuple
@@ -25,6 +26,10 @@ class VSphereController(NodeController):
         self._tf = terraform_utils.TerraformUtils(working_dir=folder, terraform_init=False)
 
     def prepare_nodes(self):
+        if not os.path.exists(self._entity_config.iso_download_path):
+            utils.recreate_folder(os.path.dirname(self._entity_config.iso_download_path), force_recreate=False)
+            # if file not exist lets create dummy
+            utils.touch(self._entity_config.iso_download_path)
         config = {**self._config.get_all(), **self._entity_config.get_all(), "cluster_name": self.cluster_name}
         # The ISO file isn't available now until preparing for installation
         del config["iso_download_path"]
@@ -105,6 +110,9 @@ class VSphereController(NodeController):
         self.__run_on_vm(node_name, reboot)
 
     def get_ingress_and_api_vips(self) -> dict:
+        if self._entity_config.api_vip and self._entity_config.ingress_vip:
+            return {"api_vip": self._entity_config.api_vip, "ingress_vip": self._entity_config.ingress_vip}
+        # Not used when DHCP is enabled
         return None
 
     def set_dns(self, api_ip: str, ingress_ip: str) -> None:

--- a/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/agent_cluster_install.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/agent_cluster_install.py
@@ -148,6 +148,9 @@ class AgentClusterInstall(BaseCustomResource):
         if "machine_cidr" in kwargs:
             spec["networking"]["machineNetwork"] = [{"cidr": kwargs.pop("machine_cidr")}]
 
+        if "platform_type" in kwargs:
+            spec["platformType"] = kwargs.pop("platform_type")
+
         if "hyperthreading" in kwargs:
             self._set_hyperthreading(spec=spec, mode=kwargs.pop("hyperthreading"))
 

--- a/src/assisted_test_infra/test_infra/tools/terraform_utils.py
+++ b/src/assisted_test_infra/test_infra/tools/terraform_utils.py
@@ -27,7 +27,7 @@ class TerraformUtils:
 
     def select_defined_variables(self, **kwargs):
         supported_variables = self.get_variable_list()
-        return {k: v for k, v in kwargs.items() if v and k in supported_variables}
+        return {k: v for k, v in kwargs.items() if v is not None and k in supported_variables}
 
     def get_variable_list(self):
         results = list()

--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -294,6 +294,16 @@ class Platforms:
     VSPHERE = "vsphere"
 
 
+class PlatformType:
+    """
+    Platform types as defined in kube-api (AgentClusterInstall)
+    """
+
+    BARE_METAL = "BareMetal"
+    NONE = "None"
+    VSPHERE = "VSphere"
+
+
 class HighAvailabilityMode:
     FULL = "Full"
     NONE = "None"

--- a/src/tests/base_kubeapi_test.py
+++ b/src/tests/base_kubeapi_test.py
@@ -150,6 +150,7 @@ class BaseKubeAPI(BaseTest):
         nodes.controller.log_configuration()
         log.info(f"Entity configuration {entity_config}")
 
+        nodes.notify_iso_ready()
         nodes.start_all(check_ips=not (is_static_ip and entity_config.is_ipv6))
 
         log.info("waiting for host agent")
@@ -169,8 +170,6 @@ class BaseKubeAPI(BaseTest):
         The setting of the hostname is required for IPv6 only, because the nodes are booted with
         hostname equal to localhost which is neither unique not legal name for AI host
         """
-        if is_ipv4:
-            return
 
         def find_matching_node_and_return_name():
             inventory = agent.status().get("inventory", {})
@@ -188,13 +187,6 @@ class BaseKubeAPI(BaseTest):
         )
         log.info(f"patching agent {agent.ref} with hostname {hostname}")
         agent.patch(hostname=hostname)
-
-    @classmethod
-    def set_agent_hostname(cls, node: Node, agent: Agent, is_ipv4: bool) -> None:
-        if is_ipv4:
-            return
-        log.info("patching agent hostname=%s", node)
-        agent.patch(hostname=node.name)
 
     @classmethod
     def set_single_node_ip(cls, cluster_deployment: ClusterDeployment, nodes: Nodes):

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -21,7 +21,7 @@ from assisted_test_infra.test_infra.helper_classes.kube_helpers import (
     Proxy,
     Secret,
 )
-from assisted_test_infra.test_infra.utils.kubeapi_utils import get_ip_for_single_node
+from assisted_test_infra.test_infra.utils.kubeapi_utils import get_ip_for_single_node, get_platform_type
 from service_client import log
 from tests.base_kubeapi_test import BaseKubeAPI
 from tests.config import ClusterConfig, InfraEnvConfig, global_variables
@@ -129,6 +129,7 @@ class TestKubeAPI(BaseKubeAPI):
             control_plane_agents=nodes.masters_count,
             worker_agents=nodes.workers_count,
             proxy=proxy.as_dict() if proxy else {},
+            platform_type=get_platform_type(cluster_config.platform),
         )
 
         agent_cluster_install.wait_to_be_ready(ready=False)


### PR DESCRIPTION
In order to support vSphere platform on KubeAPI test introduced the following changes:
* Added 'platform_type' to ACI creation on kube_api_test
* VSphereController: get_ingress_and_api_vips func should return api_vip/ingress_vip params as dhcp is not supported using kube-api.
* Ensured _set_host_name_from_node logic is performed for both ipv4 and ipv6 (as setting the hostname is always required on vSphere).
* Removed unused set_agents_hostnames and set_agent_hostname funcs.

Note: pending on https://github.com/openshift/assisted-service/pull/4219