### PR TITLE
MGMT-11337: Define wildcard DNS for ingress DNSes

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -607,7 +607,7 @@ class LibvirtController(NodeController, ABC):
     def format_node_disk(self, node_name: str, disk_index: int = 0) -> None:
         raise NotImplementedError
 
-    def get_ingress_and_api_vips(self) -> dict:
+    def get_ingress_and_api_vips(self, is_highly_available: bool = False) -> dict:
         raise NotImplementedError
 
     def get_cluster_network(self) -> str:

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -102,7 +102,7 @@ class NodeController(ABC):
         pass
 
     @abstractmethod
-    def get_ingress_and_api_vips(self) -> dict:
+    def get_ingress_and_api_vips(self, is_highly_available: bool = False) -> dict:
         pass
 
     @abstractmethod

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
@@ -109,10 +109,10 @@ class VSphereController(NodeController):
 
         self.__run_on_vm(node_name, reboot)
 
-    def get_ingress_and_api_vips(self) -> dict:
+    def get_ingress_and_api_vips(self, is_highly_available: bool = False) -> dict:
         if self._entity_config.api_vip and self._entity_config.ingress_vip:
             return {"api_vip": self._entity_config.api_vip, "ingress_vip": self._entity_config.ingress_vip}
-        # Not used when DHCP is enabled
+
         return None
 
     def set_dns(self, api_ip: str, ingress_ip: str) -> None:

--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -69,6 +69,10 @@ class Cluster(Entity):
     def enable_image_download(self):
         return self._config.download_image
 
+    @property
+    def high_availability_mode(self):
+        return self._config.high_availability_mode
+
     def _update_existing_cluster_config(self, api_client: InventoryClient, cluster_id: str):
         existing_cluster: models.cluster.Cluster = api_client.cluster_get(cluster_id)
 
@@ -333,7 +337,7 @@ class Cluster(Entity):
 
         else:
             log.info("Assigning VIPs statically")
-            access_vips = controller.get_ingress_and_api_vips()
+            access_vips = controller.get_ingress_and_api_vips(is_highly_available=True)
             api_vip = access_vips["api_vip"] if access_vips else None
             ingress_vip = access_vips["ingress_vip"] if access_vips else None
             machine_networks = None

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -879,14 +879,14 @@ class BaseTest:
         assert "No log files" in str(ex.value)
 
     @staticmethod
-    def update_oc_config(nodes, cluster):
+    def update_oc_config(nodes: Nodes, cluster: Cluster):
         os.environ["KUBECONFIG"] = cluster.kubeconfig_path
-        if nodes.masters_count == 1:
-            main_cidr = cluster.get_primary_machine_cidr()
-            api_vip = cluster.get_ip_for_single_node(cluster.api_client, cluster.id, main_cidr)
-        else:
-            vips = nodes.controller.get_ingress_and_api_vips()
-            api_vip = vips["api_vip"]
+
+        vips = nodes.controller.get_ingress_and_api_vips(
+            is_highly_available=cluster.high_availability_mode == consts.HighAvailabilityMode.FULL,
+        )
+        api_vip = vips["api_vip"]
+
         utils.config_etc_hosts(
             cluster_name=cluster.name, base_dns_domain=global_variables.base_dns_domain, api_vip=api_vip
         )

--- a/terraform_files/baremetal_host/main.tf
+++ b/terraform_files/baremetal_host/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.12"
+      version = "0.6.14"
     }
   }
 

--- a/terraform_files/baremetal_infra_env/main.tf
+++ b/terraform_files/baremetal_infra_env/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.12"
+      version = "0.6.14"
     }
   }
 }

--- a/terraform_files/none/main.tf
+++ b/terraform_files/none/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source = "dmacvicar/libvirt"
-      version = "0.6.12"
+      version = "0.6.14"
     }
   }
 }


### PR DESCRIPTION
The job e2e-metal-assisted-day2-single-node currently fails with the following error:

```
2022-07-22 05:43:31,208 - root - INFO - 139970722252608 - Asked hosts to
be in one of the statuses from ['known'] and currently hosts statuses
are [(1, 'eecb5396-0b83-422b-ae31-7418fee62663',
'test-infra-cluster-c717123a-worker-0', 'worker', 'insufficient', "Host
cannot be installed due to following failing validation(s): Couldn't
resolve domain name *.apps.test-infra-cluster-c717123a.redhat.com on the
host. To continue installation, create the necessary DNS entries to
resolve this domain name to your cluster's application ingress IP
address")]
```

assisted-test-infra does not currently create the wildcard DNS for the cluster because the terraform provider did not support that up until now.

Since the provider now supports the option, we should now be able to create the wildcard DNS using custom dnsmasq options.

In this change, I did not try to overcome the following problems I find in the current design:
* Having an actual wildcard DNS matching in the infra. It requires handling something that I yet to overcome which is related to making the libvirt dnsmasq server an authorized DNS server. Maybe a further refactoring PR will be able to actually remove the redundant DNS entries *.apps...
* We have some other duplications I want to remove (e.g. https://github.com/openshift/assisted-test-infra/blob/708d79aa066fface6f52dc274d1c6e2d7dcfe193/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py#L165). We'll have to handle it some other time because I wouldn't want this PR to get any bigger.
* Remove the need for ``single_node_ip`` variable. We can do just fine with ``api/ingress_vip``.