### PR TITLE
Set hypershift operator image only when the HYPERSHIFT_OPERATOR_IMAGE env was provided

### DIFF
--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -209,7 +209,7 @@ class TestKubeAPI(BaseKubeAPI):
                     pull_secret_file=ps,
                     agent_namespace=spoke_namespace,
                     provider_image=os.environ.get("PROVIDER_IMAGE", ""),
-                    hypershift_cpo_image=os.environ.get("HYPERSHIFT_IMAGE", ""),
+                    hypershift_cpo_image=os.environ.get("HYPERSHIFT_OPERATOR_IMAGE", ""),
                     release_image=os.environ.get("OPENSHIFT_INSTALL_RELEASE_IMAGE", ""),
                     ssh_key=ssh_public_key_file,
                 )


### PR DESCRIPTION
In case we override the hypershift-operator-image to the latest hypershift image (might happen because the setup_capi.sh script export a similar env) we might end up with a mismatch between the release we are installing and the hypershift control plane operator image 