### PR TITLE
NO-ISSUE: remove minikube from dockerignore

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,4 +1,3 @@
 storage_pool
 **/*.iso
-**/minikube*
 


### PR DESCRIPTION
Following to minikube_home folder fix in https://github.com/openshift/release/pull/31365, vsphere-kube-api job should work without adding minikube to .dockerignore file.