### PR TITLE
Add thanos endpoint for BIP 4.12 tests

### DIFF
--- a/src/tests/test_bootstrap_in_place.py
+++ b/src/tests/test_bootstrap_in_place.py
@@ -259,6 +259,7 @@ class TestBootstrapInPlace(BaseTest):
                 cluster_name=cluster_configuration.cluster_name.get(),
                 base_dns_domain=cluster_configuration.base_dns_domain,
                 api_vip=master_ip,
+                ingress_vip=master_ip,
             )
 
             log.info("Waiting for installation to complete...")

--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -35,6 +35,7 @@ resource "libvirt_network" "net" {
         data.libvirt_network_dns_host_template.oauth.*.rendered,
         data.libvirt_network_dns_host_template.console.*.rendered,
         data.libvirt_network_dns_host_template.canary.*.rendered,
+        data.libvirt_network_dns_host_template.thanos.*.rendered,
         data.libvirt_network_dns_host_template.assisted_service.*.rendered,
       )
       content {
@@ -180,6 +181,12 @@ data "libvirt_network_dns_host_template" "canary" {
   count    = var.bootstrap_in_place ? 1 : 0
   ip       = var.single_node_ip
   hostname = "canary-openshift-ingress-canary.apps.${var.cluster_name}.${var.cluster_domain}"
+}
+
+data "libvirt_network_dns_host_template" "thanos" {
+  count    = var.bootstrap_in_place ? 1 : 0
+  ip       = var.single_node_ip
+  hostname = "thanos-querier-openshift-monitoring.apps.${var.cluster_name}.${var.cluster_domain}"
 }
 
 data "libvirt_network_dns_host_template" "assisted_service" {


### PR DESCRIPTION
Trying to fix conformance tests failing on:
```
Shutting down SimultaneousPodIPControllerSimultaneousPodIPController shut downSuite run returned error: AlertErr: Thanos queriers not connected to all Prometheus sidecars: Post "https://thanos-querier-openshift-monitoring.apps.test-infra-cluster.redhat.com/api/v1/query": dial tcp: lookup thanos-querier-openshift-monitoring.apps.test-infra-cluster.redhat.com on 147.75.207.207:53: no such host
error: AlertErr: Thanos queriers not connected to all Prometheus sidecars: Post "https://thanos-querier-openshift-monitoring.apps.test-infra-cluster.redhat.com/api/v1/query": dial tcp: lookup thanos-querier-openshift-monitoring.apps.test-infra-cluster.redhat.com on 147.75.207.207:53: no such host
```

It only seems required for 4.12 jobs: https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/31590/rehearse-31590-periodic-ci-openshift-release-master-nightly-4.12-e2e-metal-ovn-single-node-live-iso/1561975528968163328