### PR TITLE
NO-ISSUE - Align `CONTAINER_RUNTIME_COMMAND` with `CONTAINER_COMMAND`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,6 +34,8 @@ JOB_TYPE := $(or ${JOB_TYPE}, "")
 REPO_NAME := $(or ${REPO_NAME}, "")
 PULL_NUMBER := $(or ${PULL_NUMBER}, "")
 
+CONTAINER_RUNTIME_COMMAND := $(or ${CONTAINER_COMMAND}, ${CONTAINER_RUNTIME_COMMAND})
+
 # lint
 LINT_CODE_STYLING_DIRS := src/tests src/triggers src/assisted_test_infra/test_infra src/assisted_test_infra/download_logs src/service_client src/consts src/virsh_cleanup src/cli
 


### PR DESCRIPTION
Prevent skipper to use different container command than the command set on `CONTAINER_COMMAND`.
`get_container_runtime_command` prioritize `podman` and skipper prioritize `docker` as container runtime command.


/cc @osherdp 