### PR TITLE
NO-ISSUE - Install openvpn as dependency for nutanix CI

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -67,6 +67,7 @@ function install_libvirt() {
         libseccomp-devel \
         net-tools \
         iproute \
+        openvpn \
         git \
         make
 


### PR DESCRIPTION
For Nutanix CI workflow we need the ability to connect to `nutanix-lts-dev` environment.
For that matter we need to connect to the environment VPN using openvpn.

/cc @osherdp 