### PR TITLE
MGMT-11852 - Update platform to none on sno installation

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -99,7 +99,6 @@ OCM_BASE_URL := $(or $(OCM_BASE_URL), https://api.integration.openshift.com/)
 DEPLOY_TARGET := $(or $(DEPLOY_TARGET),minikube)
 OCP_KUBECONFIG := $(or $(OCP_KUBECONFIG),build/kubeconfig)
 
-PLATFORM := $(or ${PLATFORM},baremetal)
 IPV6_SUPPORT := $(or ${IPV6_SUPPORT},true)
 SERVICE_REPLICAS_COUNT := 3
 LSO_DISKS := $(shell echo sd{b..d})

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -28,6 +28,7 @@ _default_triggers = frozendict(
             workers_count=0,
             high_availability_mode=consts.HighAvailabilityMode.NONE,
             user_managed_networking=True,
+            platform=consts.Platforms.NONE,
             vip_dhcp_allocation=False,
             master_memory=resources.DEFAULT_MASTER_SNO_MEMORY,
             master_vcpu=resources.DEFAULT_MASTER_SNO_CPU,


### PR DESCRIPTION
After https://github.com/openshift/assisted-service/pull/4158 SNO cluster must be none platform when enabling user-managed-networking 

/cc @osherdp 