### PR TITLE
NO-ISSUE: Add missing sudo in install_environment.sh

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -83,7 +83,7 @@ function install_libvirt() {
     pushd ${swtpm_dir}
     ./autogen.sh --with-openssl --prefix=/usr
     make -j4
-    make install
+    sudo make install
     popd
 
     sudo systemctl enable libvirtd
@@ -168,7 +168,7 @@ function allow_libvirt_cross_network_traffic() {
 #!/usr/bin/env sh
 iptables-save -c | egrep -v 'LIBVIRT_FW[IO] .* REJECT' | iptables-restore || true
 EOF
-    chmod +x "${hook_filename}"
+    sudo chmod +x "${hook_filename}"
 }
 
 function install_podman(){


### PR DESCRIPTION
Currently the `make install` command that installs the _swtpm_ package
and the `chmod` command that sets execution permission for the _libvirt_
cross network traffic hook are missing the `sudo` prefix, so they don't
work when using a non-root user. This patch fixes that.