### PR TITLE
NO-ISSUE: fix must-gather log collection in case of hypershift cluster

### DIFF
--- a/src/assisted_test_infra/download_logs/download_logs.py
+++ b/src/assisted_test_infra/download_logs/download_logs.py
@@ -249,7 +249,7 @@ def download_logs_kube_api(
                 # in case of hypershift
                 if namespace.startswith("clusters"):
                     log.info("Dumping hypershift files")
-                    hypershift = HyperShift(name=cluster_name)
+                    hypershift = HyperShift(name=cluster_name, kube_api_client=None)
                     hypershift.dump(os.path.join(output_folder, "dump"), management_kubeconfig)
                 else:
                     _must_gather_kube_api(cluster_name, cluster_deployment, agent_cluster_install, output_folder)


### PR DESCRIPTION
The download_logs.py didn't collect must-gahter logs in case of
hypershift cluster because it was failing to initalize the Hypershift
helper class