### PR TITLE
NO-ISSUE - Prevent tests from being skipped when test parameterized is empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -331,7 +331,7 @@ test:
 	skipper make $(SKIPPER_PARAMS) _test
 
 _test: $(REPORTS) _test_setup
-	JUNIT_REPORT_DIR=$(REPORTS) python3 ${DEBUG_FLAGS} -m pytest $(or ${TEST},src/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(PYTEST_JUNIT_FILE)
+	JUNIT_REPORT_DIR=$(REPORTS) python3 ${DEBUG_FLAGS} -m pytest --error-for-skips $(or ${TEST},src/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(PYTEST_JUNIT_FILE)
 
 test_parallel:
 	$(MAKE) start_load_balancer START_LOAD_BALANCER=true
@@ -347,7 +347,7 @@ _test_setup:
 	mkdir -p /tmp/assisted_test_infra_logs
 
 _test_parallel: $(REPORTS) _test_setup
-	JUNIT_REPORT_DIR=$(REPORTS) python3 -m pytest -n $(or ${TEST_WORKERS_NUM}, '3') $(or ${TEST},src/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(PYTEST_JUNIT_FILE)
+	JUNIT_REPORT_DIR=$(REPORTS) python3 -m pytest --error-for-skips -n $(or ${TEST_WORKERS_NUM}, '3') $(or ${TEST},src/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(PYTEST_JUNIT_FILE)
 
 ########
 # Capi #

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ pyvmomi>=7.0.2
 waiting>=1.4.1
 prompt_toolkit==3.0.30
 nutanix-api==0.0.17
+pytest-error-for-skips==2.0.2


### PR DESCRIPTION
pytest tests are skipped when parameterized is empty - e.g. `openshift_version` on `test_install`.
This PR force the test to fail when pytest test is skipped

/cc @osherdp 