### PR TITLE
[release-ocm-2.6] NO-ISSUE - Prevent tests from being skipped when test parameterized is empty

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -329,7 +329,7 @@ test:
 	skipper make $(SKIPPER_PARAMS) _test
 
 _test: $(REPORTS) _test_setup
-	JUNIT_REPORT_DIR=$(REPORTS) python3 ${DEBUG_FLAGS} -m pytest $(or ${TEST},src/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(PYTEST_JUNIT_FILE)
+	JUNIT_REPORT_DIR=$(REPORTS) python3 ${DEBUG_FLAGS} -m pytest --error-for-skips $(or ${TEST},src/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(PYTEST_JUNIT_FILE)
 
 test_parallel:
 	$(MAKE) start_load_balancer START_LOAD_BALANCER=true
@@ -345,7 +345,7 @@ _test_setup:
 	mkdir -p /tmp/assisted_test_infra_logs
 
 _test_parallel: $(REPORTS) _test_setup
-	JUNIT_REPORT_DIR=$(REPORTS) python3 -m pytest -n $(or ${TEST_WORKERS_NUM}, '3') $(or ${TEST},src/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(PYTEST_JUNIT_FILE)
+	JUNIT_REPORT_DIR=$(REPORTS) python3 -m pytest --error-for-skips -n $(or ${TEST_WORKERS_NUM}, '3') $(or ${TEST},src/tests) -k $(or ${TEST_FUNC},'') -m $(or ${TEST_MARKER},'') --verbose -s --junit-xml=$(PYTEST_JUNIT_FILE)
 
 ########
 # Capi #

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,3 +33,4 @@ urllib3==1.26.11
 pyvmomi>=7.0.2
 waiting>=1.4.1
 prompt_toolkit==3.0.30
+pytest-error-for-skips==2.0.2


### PR DESCRIPTION
Backport of https://github.com/openshift/assisted-test-infra/pull/1824

/cc @osherdp 