### PR TITLE
NO-ISSUE - Upgrade to python3.10

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -18,13 +18,15 @@ RUN dnf -y install --enablerepo=crb \
   httpd-tools \
   jq \
   nss_wrapper \
-  python3 \
-  python3-devel \
   libvirt-client \
   libvirt-devel \
   libguestfs-tools \
   libxslt \
    && dnf clean all
+
+# Install latest available python version - For more information see https://github.com/eliorerz/tools/tree/master/python_builder
+COPY --from=quay.io/eerez/python-builder:stream9-3.10.7 /python /python-installation
+RUN cd /python-installation && make install && dnf -y install python3-devel && dnf clean all
 
 RUN curl --retry 5 -Lo packer.zip https://releases.hashicorp.com/packer/1.8.0/packer_1.8.0_linux_386.zip && unzip packer.zip -d /usr/bin/ && mv /usr/bin/packer /usr/bin/packer.io && rm -rf packer.zip
 RUN curl --retry 5 -Lo terraform.zip https://releases.hashicorp.com/terraform/1.2.7/terraform_1.2.7_linux_amd64.zip && unzip terraform.zip -d /usr/bin/ && rm -rf terraform.zip

--- a/scripts/override_os_images.py
+++ b/scripts/override_os_images.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 import os

--- a/scripts/override_release_images.py
+++ b/scripts/override_release_images.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 import json
 import os

--- a/scripts/set_boot_order.by
+++ b/scripts/set_boot_order.by
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 """
 This small script changes the boot order of a virsh guest domain.

--- a/src/assisted_test_infra/test_infra/controllers/ipxe_controller/server/local_ipxe_server.py
+++ b/src/assisted_test_infra/test_infra/controllers/ipxe_controller/server/local_ipxe_server.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 
 import os
 from http.server import CGIHTTPRequestHandler, HTTPServer

--- a/src/update_assisted_service_cm.py
+++ b/src/update_assisted_service_cm.py
@@ -1,4 +1,4 @@
-#!/usr/bin/python3
+#!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
 Idea is to pass os environments to assisted-service config map, to make an easy way to configure assisted-service


### PR DESCRIPTION
Used in a self built image located at https://quay.io/repository/eerez/python-builder
We will do the asme for 3.11 that supposed to be released on October (3.11.0rc1 is already available for installation on `python-builder` repository)

/cc @osherdp 