### PR TITLE
MGMT-11706: Run e2e tests with the upgrade agent feature enabled

### DIFF
--- a/src/update_assisted_service_cm.py
+++ b/src/update_assisted_service_cm.py
@@ -39,6 +39,7 @@ ENVS = [
     ("HW_VALIDATOR_REQUIREMENTS", ""),
     ("HW_VALIDATOR_MIN_CPU_CORES_SNO", ""),
     ("HW_VALIDATOR_MIN_RAM_GIB_SNO", ""),
+    ("ENABLE_UPGRADE_AGENT", "true"),
 ]
 DEFAULT_MASTER_REQUIREMENTS = {
     "cpu_cores": 4,


### PR DESCRIPTION
This patch changes the e2e tests so that the upgrade agent feature is explicitly enabled.

Related: https://issues.redhat.com/browse/MGMT-11706