### PR TITLE
NO-ISSUE: Update skipper to 1.34.0

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -218,7 +218,7 @@ function install_packages() {
 
 function install_skipper() {
     echo "Installing skipper and adding ~/.local/bin to PATH"
-    pip3 install strato-skipper==1.32.0 --user
+    pip3 install strato-skipper==1.34.0 --user
 
     #grep -qxF "export PATH=~/.local/bin:$PATH" ~/.bashrc || echo "export PATH=~/.local/bin:$PATH" >> ~/.bashrc
     #export PATH="$PATH:~/.local/bin"


### PR DESCRIPTION
The more relevant change in the new version of _skipper_ is a fix to prevent leaking of mount points.

Related: https://github.com/Stratoscale/skipper/pull/155
Related: https://github.com/containers/podman/issues/15671