### PR TITLE
MGMT-11981: FIx teardown on vsphere nodes

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
@@ -72,7 +72,7 @@ class VSphereController(NodeController):
         return ips, macs
 
     def destroy_all_nodes(self) -> None:
-        self._tf.destroy()
+        self._tf.destroy(force=False)
 
     def start_node(self, node_name: str, check_ips: bool) -> None:
         def start(vm) -> task:


### PR DESCRIPTION
Same as Nutanix controller, there is some issue with the `force` flag on `python_terraform`. 
This PR disable the force flag allowing terraform to destroy the allocated resources properly.
 
```
2022-09-09 20:13:54,154  python_terraform WARNING  - 140588503791424 - 
error: 'Error: Failed to parse command-line flags\n\nflag provided but not defined: -force
For more help on using this command, run: terraform destroy -help' 	(/usr/local/lib/python3.10/site-packages/python_terraform/__init__.py:306)
```

/cc @osherdp 