### PR TITLE
fix virt-format command missing

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -19,6 +19,7 @@ RUN dnf -y install --enablerepo=crb \
   jq \
   nss_wrapper \
   libvirt-client \
+  guestfs-tools \
   libvirt-devel \
   libguestfs-tools \
   libxslt \


### PR DESCRIPTION
Latest test-infra image does not contain the ``virt-format`` command, as shown in QE tests:
```
    def run_command(command, shell=False, raise_errors=True, env=None, cwd=None, run_in_background=False):
        command = command if shell else shlex.split(command)
        if run_in_background:
            subprocess.Popen(command, shell=shell, env=env, cwd=cwd, stderr=subprocess.STDOUT)
            return
    
        process = subprocess.run(
            command, shell=shell, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env, universal_newlines=True, cwd=cwd
        )
    
        def _io_buffer_to_str(buf):
            if hasattr(buf, "read"):
                buf = buf.read().decode()
            return buf
    
        out = _io_buffer_to_str(process.stdout).strip()
        err = _io_buffer_to_str(process.stderr).strip()
    
        if raise_errors and process.returncode != 0:
>           raise RuntimeError(f"command: {command} exited with an error: {err} " f"code: {process.returncode}")
E           RuntimeError: command: virt-format -a /tmp/tmp2gmjr586 --partition=mbr exited with an error: /bin/sh: line 1: virt-format: command not found code: 127
```

A possible explanation for it is that there has been some change in either base stream9 image or in the repositories neglecting the previously installed binary.

This fixes it by adding the ``libguestfs-tools`` package explicitly.