### PR TITLE
NO-ISSUE: download kubeconfig in BaseKubeAPI test

### DIFF
--- a/src/tests/base_kubeapi_test.py
+++ b/src/tests/base_kubeapi_test.py
@@ -120,11 +120,12 @@ class BaseKubeAPI(BaseTest):
         return api_vip, ingress_vip
 
     @classmethod
-    def _wait_for_install(cls, agent_cluster_install: AgentClusterInstall, agents: List[Agent]):
+    def _wait_for_install(cls, agent_cluster_install: AgentClusterInstall, agents: List[Agent], kubeconfig_path: str):
         agent_cluster_install.wait_to_be_ready(ready=True)
         agent_cluster_install.wait_to_be_installing()
         Agent.wait_for_agents_to_install(agents)
         agent_cluster_install.wait_to_be_installed()
+        agent_cluster_install.download_kubeconfig(kubeconfig_path)
 
     @classmethod
     def _set_agent_cluster_install_machine_cidr(cls, agent_cluster_install: AgentClusterInstall, nodes: Nodes):

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -157,7 +157,7 @@ class TestKubeAPI(BaseKubeAPI):
         nodes.controller.set_dns(api_ip=api_vip, ingress_ip=ingress_vip)
 
         log.info("Waiting for install")
-        self._wait_for_install(agent_cluster_install, agents)
+        self._wait_for_install(agent_cluster_install, agents, cluster_config.kubeconfig_path)
 
     @JunitTestCase()
     def capi_test(
@@ -413,7 +413,7 @@ class TestLateBinding(BaseKubeAPI):
         agent_cluster_install.wait_to_be_ready(ready=True)
         Agent.wait_for_agents_to_be_bound(agents)
         if not hold_installation:
-            cls._wait_for_install(agent_cluster_install, agents)
+            cls._wait_for_install(agent_cluster_install, agents, utils.get_kubeconfig_path(cluster_deployment.ref.name))
 
     @JunitTestSuite()
     @pytest.mark.kube_api


### PR DESCRIPTION
On BaseKubeAPI test, download kubeconfig using secret ref in ACI.