### PR TITLE
MGMT-12096: Fix errors accessing load-balancer http conf file

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -171,7 +171,7 @@ destroy_onprem:
 # Start load balancer if it does not already exist.
 # Map the directory $(HOME)/.test-infra/etc/nginx/conf.d to be /etc/nginx/conf.d
 # so it will be used by the python code to fill up load balancing definitions
-start_load_balancer:
+start_load_balancer: stop_load_balancer
 	@if [ "$(PLATFORM)" = "none"  ] || [ "$(START_LOAD_BALANCER)" = "true" ]; then \
 		id=$(shell $(CONTAINER_COMMAND) ps --quiet --filter "name=load_balancer"); \
 		( test -z "$$id" && echo "Starting load balancer ..." && \
@@ -183,7 +183,7 @@ start_load_balancer:
 stop_load_balancer:
 	@id=$(shell $(CONTAINER_COMMAND) ps --all --quiet --filter "name=load_balancer"); \
 	test ! -z "$$id"  && $(CONTAINER_COMMAND) rm -f load_balancer; \
-	rm -f  $(HOME)/.test-infra/etc/nginx/conf.d/stream.d/*.conf >& /dev/null || /bin/true
+	rm -f  $(HOME)/.test-infra/etc/nginx/conf.d/*.conf >& /dev/null || /bin/true
 
 
 #############


### PR DESCRIPTION
On some cases the load balancer failed to start due to the following error

```
nginx: [emerg] bind() to 192.168.127.1:6443 failed (99: Cannot assign requested address)
```

This PR remove the conf file before each time we start it, also fixed the conf file path on the `stop_load_balancer` Makefile target 

See right path on https://github.com/openshift/assisted-test-infra/blob/master/terraform_files/none/main.tf#L170

/cc @osherdp @tsorya 

FYI @lalon4 