### PR TITLE
NO-ISSUE: Change log folder time format to use dashes rather than colons

### DIFF
--- a/src/assisted_test_infra/download_logs/download_logs.py
+++ b/src/assisted_test_infra/download_logs/download_logs.py
@@ -40,7 +40,7 @@ from tests.config import ClusterConfig, TerraformConfig
 
 private_ssh_key_path_default = os.path.join(os.getcwd(), str(env_defaults.DEFAULT_SSH_PRIVATE_KEY_PATH))
 
-TIME_FORMAT = "%Y-%m-%d_%H:%M:%S"
+TIME_FORMAT = "%Y-%m-%d_%H-%M-%S"
 MAX_RETRIES = 3
 MUST_GATHER_MAX_RETRIES = 15
 RETRY_INTERVAL = 60 * 5


### PR DESCRIPTION
https://github.com/openshift/oc/pull/1178 introduced a breaking change
where the destination dir for the must-gather command must not contain a
colon.

This leads to our CI gather step to show this error:

```
2022-09-21 09:56:29,314  download_logs WARNING    - 140125667993408 - Failed to run must gather: command: oc --insecure-skip-tls-verify --kubeconfig=/tmp/artifacts/2022-09-21_09:15:17_e270331f-a66d-493d-9e01-fa72c71bb46c/kubeconfig-noingress adm must-gather --dest-dir /tmp/artifacts/2022-09-21_09:15:17_e270331f-a66d-493d-9e01-fa72c71bb46c/must-gather-dir > /tmp/artifacts/2022-09-21_09:15:17_e270331f-a66d-493d-9e01-fa72c71bb46c/must-gather-dir/must-gather.log exited with an error: error: --dest-dir may not contain special characters such as colon(:) code: 1 \t(/home/assisted/src/assisted_test_infra/download_logs/download_logs.py:347)",
```

As you can see in this job:

https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-in[…]staller-master-edge-e2e-metal-assisted/1572505786586763264

This commit changes the colons to dashes to avoid this must-gather error