### PR TITLE
NO-ISSUE: Fix late-binding job

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -183,7 +183,9 @@ start_load_balancer: stop_load_balancer
 stop_load_balancer:
 	@id=$(shell $(CONTAINER_COMMAND) ps --all --quiet --filter "name=load_balancer"); \
 	test ! -z "$$id"  && $(CONTAINER_COMMAND) rm -f load_balancer; \
-	rm -f  $(HOME)/.test-infra/etc/nginx/conf.d/*.conf >& /dev/null || /bin/true
+	if [ "$(TEST_TEARDOWN)" != "false" ]; then \
+		rm -f  $(HOME)/.test-infra/etc/nginx/conf.d/*.conf >& /dev/null || /bin/true; \
+	fi
 
 
 #############

--- a/src/tests/base_kubeapi_test.py
+++ b/src/tests/base_kubeapi_test.py
@@ -1,5 +1,5 @@
 import os
-from typing import List
+from typing import List, Optional
 
 import pytest
 import waiting
@@ -125,12 +125,15 @@ class BaseKubeAPI(BaseTest):
         return api_vip, ingress_vip
 
     @classmethod
-    def _wait_for_install(cls, agent_cluster_install: AgentClusterInstall, agents: List[Agent], kubeconfig_path: str):
+    def _wait_for_install(
+        cls, agent_cluster_install: AgentClusterInstall, agents: List[Agent], kubeconfig_path: Optional[str] = None
+    ):
         agent_cluster_install.wait_to_be_ready(ready=True)
         agent_cluster_install.wait_to_be_installing()
         Agent.wait_for_agents_to_install(agents)
         agent_cluster_install.wait_to_be_installed()
-        agent_cluster_install.download_kubeconfig(kubeconfig_path)
+        if kubeconfig_path:
+            agent_cluster_install.download_kubeconfig(kubeconfig_path)
 
     @classmethod
     def _set_agent_cluster_install_machine_cidr(cls, agent_cluster_install: AgentClusterInstall, nodes: Nodes):

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -426,7 +426,7 @@ class TestLateBinding(BaseKubeAPI):
         agent_cluster_install.wait_to_be_ready(ready=True)
         Agent.wait_for_agents_to_be_bound(agents)
         if not hold_installation:
-            cls._wait_for_install(agent_cluster_install, agents, utils.get_kubeconfig_path(cluster_deployment.ref.name))
+            cls._wait_for_install(agent_cluster_install, agents)
 
     @classmethod
     @JunitTestCase()


### PR DESCRIPTION
Two issues:

1/
Since https://github.com/openshift/assisted-test-infra/pull/1852 the
loadbalancer configuration is cleaned up before starting it.

This change does not cleanup the configuration when `TEST_TEARDOWN` is
set to `false`.

It should fix the late binding job, that configures the nginx server
before running the tests.

2/
Since https://github.com/openshift/assisted-test-infra/pull/1849/files#diff-21e688d6eb3b87727264f6934118765f035f5bf7504dff17b3ab9fb388f4d054L416

The kubeconfig used for the hub cluster is replaced by the kubeconfig that points
to the sno cluster which leads to fail the conformance test as the DNS for this cluster
 is not configured.

I made the parameter optional, as I guess the kubeconfig from the `AgentClusterInstall`
is not used in this case.