### PR TITLE
MGMT-11968: Use lock and tmp file when altering iptables rules

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -166,7 +166,12 @@ function allow_libvirt_cross_network_traffic() {
     sudo mkdir -p "${hook_dir}"
     sudo tee "${hook_filename}" << EOF
 #!/usr/bin/env sh
-iptables-save -c | egrep -v 'LIBVIRT_FW[IO] .* REJECT' | iptables-restore || true
+(
+    flock 3
+    iptables-save -c | egrep -v 'LIBVIRT_FW[IO] .* REJECT' >/tmp/iptables.txt
+    iptables-restore </tmp/iptables.txt
+    rm /tmp/iptables.txt
+) 3>/tmp/iptables.lock
 EOF
     sudo chmod +x "${hook_filename}"
 }


### PR DESCRIPTION
In order to prevent potential races when multiple threads or processes try to modify iptables rules by using libvirt hook, we are introducing use of a temporary file as well as the lock. This should ensure that there are no concurrent attempts to -save and -restore the firewall configuration.

Co-authored-by: jhernand@redhat.com
Closes: [MGMT-11968](https://issues.redhat.com//browse/MGMT-11968)