### PR TITLE
NO-ISSUE: add xorriso

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -23,6 +23,7 @@ RUN dnf -y install --enablerepo=crb \
   libvirt-devel \
   libguestfs-tools \
   libxslt \
+  xorriso \
    && dnf clean all
 
 # Install latest available python version - For more information see https://github.com/eliorerz/tools/tree/master/python_builder


### PR DESCRIPTION
xorriso (or any other ISO tool) is required in assisted-test-infra-internal image to build images for vSphere/Nutanix via Packer