### PR TITLE
nutanix machine: enable nested virt

### DIFF
--- a/terraform_files/nutanix-ci-machine/main.tf
+++ b/terraform_files/nutanix-ci-machine/main.tf
@@ -39,6 +39,8 @@ resource "nutanix_virtual_machine" "vm" {
   boot_device_order_list      = ["DISK"]
   boot_type                   = "LEGACY"
 
+  enable_cpu_passthrough      = true
+
   disk_list {
     data_source_reference = {
       kind = "image"


### PR DESCRIPTION
Set CPU passthrough on Nutanix CI machine so that minikube could create a nested VM