### PR TITLE
nutanix packer: eject cdrom

### DIFF
--- a/packer_files/nutanix_centos_template/centos-config/ks.cfg
+++ b/packer_files/nutanix_centos_template/centos-config/ks.cfg
@@ -55,4 +55,4 @@ pwpolicy user --minlen=6 --minquality=1 --notstrict --nochanges --emptyok
 pwpolicy luks --minlen=6 --minquality=1 --notstrict --nochanges --notempty
 %end
 
-reboot
+reboot --eject


### PR DESCRIPTION
When install is finished, CDROM needs to be ejected, so that machine would boot from disk. Unlike vSphere Packer plugin it can't set boot order