### PR TITLE
nutanix: don't allocation VIPs if DHCP allocation is not set

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/nutanix_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/nutanix_controller.py
@@ -125,6 +125,13 @@ class NutanixController(NodeController):
         vm.power_on()
 
     def get_ingress_and_api_vips(self, is_highly_available: bool = True):
+        if not self._entity_config.vip_dhcp_allocation:
+            if not self._entity_config.api_vip:
+                raise ValueError("API VIP is not set")
+            if not self._entity_config.ingress_vip:
+                raise ValueError("Ingress VIP is not set")
+            return {"api_vip": self._entity_config.api_vip, "ingress_vip": self._entity_config.ingress_vip}
+
         nutanix_subnet = next(
             s for s in NutanixSubnet.list_entities(self._nutanix_client) if s.name == self._config.nutanix_subnet
         )

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_nutanix_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_nutanix_config.py
@@ -1,11 +1,12 @@
 from abc import ABC
 from dataclasses import dataclass
 
+from assisted_test_infra.test_infra.helper_classes.config.base_cluster_config import BaseClusterConfig
 from assisted_test_infra.test_infra.helper_classes.config.base_nodes_config import BaseNodesConfig
 
 
 @dataclass
-class BaseNutanixConfig(BaseNodesConfig, ABC):
+class BaseNutanixConfig(BaseNodesConfig, BaseClusterConfig, ABC):
     nutanix_username: str = None
     nutanix_password: str = None
     nutanix_endpoint: str = None


### PR DESCRIPTION
In CI we might want to allocate VIPs and create DNS records using existing IPI steps. Nutanix controller should not use DHCP to allocate VIPs if these are already set using environment variables.

Being tested in https://github.com/openshift/release/pull/31726