### PR TITLE
requirements.txt: bump nutanix-api to 0.0.18

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -33,5 +33,5 @@ urllib3==1.26.12
 pyvmomi>=7.0.2
 waiting>=1.4.1
 prompt_toolkit==3.0.31
-nutanix-api==0.0.17
+nutanix-api==0.0.18
 pytest-error-for-skips==2.0.2


### PR DESCRIPTION
This is required to fix boot order change when Nutanix VM is not yet started. Required for https://github.com/openshift/release/pull/31726