### PR TITLE
MGMT-11926: bump vsphere machine specs

### DIFF
--- a/terraform_files/vsphere-ci-machine/variables-vsphere.tf
+++ b/terraform_files/vsphere-ci-machine/variables-vsphere.tf
@@ -59,7 +59,7 @@ variable "vcpu" {
 
 variable "memory" {
   type = number
-  default = 16984
+  default = 24576
   description = "The size of the virtual machine's memory, in MB"
 }
 


### PR DESCRIPTION
Add more memory to the cluster machines so that periodic conformance tests would have a better chance of passing.

Todo:
* [ ] Find out why KubeCPUOvercommit is still firing