### PR TITLE
NO-ISSUE: yaml-friendly pull secret removal

### DIFF
--- a/src/assisted_test_infra/download_logs/download_logs.py
+++ b/src/assisted_test_infra/download_logs/download_logs.py
@@ -156,7 +156,7 @@ def download_logs(
             install_config = Path(output_folder) / "cluster_files" / "install-config.yaml"
             client.download_and_save_file(cluster["id"], "install-config.yaml", str(install_config))
             censored_content = re.sub(
-                r"(pullSecret:\s+)'(.*)'", r"\g<1>*** PULL_SECRET ***", install_config.read_text()
+                r"(pullSecret:\s+)'(.*)'", r"\g<1>xxxx_PULL_SECRET_REDACTED_xxxx", install_config.read_text()
             )
             install_config.write_text(censored_content)
 


### PR DESCRIPTION
`*` has a special meaning in YAML and replacing this pull secret in this manner results
in an invalid YAML. changed to use `x`'s instead of `*`'s.