### PR TITLE
MGMT-12381: Remove VIP DHCP allocation defaults from test-infra

### DIFF
--- a/src/consts/env_defaults.py
+++ b/src/consts/env_defaults.py
@@ -5,7 +5,6 @@ import consts
 DEFAULT_NUMBER_OF_MASTERS: int = consts.NUMBER_OF_MASTERS
 DEFAULT_DAY2_WORKERS_COUNT: int = 1
 DEFAULT_WORKERS_COUNT: int = 2
-DEFAULT_VIP_DHCP_ALLOCATION: bool = True
 DEFAULT_STORAGE_POOL_PATH: str = str(Path.cwd().joinpath("storage_pool"))
 DEFAULT_SSH_PRIVATE_KEY_PATH: Path = Path.home() / ".ssh" / "id_rsa"
 DEFAULT_SSH_PUBLIC_KEY_PATH: Path = Path.home() / ".ssh" / "id_rsa.pub"

--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -29,9 +29,7 @@ class _EnvVariables(DataPool, ABC):
     day2_workers_count: EnvVar = EnvVar(
         ["NUM_DAY2_WORKERS"], loader=int, default=env_defaults.DEFAULT_DAY2_WORKERS_COUNT
     )
-    vip_dhcp_allocation: EnvVar = EnvVar(
-        ["VIP_DHCP_ALLOCATION"], loader=lambda x: bool(strtobool(x)), default=env_defaults.DEFAULT_VIP_DHCP_ALLOCATION
-    )
+    vip_dhcp_allocation: EnvVar = EnvVar(["VIP_DHCP_ALLOCATION"], loader=lambda x: bool(strtobool(x)))
 
     worker_memory: EnvVar = EnvVar(["WORKER_MEMORY"], loader=int, default=resources.DEFAULT_WORKER_MEMORY)
     master_memory: EnvVar = EnvVar(["MASTER_MEMORY"], loader=int, default=resources.DEFAULT_MASTER_MEMORY)

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -15,7 +15,6 @@ _default_triggers = frozendict(
         "none_platform": Trigger(
             condition=lambda config: config.platform == consts.Platforms.NONE,
             user_managed_networking=True,
-            vip_dhcp_allocation=False,
             tf_platform=consts.Platforms.NONE,
         ),
         "vsphere_platform": Trigger(
@@ -26,21 +25,19 @@ _default_triggers = frozendict(
         "nutanix_platform": Trigger(
             condition=lambda config: config.platform == consts.Platforms.NUTANIX,
             tf_platform=consts.Platforms.NUTANIX,
-            vip_dhcp_allocation=False,
         ),
         "sno": Trigger(
             condition=lambda config: config.masters_count == 1,
             workers_count=0,
             high_availability_mode=consts.HighAvailabilityMode.NONE,
             user_managed_networking=True,
-            vip_dhcp_allocation=False,
             master_memory=resources.DEFAULT_MASTER_SNO_MEMORY,
             master_vcpu=resources.DEFAULT_MASTER_SNO_CPU,
             network_type=None,
         ),
         "let_service_choose_network_type": Trigger(
-            condition=lambda config: version.parse(config.openshift_version) >= version.parse("4.12"),
-            vip_dhcp_allocation=False,
+            condition=lambda config: version.parse(config.openshift_version)
+            >= version.parse(consts.OpenshiftVersion.VERSION_4_12.value),
             network_type=None,
         ),
         "ipv4": Trigger(
@@ -55,12 +52,10 @@ _default_triggers = frozendict(
         ),
         "ipv6_required_configurations": Trigger(
             condition=lambda config: config.is_ipv6 is True,
-            vip_dhcp_allocation=False,
             network_type=consts.NetworkType.OVNKubernetes,
         ),
         "OVNKubernetes": Trigger(
             condition=lambda config: config.network_type == consts.NetworkType.OVNKubernetes,
-            vip_dhcp_allocation=False,
         ),
         "dualstack": Trigger(
             condition=lambda config: config.is_ipv4 is True and config.is_ipv6 is True,


### PR DESCRIPTION
Back on https://issues.redhat.com/browse/MGMT-10840 we changed the default value of vip_dhcp_allocation but left assisted-test-infra untouched causing vip_dhcp_allocation to stay `True` on some tests.

We need to remove vip_dhcp_allocation default from test-infra and allowing the service to set the default by itself.

/cc @osherdp 