### PR TITLE
vsphere: upload iso to test folder

### DIFF
--- a/terraform_files/vsphere/main.tf
+++ b/terraform_files/vsphere/main.tf
@@ -75,7 +75,7 @@ resource "vsphere_file" "ISO_UPLOAD" {
   datacenter       = var.vsphere_datacenter
   datastore        = var.vsphere_datastore
   source_file      = var.iso_download_path
-  destination_file = "assisted-installer-isos/cluster-${var.cluster_name}/${basename(var.iso_download_path)}"
+  destination_file = "test/cluster-${var.cluster_name}/${basename(var.iso_download_path)}"
 }
 
 # Creating the master VMs.


### PR DESCRIPTION
Seems vSphere throws HTTP 500 when a file is uploaded. `test` folder is unaffected, so lets use that temporarily