### PR TITLE
MGMT-8707: Revert swtpm installation from source

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -41,50 +41,9 @@ function install_libvirt() {
         libvirt-devel \
         libvirt-daemon-kvm \
         qemu-kvm \
-        libgcrypt
-
-    # TODO: get swtpm RPMs from EPEL as soon as 0.7.1 or later lands there.
-    # based on: https://github.com/stefanberger/swtpm/wiki#compile-and-install-on-linux
-
-    echo "Install swtpm dependencies"
-    sudo dnf install -y \
-        libtasn1-devel \
-        expect \
-        socat \
-        python3-twisted \
-        fuse-devel \
-        glib2-devel \
-        gnutls-devel \
-        gnutls-utils \
-        gnutls \
-        json-glib-devel \
-        autoconf \
-        automake \
-        libtool \
-        openssl-devel \
-        libtpms \
-        libtpms-devel \
-        libseccomp-devel \
-        net-tools \
-        iproute \
-        openvpn \
-        git \
-        make
-
-    echo "Install swtpm v0.7.1 from source"
-    swtpm_dir=$(mktemp -d -t swtpm-dir-XXXXXX)
-    function cleanup {
-        echo "deleting ${swtpm_dir}..."
-        rm -rf "${swtpm_dir}"
-    }
-    trap cleanup EXIT
-
-    git clone --depth 1 --branch v0.7.1 https://github.com/stefanberger/swtpm.git ${swtpm_dir}
-    pushd ${swtpm_dir}
-    ./autogen.sh --with-openssl --prefix=/usr
-    make -j4
-    sudo make install
-    popd
+        libgcrypt \
+        swtpm \
+        swtpm-tools
 
     sudo systemctl enable libvirtd
 


### PR DESCRIPTION
Manual revert of
https://github.com/openshift/assisted-test-infra/pull/1748.

The fixed versions of swtpm packages has landed for RHEL 8.7+8.6 as well as latest Rocky Linux 8 version.

It means we should not have any kind of flaky behavior as we previously had in CI (might still happen locally, but either way disk-encryption is not heavily prioritized for testing and development).

/cc @nmagnezi @eliorerz 