### PR TITLE
Fix network interface getting removed intermediately

### DIFF
--- a/src/assisted_test_infra/test_infra/tools/assets.py
+++ b/src/assisted_test_infra/test_infra/tools/assets.py
@@ -75,8 +75,14 @@ class LibvirtNetworkAssets:
     def _fill_allocated_ips_and_bridges_by_interface(self):
         for interface in netifaces.interfaces():
             self._add_allocated_net_bridge(interface)
-            for ifaddresses in netifaces.ifaddresses(interface).values():
-                for item in ifaddresses:
+            try:
+                ifaddresses = netifaces.ifaddresses(interface)
+            except ValueError:
+                log.debug(f"Interface {interface} no longer exists. It might has been removed intermediately")
+                continue
+
+            for ifaddress in ifaddresses.values():
+                for item in ifaddress:
                     try:
                         self._add_allocated_ip(IPAddress(item["addr"]))
                     except AddrFormatError:


### PR DESCRIPTION
It is possible to try reading a network interface that has been removed
while ``_fill_allocated_ips_and_bridges_by_interface`` traverses the
network interfaces. On those cases we get:
```
    def _fill_allocated_ips_and_bridges_by_interface(self):
        for interface in netifaces.interfaces():
            self._add_allocated_net_bridge(interface)
>           for ifaddresses in
netifaces.ifaddresses(interface).values():
E           ValueError: You must specify a valid interface name.
```

This changes the code to allow getting ``ValueError`` and continueing to
the next interface.

/cc @eliorerz @lalon4 