### PR TITLE
Remove redundant wget dependency

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -12,7 +12,6 @@ RUN dnf -y install --enablerepo=crb \
   make \
   gcc \
   unzip \
-  wget \
   curl-minimal \
   git \
   httpd-tools \


### PR DESCRIPTION
It is redundant ever since https://github.com/openshift/assisted-test-infra/pull/552.