### PR TITLE
MGMT-12670: Set terraform parameters only on `create_nodes` and `destroy_nodes`

### DIFF
--- a/src/tests/test_bootstrap_in_place.py
+++ b/src/tests/test_bootstrap_in_place.py
@@ -416,7 +416,7 @@ class TestBootstrapInPlace(BaseTest):
 
             time.sleep(10)
 
-    @JunitTestSuite()
+    @JunitTestCase()
     def prepare_worker_installation(
         self,
         controller_configuration: BaseNodesConfig,
@@ -431,14 +431,14 @@ class TestBootstrapInPlace(BaseTest):
         worker_image_path = self.embed("installer-image.iso", "worker-live-iso.ign", EMBED_IMAGE_NAME_WORKER)
         cluster_configuration.worker_iso_download_path = worker_image_path
 
-    @JunitTestSuite()
+    @JunitTestCase()
     def master_installation(self, controller: TerraformController, cluster_configuration: ClusterConfig):
         log.info("Starting master node...")
         controller.start_node(node_name=f"{CLUSTER_PREFIX}-master-0")
 
         self.waiting_for_installation_completion(controller, cluster_configuration, skip_logs=True)
 
-    @JunitTestSuite()
+    @JunitTestCase()
     def worker_installation(self, controller: TerraformController, cluster_configuration: ClusterConfig):
         controller.start_node(node_name=f"{CLUSTER_PREFIX}-worker-0")
 


### PR DESCRIPTION
This allowing us to update node configurations after the cluster was created but before creating the nodes
e.g.
```python
class TestInstall(BaseTest):

    def test_install(self, cluster, controller_configuration):
        min_host_ocp_requirements = cluster.get_preflight_requirements()
        controller_configuration.master_vcpu = min_host_ocp_requirements.ocp.master.quantitative.cpu_cores

        cluster.prepare_for_installation()
        cluster.start_install_and_wait_for_installed()

```

/cc @osherdp 