### PR TITLE
Add return to get_disks

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
@@ -172,7 +172,7 @@ class Node:
         self.set_ram_kib(self.original_ram_kib)
 
     def get_disks(self):
-        self.node_controller.list_disks(self.name)
+        return self.node_controller.list_disks(self.name)
 
     def attach_test_disk(self, disk_size, **kwargs):
         return self.node_controller.attach_test_disk(self.name, disk_size, **kwargs)


### PR DESCRIPTION
Current nody.py get_disks function returns none instead of disks Fixed and added return.