### PR TITLE
fix download-logs.sh script syntax

### DIFF
--- a/scripts/download_logs.sh
+++ b/scripts/download_logs.sh
@@ -77,7 +77,7 @@ function download_capi_logs() {
   ${KUBECTL} get pods -n ${NAMESPACE} -o=custom-columns=NAME:.metadata.name --no-headers | xargs -r -I {} sh -c "${KUBECTL} get pods -o yaml {} -n ${NAMESPACE} > ${LOGS_DEST}/${NAMESPACE}/pods_{}}.yaml" || true
   ${KUBECTL} get cm -n ${NAMESPACE} -o=custom-columns=NAME:.metadata.name --no-headers | xargs -r -I {} sh -c "${KUBECTL} get cm -o yaml {} -n ${NAMESPACE} > ${LOGS_DEST}/${NAMESPACE}/cm_{}.yaml" || true
   ${KUBECTL} get cm -n ${NAMESPACE} -o=custom-columns=NAME:.metadata.name --no-headers | xargs -r -I {} sh -c "${KUBECTL} get secret -o yaml {} -n ${NAMESPACE} > ${LOGS_DEST}/${NAMESPACE}/secret_{}.yaml" || true
-  ${KUBECTL} get events -n ${NAMESPACE} > ${LOGS_DEST}/${NAMESPACE}/events.yaml" || true
+  ${KUBECTL} get events -n ${NAMESPACE} > ${LOGS_DEST}/${NAMESPACE}/events.yaml || true
   skipper run ./src/junit_log_parser.py --src "${LOGS_DEST}" --dst "${JUNIT_REPORT_DIR}"
 }
 


### PR DESCRIPTION
Currently getting:
```
15:53:17  ./scripts/download_logs.sh: line 100: unexpected EOF while
   looking for matching `"'
15:53:17  make: *** [Makefile:293: download_cluster_logs] Error 2
```

E.g.:
http://assisted-jenkins.usersys.redhat.com/job/download_logs/44906/console

/cc @eranco74 