### PR TITLE
Add drop cache when change nodes state

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/iptables.py
+++ b/src/assisted_test_infra/test_infra/controllers/iptables.py
@@ -62,7 +62,8 @@ class IptableRule:
             utils.run_command(insert_rule, shell=True)
 
     def delete(self) -> None:
-        if self._does_rule_exist():
-            delete_rule = self._build_command_string(IpTableCommandOption.DELETE)
+        delete_rule = self._build_command_string(IpTableCommandOption.DELETE)
+        # delete duplicate rules - iptable deletes only first hit
+        while self._does_rule_exist():
             log.info(f"Removing iptable rule: {delete_rule}")
             utils.run_command(delete_rule, shell=True)

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -648,9 +648,19 @@ class BaseTest:
             log.info(f"Given node ips: {given_node_ips}")
 
             for _rule in iptables_rules:
-                _rule.add_sources(given_node_ips)
-                rules.append(_rule)
-                _rule.insert()
+                if not given_node_ips:
+                    # in case a rule without given_node_ips
+                    rules.append(_rule)
+                    _rule.insert()
+                    continue
+                for source in given_node_ips:
+                    # iptables check broken for list of sources
+                    # copy base rule and add a single source.
+                    copy_rule = deepcopy(_rule)
+                    copy_rule.add_sources([source])
+                    log.info(f"Adding rule with source: {copy_rule}")
+                    rules.append(copy_rule)
+                    copy_rule.insert()
 
         yield set_iptables_rules_for_nodes
         log.info("---TEARDOWN iptables ---")


### PR DESCRIPTION
Current iptables fixture tears down nodes in order modify iptables. When the machines started again the cached info must be refreshed.

In case machines state changed like stop/reboot cashed info may hide bugs in the node controllers or fail tests.