### PR TITLE
MGMT-12881: fix REBOOT_TIMEOUT message string to match the message in assisted-service

### DIFF
--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -288,7 +288,7 @@ class HostEvents:
 class HostStatusInfo:
     WRONG_BOOT_ORDER = "Expected the host to boot from disk, but it booted the installation image"
     OLD_REBOOT_TIMEOUT = "Host failed to reboot within timeout"
-    REBOOT_TIMEOUT = "Host failed to pull ignition within timeout"
+    REBOOT_TIMEOUT = "Host timed out when pulling ignition"
 
 
 class Platforms:


### PR DESCRIPTION

https://github.com/openshift/assisted-service/blob/c0b3526c379e81df5925fd0f2d61e7559e9a41a7/internal/host/common.go#L39