### PR TITLE
MGMT-12439: Deploy heterogeneous infrastructure

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -7,6 +7,11 @@ ENV TOOLS=/tools/
 ENV PATH="$TOOLS:$PATH"
 RUN mkdir $TOOLS --mode g+xw
 
+# TODO: Remove once OpenShift CI supports it out of the box (see https://access.redhat.com/articles/4859371)
+RUN chmod g+w /etc/passwd && \
+    echo 'echo default:x:$(id -u):$(id -g):Default Application User:/alabama:/sbin/nologin\ >> /etc/passwd' > /usr/local/bin/fix_uid.sh && \
+    chmod g+rwx /usr/local/bin/fix_uid.sh
+
 # CRB repo is required for libvirt-devel
 RUN dnf -y install --enablerepo=crb \
   make \
@@ -53,7 +58,9 @@ ENV PATH=$PATH:/usr/local/go/bin:/go/bin
 
 COPY . .
 
-RUN chgrp -R 0 /home/assisted-test-infra && \
+# init terraform in order to cache the provider
+RUN terraform -chdir=/home/assisted-test-infra/terraform_files/equinix-ci-machine init && \
+    chgrp -R 0 /home/assisted-test-infra && \
     chmod -R g=u /home/assisted-test-infra
 
 # setting pre-commit env

--- a/ansible_files/ansible.cfg
+++ b/ansible_files/ansible.cfg
@@ -1,0 +1,4 @@
+[defaults]
+host_key_checking = False
+remote_tmp = /tmp/ansible
+verbosity = 3

--- a/ansible_files/equinix_generic_destroy_infra_playbook.yml
+++ b/ansible_files/equinix_generic_destroy_infra_playbook.yml
@@ -1,0 +1,15 @@
+- name: Destroy equinix infrastructure
+  hosts: localhost
+  vars_prompt:
+    - name: equinix_auth_token
+      prompt: Equinix metal API token
+    - name: equinix_tf_vars_file
+      prompt: Terrafom variable file that was used to create the device(s)
+      private: false
+    - name: equinix_tf_state_file
+      prompt: Terrafom state file that was used to create the device(s)
+      private: false
+  vars:
+    terraform_equinix_workdir: "{{ [playbook_dir, '..', 'terraform_files', 'equinix-ci-machine'] | path_join | realpath }}"
+  roles:
+    - equinix/generic_destroy_infra

--- a/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
+++ b/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
@@ -1,0 +1,38 @@
+- name: Create and configure the equinix infrastructure to run heterogneous cluster tests
+  hosts: localhost
+  vars_prompt:
+    - name: equinix_project_id
+      prompt: Equinix metal project ID in which the device(s) will be created
+      private: false
+    - name: equinix_auth_token
+      prompt: Equinix metal API token
+    - name: equinix_ssh_private_key_path
+      prompt: Path to an SSH private key allowed to connect on the created device(s)
+      private: false
+    - name: equinix_unique_id
+      prompt: Hostname prefix which will be used to identify the device(s)
+      private: false
+    - name: equinix_tf_vars_file
+      prompt: Place where the Terrafom variable file will be stored
+      private: false
+    - name: equinix_tf_state_file
+      prompt: Place where the Terrafom state file will be stored
+      private: false
+  vars:
+    terraform_equinix_workdir: "{{ [playbook_dir, '..', 'terraform_files', 'equinix-ci-machine'] | path_join | realpath }}"
+  tasks:
+    # Create the required devices to test heterogeneous scenarios
+    - ansible.builtin.import_role:
+        name: equinix/heterogeneous_create_infra
+    # Export the connection details, required for the common steps in Prow
+    - ansible.builtin.import_role:
+        name: equinix/export_primary_device_connection_details
+    # Build an IPIP tunnel between both of the machines in "heterogeneous" group
+    - ansible.builtin.import_role:
+        name: common/setup_ipip_tunnel
+      vars:
+        ipip_group: heterogeneous
+    # - ansible.builtin.import_role:
+    #     name: equinix/install_libvirt
+    # - ansible.builtin.import_role:
+    #     name: equinix/expose_libvirt

--- a/ansible_files/roles/common/setup_ipip_tunnel/tasks/main.yml
+++ b/ansible_files/roles/common/setup_ipip_tunnel/tasks/main.yml
@@ -1,0 +1,9 @@
+- name: Check if group "{{ ipip_group }}" exists and contains exactly 2 hosts
+  ansible.builtin.fail:
+    msg: Group "{{ ipip_group }}" must exist and contain exactly 2 hosts
+  when: groups[ipip_group] is not defined or (groups[ipip_group] | length != 2)
+
+- name: Ping hosts in group "{{ ipip_group }}"
+  ansible.builtin.ping:
+  delegate_to: "{{ item }}"
+  loop: "{{ groups[ipip_group] }}"

--- a/ansible_files/roles/equinix/export_primary_device_connection_details/defaults/main.yml
+++ b/ansible_files/roles/equinix/export_primary_device_connection_details/defaults/main.yml
@@ -1,0 +1,1 @@
+primary_device_group_name: "primary"

--- a/ansible_files/roles/equinix/export_primary_device_connection_details/tasks/main.yml
+++ b/ansible_files/roles/equinix/export_primary_device_connection_details/tasks/main.yml
@@ -1,0 +1,11 @@
+- name: Check if primary group exists and contains exactly 1 host
+  ansible.builtin.fail:
+    msg: Group primary must exits and contain exactly 1 host
+  when: groups[primary_device_group_name] is not defined or (groups[primary_device_group_name] | length != 1)
+
+- name: "Export connection details of primary device"
+  ansible.builtin.template:
+    src: "ci-machine-config.sh.j2"
+    dest: "{{ shared_dir }}/ci-machine-config.sh"
+    mode: 0644
+  when: shared_dir is defined

--- a/ansible_files/roles/equinix/export_primary_device_connection_details/templates/ci-machine-config.sh.j2
+++ b/ansible_files/roles/equinix/export_primary_device_connection_details/templates/ci-machine-config.sh.j2
@@ -1,0 +1,2 @@
+export IP="{{ hostvars[groups[primary_device_group_name][0]].access_public_ipv4 }}"
+export SSH_KEY_FILE="{{ equinix_ssh_private_key_path }}"

--- a/ansible_files/roles/equinix/generic_destroy_infra/tasks/main.yml
+++ b/ansible_files/roles/equinix/generic_destroy_infra/tasks/main.yml
@@ -1,0 +1,18 @@
+- name: "Restore Terraform state file from {{ equinix_tf_state_file }}"
+  ansible.builtin.copy:
+    src: "{{ equinix_tf_state_file }}"
+    dest: "{{ terraform_equinix_workdir }}/terraform.tfstate"
+    force: true
+    mode: 0644
+
+- name: "Destroy terraform infrastructure"
+  community.general.terraform:
+    project_path: "{{ terraform_equinix_workdir }}"
+    state: absent
+    force_init: false
+    variables_files:
+      - "{{ equinix_tf_vars_file }}"
+    state_file: "{{ equinix_tf_state_file }}"
+  register: destroyed_tf
+  environment:
+    METAL_AUTH_TOKEN: "{{ equinix_auth_token }}"

--- a/ansible_files/roles/equinix/heterogeneous_create_infra/defaults/main.yaml
+++ b/ansible_files/roles/equinix/heterogeneous_create_infra/defaults/main.yaml
@@ -1,0 +1,9 @@
+primary_device_group_name: "primary"
+secondary_device_group_name: "secondary"
+equinix_ssh_user: "root"
+equinix_plans: "{{
+      {
+       primary_device_group_name : 'c3.small.x86',
+       secondary_device_group_name : 'c3.small.x86'
+      }
+  }}"

--- a/ansible_files/roles/equinix/heterogeneous_create_infra/tasks/main.yml
+++ b/ansible_files/roles/equinix/heterogeneous_create_infra/tasks/main.yml
@@ -1,0 +1,34 @@
+- name: "Save terraform variables into {{ equinix_tf_vars_file }}"
+  ansible.builtin.template:
+    src: "terraform.tfvars.j2"
+    dest: "{{ equinix_tf_vars_file }}"
+    mode: 0644
+
+- name: "Deploy Terraform Instance"
+  community.general.terraform:
+    project_path: "{{ terraform_equinix_workdir }}"
+    state: present
+    force_init: true
+    variables_files:
+      - "{{ equinix_tf_vars_file }}"
+  register: deployed_tf
+  environment:
+    METAL_AUTH_TOKEN: "{{ equinix_auth_token }}"
+
+- name: "Add created devices to inventory"
+  ansible.builtin.add_host:
+    name: "{{ item.hostname }}"
+    ansible_host: "{{ item.access_public_ipv4 }}"
+    ansible_user: "{{ equinix_ssh_user }}"
+    ansible_ssh_private_key_file: "{{ equinix_ssh_private_key_path }}"
+    groups: "{{ item.tags }}"
+    access_public_ipv4: "{{ item.access_public_ipv4 }}"
+    access_private_ipv4: "{{ item.access_private_ipv4 }}"
+  loop: "{{ deployed_tf.outputs.inventory.value }}"
+
+- name: "Save Terraform state file in {{ equinix_tf_state_file }}"
+  ansible.builtin.copy:
+    src: "{{ terraform_equinix_workdir }}/terraform.tfstate"
+    dest: "{{ equinix_tf_state_file }}"
+    mode: 0644
+  when: equinix_tf_state_file is defined

--- a/ansible_files/roles/equinix/heterogeneous_create_infra/templates/terraform.tfvars.j2
+++ b/ansible_files/roles/equinix/heterogeneous_create_infra/templates/terraform.tfvars.j2
@@ -1,0 +1,17 @@
+{% macro device(group) %}
+  hostname = "{{ equinix_unique_id }}-{{ group }}"
+  plan = "{{ equinix_plans[group] }}"
+  project_id = "{{ equinix_project_id }}"
+  ssh_private_key_path = "{{ equinix_ssh_private_key_path }}"
+  ssh_user = "{{ equinix_ssh_user }}"
+  tags = ["heterogeneous", "{{ group }}"]
+{% endmacro %}
+
+devices = [
+  {
+    {{ device(primary_device_group_name) }}
+  },
+  {
+    {{ device(secondary_device_group_name) }}
+  }
+]

--- a/ansible_files/vars/ci.yml
+++ b/ansible_files/vars/ci.yml
@@ -1,0 +1,7 @@
+# CI related vars
+build_id:  "{{ lookup('env', 'BUILD_ID') }}"
+cluster_profile_dir: "{{ lookup('env', 'CLUSTER_PROFILE_DIR') }}"
+job_name_hash: "{{ lookup('env', 'JOB_NAME_HASH') }}"
+namespace: "{{ lookup('env', 'NAMESPACE') }}"
+openshift_ci : "{{ lookup('env', 'OPENSHIFT_CI') | bool }}"
+shared_dir: "{{ lookup('env', 'SHARED_DIR') }}"

--- a/ansible_files/vars/ci_equinix_infrastucture.yml
+++ b/ansible_files/vars/ci_equinix_infrastucture.yml
@@ -1,0 +1,7 @@
+# Equinix related vars, built from CI vars
+equinix_project_id: "{{ lookup('file', cluster_profile_dir + '/packet-project-id') | trim }}"
+equinix_auth_token: "{{ lookup('file', cluster_profile_dir + '/packet-auth-token') | trim }}"
+equinix_ssh_private_key_path: "{{ cluster_profile_dir }}/packet-ssh-key"
+equinix_unique_id: "ipi-{{ namespace }}-{{ job_name_hash }}-{{ build_id }}"
+equinix_tf_vars_file: "{{ shared_dir }}/{{ equinix_unique_id }}.tfvars"
+equinix_tf_state_file: "{{ shared_dir }}/{{ equinix_unique_id }}.tfstate"

--- a/ansible_files/vars/standalone_equinix_sample.yml
+++ b/ansible_files/vars/standalone_equinix_sample.yml
@@ -1,0 +1,8 @@
+# Adapt and use this var file if you want to easily provision devices from equinix outside of the CI environment, e.g.:
+# ansible-playbook -e "@vars/standalone_equinix_sample.yml" equinix_heterogeneous_create_infra_playbook.yml
+equinix_project_id: "{{ lookup('env', 'METAL_PROJECT_ID') }}"
+equinix_auth_token: "{{ lookup('env', 'METAL_AUTH_TOKEN') }}"
+equinix_ssh_private_key_path: "{{ lookup('env', 'HOME') }}/.ssh/equinix_id"
+equinix_unique_id: "ipi-{{ lookup('env', 'USER') }}-test"
+equinix_tf_vars_file: "/tmp/{{ equinix_unique_id }}.tfvars"
+equinix_tf_state_file: "/tmp/{{ equinix_unique_id }}.tfstate"

--- a/requirements.txt
+++ b/requirements.txt
@@ -34,3 +34,4 @@ waiting>=1.4.1
 prompt_toolkit==3.0.36
 nutanix-api==0.0.19
 pytest-error-for-skips==2.0.2
+ansible==7.1.0

--- a/terraform_files/equinix-ci-machine/main.tf
+++ b/terraform_files/equinix-ci-machine/main.tf
@@ -1,0 +1,33 @@
+terraform {
+  required_providers {
+    equinix = {
+      source = "equinix/equinix"
+    }
+  }
+}
+
+resource "equinix_metal_device" "ci_devices" {
+  for_each = { for idx, device in var.devices : idx => device }
+
+  hostname         = each.value["hostname"]
+  plan             = each.value["plan"]
+  facilities       = each.value["facilities"]
+  operating_system = each.value["operating_system"]
+  project_id       = each.value["project_id"]
+  tags             = each.value["tags"]
+
+  # wait an ssh connection and wait for cloud-init to complete
+  connection {
+    type        = "ssh"
+    user        = each.value["ssh_user"]
+    host        = self.access_public_ipv4
+    timeout     = "5m"
+    private_key = file(each.value["ssh_private_key_path"])
+  }
+
+  provisioner "remote-exec" {
+    inline = [
+      "cloud-init status --wait"
+    ]
+  }
+}

--- a/terraform_files/equinix-ci-machine/output.tf
+++ b/terraform_files/equinix-ci-machine/output.tf
@@ -1,0 +1,9 @@
+output "inventory" {
+  value = [for d in equinix_metal_device.ci_devices : {
+    "access_private_ipv4" : d.access_private_ipv4,
+    "access_public_ipv4" : d.access_public_ipv4
+    "hostname" : d.hostname,
+    "tags" : d.tags,
+    }
+  ]
+}

--- a/terraform_files/equinix-ci-machine/variables_equinix.tf
+++ b/terraform_files/equinix-ci-machine/variables_equinix.tf
@@ -1,0 +1,15 @@
+variable "devices" {
+  description = "Settings for desired devices"
+  type = list(
+    object({
+      facilities           = optional(list(string), ["any"])
+      hostname             = string
+      operating_system     = optional(string, "rocky_8")
+      plan                 = string
+      project_id           = string
+      ssh_private_key_path = string
+      ssh_user             = optional(string, "root")
+      tags                 = optional(list(string), [])
+    })
+  )
+}


### PR DESCRIPTION
This PR contains:
- a terraform module able to provision multiple devices from equinix metal
- Two ansible playbooks: 
  -  create heterogeneous clusters, which is responsible to provision the devices from equinix using the terraform module above, and soon, configure both of the machines (ipip tunnel and libvirt)
  - destroy the machines created by the first playbook

Here is CI definition if you want to check how the playbooks are used: https://github.com/openshift/release/tree/master/ci-operator/step-registry/assisted/equinix