### PR TITLE
Fix iptables fixture and delete action

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/iptables.py
+++ b/src/assisted_test_infra/test_infra/controllers/iptables.py
@@ -62,7 +62,8 @@ class IptableRule:
             utils.run_command(insert_rule, shell=True)
 
     def delete(self) -> None:
-        if self._does_rule_exist():
-            delete_rule = self._build_command_string(IpTableCommandOption.DELETE)
+        # delete duplicate rules when exists
+        delete_rule = self._build_command_string(IpTableCommandOption.DELETE)
+        while self._does_rule_exist():
             log.info(f"Removing iptable rule: {delete_rule}")
             utils.run_command(delete_rule, shell=True)


### PR DESCRIPTION
    Iptables check does not work when having a chain of sources
    When we insert a rule with multiple source, iptables split the list
    and adding each source with same conditions

    On check action iptables wont catch case when having a mix of source
    when 1 is not in the table. looks like iptables check only one.
    In case check action returned wrong result add/delete rule chnaged and
    may trigger failures due to unexpected results

    Also deletion , iptables delete only the first match when having duplicate
    rules.

    Example:
    iptables --insert FORWARD -p tcp -j DROP -s 192.168.128.10,192.168.128.13
    results with:
    -A FORWARD -s 192.168.128.13/32 -p tcp -m tcp --dport 80 -j DROP
    -A FORWARD -s 192.168.128.10/32 -p tcp -m tcp --dport 80 -j DROP

    We will get different result from iptables for:
    iptables --check FORWARD -p tcp -j DROP -s 7.7.7.7,192.168.128.10
    iptables --check FORWARD -p tcp -j DROP -s 192.168.128.10,7.7.7.7

    Means that only 1 is the best approch here.