### PR TITLE
Current iptables fixture tears down nodes in order modify iptables.

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/nodes.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/nodes.py
@@ -99,6 +99,7 @@ class Nodes:
 
     def shutdown_all(self):
         self.run_for_all_nodes("shutdown")
+        self.drop_cache()
 
     def notify_iso_ready(self):
         self.controller.notify_iso_ready()
@@ -108,9 +109,11 @@ class Nodes:
 
     def start_given(self, nodes):
         self.run_for_given_nodes(nodes, "start")
+        self.drop_cache()
 
     def shutdown_given(self, nodes):
         self.run_for_given_nodes(nodes, "shutdown")
+        self.drop_cache()
 
     def format_all_disks(self):
         self.run_for_all_nodes("format_disk")
@@ -129,9 +132,11 @@ class Nodes:
 
     def reboot_all(self):
         self.run_for_all_nodes("restart")
+        self.drop_cache()
 
     def reboot_given(self, nodes):
         self.run_for_given_nodes(nodes, "restart")
+        self.drop_cache()
 
     def get_cluster_network(self):
         return self.controller.get_cluster_network()


### PR DESCRIPTION
When the machines started again the cached info must be refreshed.

In case machines state changed like stop/reboot cashed info may hide bugs in the node controllers or fail tests.

This patch is continuation of https://github.com/openshift/assisted-test-infra/pull/1947 Due to some mismach i created new patch.