### PR TITLE
MGMT-12881: fix REBOOT_TIMEOUT message string to match the message in assisted-service

### DIFF
--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -288,7 +288,7 @@ class HostEvents:
 class HostStatusInfo:
     WRONG_BOOT_ORDER = "Expected the host to boot from disk, but it booted the installation image"
     OLD_REBOOT_TIMEOUT = "Host failed to reboot within timeout"
-    REBOOT_TIMEOUT = "Host timed out when pulling ignition"
+    REBOOT_TIMEOUT = "Host timed out when pulling"
 
 
 class Platforms:


### PR DESCRIPTION
The old message started with:
`Host timed out when pulling ignition.`

The new message starts with:
`Host timed out when pulling the configuration files.`