### PR TITLE
Iptables rules added without destination port due to iptables versions

### DIFF
--- a/skipper.yaml
+++ b/skipper.yaml
@@ -11,6 +11,7 @@ volumes:
   - /usr/bin/kubectl:/usr/bin/kubectl
   - /usr/local/bin/kubectl:/usr/local/bin/kubectl
   - $MINIKUBE_HOME:$MINIKUBE_HOME
+  - $(which iptables):/usr/sbin/iptables
   # config
   - $HOME/.kube/:$HOME/.kube/
   - $HOME/.minikube/:$HOME/.minikube/


### PR DESCRIPTION
When running hypervisor with rhel8.6 and containers with centos9, iptables rules with --dport value not submitted on hypervisor and all tcp traffic blocked. reproduced with skipper code on multiple setups. the rule set with port and sources and targets. on hpervisor side the --dport was not submitted but the NFT table updated with the dport.
Example when reproduced:
-A FORWARD -s 192.168.128.11/32 -p tcp -j DROP
Here we dont have the dport assigned and the rule blocks all tcp

versions we hit on the issue:
container centos 9 - >iptables v1.8.8 (nf_tables)
hypervisor (rhel 8.6) ->  iptables v1.8.4 (nf_tables)

The fix mount containers to the hypervisor iptables binary centos iptables version and rhel8.6 with same version and it works. -A FORWARD -s 192.168.128.11/32 -p tcp -m tcp --dport 443 -j DROP

There is a warning message from container side when running the command but i did not find any impact on the funtion

iptables: Symbol `xtables_chain_protos' has different size in shared object, consider re-linking iptables v1.8.4 (nf_tables)