### PR TITLE
MGMT-12441: Install libvirtd on the ARM machine

### DIFF
--- a/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
+++ b/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
@@ -64,3 +64,13 @@
         ipip_remote_ipv4: "{{ hostvars[groups['primary'][0]].access_private_ipv4 }}"
         ipip_tunnel_ipv4: "{{ secondary_ipip_tunnel_ipv4 }}"
         ipip_route_to_network: "{{ primary_internal_network_prefix }}"
+
+- name: Share a unique SSH key pair among the created devices
+  hosts: heterogeneous
+  roles:
+    - name: common/setup_ssh_key_pair
+
+- name: Setup libvirtd on secondary machine
+  hosts: secondary[0]
+  roles:
+    - name: common/setup_libvirtd

--- a/ansible_files/roles/common/setup_libvirtd/handlers/main.yml
+++ b/ansible_files/roles/common/setup_libvirtd/handlers/main.yml
@@ -1,0 +1,4 @@
+- name: Start libvirtd service
+  ansible.builtin.systemd:
+    name: libvirtd.service
+    state: started

--- a/ansible_files/roles/common/setup_libvirtd/tasks/main.yml
+++ b/ansible_files/roles/common/setup_libvirtd/tasks/main.yml
@@ -1,0 +1,7 @@
+- name: Install libvirtd
+  ansible.builtin.package:
+    name:
+      - libvirt-daemon-kvm
+    state: present
+  notify:
+    - Start libvirtd service

--- a/ansible_files/roles/common/setup_ssh_key_pair/defaults/main.yml
+++ b/ansible_files/roles/common/setup_ssh_key_pair/defaults/main.yml
@@ -1,0 +1,1 @@
+cluster_ssh_private_key_path: "~/.ssh/id_cluster"

--- a/ansible_files/roles/common/setup_ssh_key_pair/tasks/main.yml
+++ b/ansible_files/roles/common/setup_ssh_key_pair/tasks/main.yml
@@ -1,0 +1,28 @@
+- name: Generate an OpenSSH keypair
+  local_action:
+    module: community.crypto.openssh_keypair
+    path: /tmp/{{ cluster_ssh_private_key_path | basename }}
+  register: ssh_key_pair
+  run_once: true
+
+- name: Copy private key to remote host
+  copy:
+    src: "{{ ssh_key_pair.filename }}"
+    dest: "{{ cluster_ssh_private_key_path }}"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid }}"
+    mode: '0600'
+
+- name: Authorize key
+  ansible.posix.authorized_key:
+    user: "{{ ansible_user_id }}"
+    state: present
+    key: "{{ ssh_key_pair.public_key }}"
+
+- name: Generate SSH client configuration
+  ansible.builtin.template:
+    src: "config.j2"
+    dest: "~/.ssh/config"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid }}"
+    mode: '0600'

--- a/ansible_files/roles/common/setup_ssh_key_pair/templates/config.j2
+++ b/ansible_files/roles/common/setup_ssh_key_pair/templates/config.j2
@@ -1,0 +1,10 @@
+{% for host in ansible_play_hosts %}
+host {{ hostvars[host].inventory_hostname }}
+    {# take first private IP available, default on public IP if no private IP -#}
+    {% set private_ips = hostvars[host].ansible_all_ipv4_addresses | sort | ansible.utils.ipaddr('private') -%}
+    Hostname {{ private_ips | first | default(hostvars[host].ansible_all_ipv4_addresses[0]) }}
+    User {{ hostvars[host].ansible_user }}
+    IdentityFile {{ cluster_ssh_private_key_path }}
+    StrictHostKeyChecking no
+
+{% endfor %}


### PR DESCRIPTION
Install libvirtd and configure a throwable SSH key pair between both of
the machines, so the primary machine can control libvirtd on the ARM 
machine through SSH, e.g.:
```
virsh -c "qemu+ssh://secondary-host/system"
```
