### PR TITLE
Cannot remove container as it is running issue

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -428,7 +428,7 @@ def run_container(container_name, image, flags=None, command=""):
 
 def remove_running_container(container_name):
     log.info(f"Removing Container {container_name}")
-    container_rm_cmd = f"podman-remote stop {container_name} && podman-remote rm {container_name}"
+    container_rm_cmd = f"podman-remote rm --force {container_name}"
     run_command(container_rm_cmd, shell=True)
 
 


### PR DESCRIPTION
Test failed when trying to remove proxy container squid Error message refers to running or paused containers cannot be removed The code stop && rm the podman but it might be that stop code not really blocked and waiting before we call remove.

Added sleep between stop to remove.