### PR TITLE
Extending SNO installation timeout to 70 mins

### DIFF
--- a/src/tests/test_bootstrap_in_place.py
+++ b/src/tests/test_bootstrap_in_place.py
@@ -265,7 +265,7 @@ class TestBootstrapInPlace(BaseTest):
             waiting.wait(
                 self.all_operators_available,
                 sleep_seconds=20,
-                timeout_seconds=60 * 60,
+                timeout_seconds=70 * 60,
                 waiting_for="all operators to get up",
             )
             log.info("Installation completed successfully!")


### PR DESCRIPTION
In
https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_assisted-test-infra/1883/pull-ci-openshift-assisted-test-infra-master-e2e-metal-single-node-live-iso/1607833190590844928 we get to a timeout for waiting for the installation, even though in the post must-gather logs it seems like installation finished successfully.

This increases the timeout by 10 minutes to make the job more stable.