### PR TITLE
Fix prepare network - get platform from configuration

### DIFF
--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -294,7 +294,7 @@ class BaseTest:
 
     @classmethod
     def _prepare_nodes_network(cls, prepared_nodes: Nodes, controller_configuration: BaseNodesConfig) -> Nodes:
-        if global_variables.platform not in (consts.Platforms.BARE_METAL, consts.Platforms.NONE):
+        if controller_configuration.tf_platform not in (consts.Platforms.BARE_METAL, consts.Platforms.NONE):
             yield prepared_nodes
             return
 


### PR DESCRIPTION
Current code is part of cluster fixture, configuration_controller already contains that updated platform.

This fix is going to fix test_none_platform test.

We will have to change the name of tf_platform name to common name that will be supported by other controllers , different patch