### PR TITLE
MGMT-11111: refactor day2 cluster code

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -180,7 +180,8 @@ class LibvirtController(NodeController, ABC):
         except IndexError:
             return []
 
-    def wait_till_nodes_are_ready(self, network_name):
+    def wait_till_nodes_are_ready(self, network_name: str = None):
+        assert network_name is not None
         log.info("Wait till %s nodes will be ready and have ips", self._config.nodes_count)
         try:
             waiting.wait(
@@ -647,3 +648,6 @@ class LibvirtController(NodeController, ABC):
 
     def set_single_node_ip(self, ip):
         raise NotImplementedError
+
+    def get_day2_static_network_data(self):
+        pass

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -195,7 +195,7 @@ class NodeController(ABC):
     def get_network_by_name(self, network_name: str) -> libvirt.virNetwork:
         pass
 
-    def wait_till_nodes_are_ready(self, network_name: str):
+    def wait_till_nodes_are_ready(self, network_name: str = None):
         """If not overridden - do not wait"""
         pass
 
@@ -213,4 +213,7 @@ class NodeController(ABC):
         pass
 
     def set_ipxe_url(self, network_name: str, ipxe_url: str):
+        pass
+
+    def get_day2_static_network_data(self):
         pass

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -337,3 +337,11 @@ class TerraformController(LibvirtController):
 
     def set_single_node_ip(self, ip):
         self.tf.change_variables({"single_node_ip": ip})
+
+    def get_day2_static_network_data(self):
+        if self._entity_config.is_static_ip:
+            return static_network.generate_day2_static_network_data_from_tf(self.tf_folder, self._config.workers_count)
+        return None
+
+    def wait_till_nodes_are_ready(self, network_name: str = None):
+        return super().wait_till_nodes_are_ready(network_name or self.network_name)

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -339,9 +339,7 @@ class TerraformController(LibvirtController):
         self.tf.change_variables({"single_node_ip": ip})
 
     def get_day2_static_network_data(self):
-        if self._entity_config.is_static_ip:
-            return static_network.generate_day2_static_network_data_from_tf(self.tf_folder, self._config.workers_count)
-        return None
+        return static_network.generate_day2_static_network_data_from_tf(self.tf_folder, self._config.workers_count)
 
     def wait_till_nodes_are_ready(self, network_name: str = None):
         return super().wait_till_nodes_are_ready(network_name or self.network_name)

--- a/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
@@ -101,3 +101,6 @@ class BaseCluster(Entity, ABC):
         log.info(f"Setting pull secret:{pull_secret} for cluster: {self.id}")
         self.update_config(pull_secret=pull_secret)
         self.api_client.update_cluster(cluster_id or self.id, {"pull_secret": pull_secret})
+
+    def get_iso_download_path(self, iso_download_path: str = None):
+        return iso_download_path or self._infra_env_config.iso_download_path

--- a/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
@@ -1,0 +1,103 @@
+from abc import ABC, abstractmethod
+from pathlib import Path
+from typing import Optional, Union
+
+from assisted_service_client import models
+from junit_report import JunitTestCase
+
+from assisted_test_infra.test_infra import BaseClusterConfig, BaseInfraEnvConfig, Nodes
+from assisted_test_infra.test_infra.helper_classes.entity import Entity
+from assisted_test_infra.test_infra.helper_classes.infra_env import InfraEnv
+from assisted_test_infra.test_infra.tools import static_network
+from service_client import InventoryClient, log
+
+
+class BaseCluster(Entity, ABC):
+    _config: BaseClusterConfig
+
+    def __init__(
+        self,
+        api_client: InventoryClient,
+        config: BaseClusterConfig,
+        infra_env_config: BaseInfraEnvConfig,
+        nodes: Optional[Nodes] = None,
+    ):
+        self._infra_env_config = infra_env_config
+        self._infra_env: Optional[InfraEnv] = None
+
+        super().__init__(api_client, config, nodes)
+
+        # Update infraEnv configurations
+        self._infra_env_config.cluster_id = config.cluster_id
+        self._infra_env_config.openshift_version = self._config.openshift_version
+        self._infra_env_config.pull_secret = self._config.pull_secret
+
+    @property
+    def id(self) -> str:
+        return self._config.cluster_id
+
+    def get_details(self) -> Union[models.infra_env.InfraEnv, models.cluster.Cluster]:
+        return self.api_client.cluster_get(self.id)
+
+    @abstractmethod
+    def start_install_and_wait_for_installed(self, **kwargs):
+        pass
+
+    def download_image(self, iso_download_path: str = None, static_network_config=None) -> Path:
+        if self._infra_env is None:
+            log.warning("No infra_env found. Generating infra_env and downloading ISO")
+            return self.generate_and_download_infra_env(
+                static_network_config=static_network_config,
+                iso_download_path=iso_download_path or self._config.iso_download_path,
+                iso_image_type=self._config.iso_image_type,
+            )
+        return self._infra_env.download_image(iso_download_path or self._config.iso_download_path)
+
+    @JunitTestCase()
+    def generate_and_download_infra_env(
+        self,
+        iso_download_path=None,
+        static_network_config=None,
+        iso_image_type=None,
+        ssh_key=None,
+        ignition_info=None,
+        proxy=None,
+    ) -> Path:
+        self.generate_infra_env(
+            static_network_config=static_network_config,
+            iso_image_type=iso_image_type,
+            ssh_key=ssh_key,
+            ignition_info=ignition_info,
+            proxy=proxy,
+        )
+        return self.download_infra_env_image(iso_download_path=iso_download_path or self._config.iso_download_path)
+
+    def generate_infra_env(
+        self, static_network_config=None, iso_image_type=None, ssh_key=None, ignition_info=None, proxy=None
+    ) -> InfraEnv:
+        if self._infra_env:
+            return self._infra_env
+
+        self._infra_env = self.create_infra_env(static_network_config, iso_image_type, ssh_key, ignition_info, proxy)
+        return self._infra_env
+
+    def download_infra_env_image(self, iso_download_path=None) -> Path:
+        iso_download_path = iso_download_path or self._config.iso_download_path
+        log.debug(f"Downloading ISO to {iso_download_path}")
+        return self._infra_env.download_image(iso_download_path=iso_download_path)
+
+    def create_infra_env(
+        self, static_network_config=None, iso_image_type=None, ssh_key=None, ignition_info=None, proxy=None
+    ) -> InfraEnv:
+        self._infra_env_config.ssh_public_key = ssh_key or self._config.ssh_public_key
+        self._infra_env_config.iso_image_type = iso_image_type or self._config.iso_image_type
+        self._infra_env_config.static_network_config = static_network_config
+        self._infra_env_config.ignition_config_override = ignition_info
+        self._infra_env_config.proxy = proxy or self._config.proxy
+        infra_env = InfraEnv(api_client=self.api_client, config=self._infra_env_config)
+        return infra_env
+
+    def set_pull_secret(self, pull_secret: str, cluster_id: str = None):
+        log.info(f"Setting pull secret:{pull_secret} for cluster: {self.id}")
+        self.update_config(pull_secret=pull_secret)
+        self.api_client.update_cluster(cluster_id or self.id, {"pull_secret": pull_secret})

--- a/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
@@ -8,7 +8,6 @@ from junit_report import JunitTestCase
 from assisted_test_infra.test_infra import BaseClusterConfig, BaseInfraEnvConfig, Nodes
 from assisted_test_infra.test_infra.helper_classes.entity import Entity
 from assisted_test_infra.test_infra.helper_classes.infra_env import InfraEnv
-from assisted_test_infra.test_infra.tools import static_network
 from service_client import InventoryClient, log
 
 

--- a/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
@@ -93,7 +93,7 @@ class BaseCluster(Entity, ABC):
         self._infra_env_config.static_network_config = static_network_config
         self._infra_env_config.ignition_config_override = ignition_info
         self._infra_env_config.proxy = proxy or self._config.proxy
-        infra_env = InfraEnv(api_client=self.api_client, config=self._infra_env_config)
+        infra_env = InfraEnv(api_client=self.api_client, config=self._infra_env_config, nodes=self.nodes)
         return infra_env
 
     def set_pull_secret(self, pull_secret: str, cluster_id: str = None):

--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -37,7 +37,7 @@ class Cluster(BaseCluster):
         infra_env_config: BaseInfraEnvConfig,
         nodes: Optional[Nodes] = None,
     ):
-        self._was_existed = False
+        self._is_installed = False
 
         super().__init__(api_client, config, infra_env_config, nodes)
 
@@ -53,8 +53,9 @@ class Cluster(BaseCluster):
         return self._config.iso_download_path
 
     @property
-    def was_existed(self) -> bool:
-        return self._was_existed
+    def is_installed(self) -> bool:
+        """Returns true when this cluster is installed."""
+        return self._is_installed
 
     @property
     def enable_image_download(self):
@@ -90,7 +91,7 @@ class Cluster(BaseCluster):
             self._infra_env_config.infra_env_id = infra_env.get("id")
             self._infra_env = InfraEnv(self.api_client, self._infra_env_config, self.nodes)
             log.info(f"Found infra-env {self._infra_env.id} for cluster {self.id}")
-            self._was_existed = True
+            self._is_installed = True
             break
         else:
             log.warning(f"Could not find any infra-env object for cluster ID {self.id}")
@@ -618,6 +619,8 @@ class Cluster(BaseCluster):
             self.wait_for_install()
         if download_kubeconfig:
             self.download_kubeconfig()
+
+        self._is_installed = True
 
     def disable_worker_hosts(self):
         hosts = self.get_hosts_by_role(consts.NodeRoles.WORKER)

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -12,7 +12,6 @@ from junit_report import JunitTestCase
 import consts
 from assisted_test_infra.test_infra import BaseInfraEnvConfig, ClusterName, utils
 from assisted_test_infra.test_infra.helper_classes.base_cluster import BaseCluster
-from assisted_test_infra.test_infra.controllers import NodeController
 from assisted_test_infra.test_infra.helper_classes.cluster import Cluster
 from assisted_test_infra.test_infra.helper_classes.config.base_day2_cluster_config import BaseDay2ClusterConfig
 from assisted_test_infra.test_infra.tools import static_network
@@ -117,7 +116,10 @@ class Day2Cluster(BaseCluster):
             f.writelines(hosts_lines)
 
     def configure_terraform(self):
-        """Use same terraform as the one used to spawn the day1 cluster, update the variables accordingly in order to spawn the day2 worker nodes"""
+        """
+        Use same terraform as the one used to spawn the day1 cluster,
+        update the variables accordingly in order to spawn the day2 worker nodes.
+        """
         tfvars = utils.get_tfvars(self.nodes.controller.tf_folder)
         self.configure_terraform_workers_nodes(tfvars)
         tfvars["api_vip"] = self._api_vip

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -119,6 +119,7 @@ class Day2Cluster(BaseCluster):
         tfvars = utils.get_tfvars(self.nodes.controller.tf_folder)
         self.configure_terraform_workers_nodes(tfvars, num_worker_nodes)
         tfvars["api_vip"] = api_vip_ip
+        tfvars["running"] = True
         utils.set_tfvars(self.nodes.controller.tf_folder, tfvars)
 
     def configure_terraform_workers_nodes(self, tfvars: Any, num_worker_nodes: int):

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -86,8 +86,9 @@ class Day2Cluster(BaseCluster):
         if self._day1_cluster._infra_env_config.is_static_ip:
             static_network_config = self.nodes.controller.get_day2_static_network_data()
 
+        tfvars = utils.get_tfvars(self.nodes.controller.tf_folder)
         self.download_image(
-            iso_download_path=self._day1_cluster.iso_download_path,
+            iso_download_path=tfvars["worker_image_path"],
             static_network_config=static_network_config,
         )
 

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -14,7 +14,7 @@ from assisted_test_infra.test_infra import BaseInfraEnvConfig, ClusterName, util
 from assisted_test_infra.test_infra.helper_classes.base_cluster import BaseCluster
 from assisted_test_infra.test_infra.controllers import NodeController
 from assisted_test_infra.test_infra.helper_classes.cluster import Cluster
-from assisted_test_infra.test_infra.helper_classes.config.day2_cluster_config import BaseDay2ClusterConfig
+from assisted_test_infra.test_infra.helper_classes.config.base_day2_cluster_config import BaseDay2ClusterConfig
 from assisted_test_infra.test_infra.tools import static_network
 from assisted_test_infra.test_infra.utils.waiting import wait_till_all_hosts_are_in_status
 from service_client import log

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -287,7 +287,7 @@ class Day2Cluster(BaseCluster):
 
         for host in hosts:
             if host["status"] == "known":
-                self.api_client.install_day2_host(self._day1_cluster._infra_env_config.infra_env_id, host["id"])
+                self.api_client.install_day2_host(self._infra_env_config.infra_env_id, host["id"])
 
         log.info(
             f"Waiting until all nodes of cluster {self.id} have been installed (reached " "added-to-existing-cluster)",

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -24,11 +24,11 @@ from service_client.assisted_service_api import InventoryClient
 class Day2Cluster(BaseCluster):
     _config: BaseDay2ClusterConfig
 
-    def __init__(self, config: BaseDay2ClusterConfig, infra_env_config: BaseInfraEnvConfig, cluster: Cluster):
-        self._day1_cluster: Cluster = cluster
+    def __init__(self, config: BaseDay2ClusterConfig, infra_env_config: BaseInfraEnvConfig, day1_cluster: Cluster):
+        self._day1_cluster: Cluster = day1_cluster
         self._api_vip_ip = None
 
-        super().__init__(cluster.api_client, config, infra_env_config, cluster.nodes)
+        super().__init__(day1_cluster.api_client, config, infra_env_config, day1_cluster.nodes)
 
     def wait_until_hosts_are_discovered(self, allow_insufficient=False, nodes_count: int = None):
         statuses = [consts.NodesStatus.PENDING_FOR_INPUT, consts.NodesStatus.KNOWN]
@@ -43,7 +43,7 @@ class Day2Cluster(BaseCluster):
         )
 
     def _create(self) -> str:
-        if not self._day1_cluster.was_existed:
+        if not self._day1_cluster.is_installed:
             self._day1_cluster.prepare_for_installation()
             self._day1_cluster.start_install_and_wait_for_installed()
 

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -4,155 +4,101 @@ import os
 import subprocess
 import time
 import uuid
-from abc import ABC
 from typing import Any
 
 import waiting
+from junit_report import JunitTestCase
 
 import consts
-from assisted_test_infra.test_infra import BaseInfraEnvConfig, utils
+from assisted_test_infra.test_infra import BaseInfraEnvConfig, ClusterName, utils
+from assisted_test_infra.test_infra.helper_classes.base_cluster import BaseCluster
 from assisted_test_infra.test_infra.controllers import NodeController
-from assisted_test_infra.test_infra.helper_classes.config import BaseDay2ClusterConfig
+from assisted_test_infra.test_infra.helper_classes.cluster import Cluster
+from assisted_test_infra.test_infra.helper_classes.config.day2_cluster_config import BaseDay2ClusterConfig
 from assisted_test_infra.test_infra.tools import static_network
 from assisted_test_infra.test_infra.utils.waiting import wait_till_all_hosts_are_in_status
 from service_client import log
 from service_client.assisted_service_api import InventoryClient
 
 
-class Day2Cluster(ABC):
-    def __init__(
-        self, api_client: InventoryClient, config: BaseDay2ClusterConfig, infra_env_config: BaseInfraEnvConfig
-    ):
-        self.config = config
-        self.api_client = api_client
-        self._infra_env_config = infra_env_config
+class Day2Cluster(BaseCluster):
+    _config: BaseDay2ClusterConfig
 
-    def prepare_for_installation(self, iso_download_path: str = None):
-        utils.recreate_folder(consts.IMAGE_FOLDER, force_recreate=False)
+    def __init__(self, config: BaseDay2ClusterConfig, infra_env_config: BaseInfraEnvConfig, cluster: Cluster):
+        self._day1_cluster: Cluster = cluster
+        self._api_vip_ip = None
 
-        cluster = self.api_client.cluster_get(cluster_id=self.config.day1_cluster_id)
-        self.config.day1_cluster_name = cluster.name
-        openshift_version = cluster.openshift_version
-        api_vip_dnsname = "api." + self.config.day1_cluster_name + "." + cluster.base_dns_domain
-        api_vip_ip = cluster.api_vip
+        super().__init__(cluster.api_client, config, infra_env_config, cluster.nodes)
+
+    def wait_until_hosts_are_discovered(self, allow_insufficient=False, nodes_count: int = None):
+        statuses = [consts.NodesStatus.PENDING_FOR_INPUT, consts.NodesStatus.KNOWN]
+        if allow_insufficient:
+            statuses.append(consts.NodesStatus.INSUFFICIENT)
+        wait_till_all_hosts_are_in_status(
+            client=self.api_client,
+            cluster_id=self.id,
+            nodes_count=nodes_count or self.nodes.nodes_count,
+            statuses=statuses,
+            timeout=consts.NODES_REGISTERED_TIMEOUT,
+        )
+
+    def _create(self) -> str:
+        if not self._day1_cluster.was_existed:
+            self._day1_cluster.prepare_for_installation()
+            self._day1_cluster.start_install_and_wait_for_installed()
 
         openshift_cluster_id = str(uuid.uuid4())
-        params = {"openshift_version": openshift_version, "api_vip_dnsname": api_vip_dnsname}
-        cluster = self.api_client.create_day2_cluster(
-            self.config.day1_cluster_name + "-day2", openshift_cluster_id, **params
-        )
-        self.config.cluster_id = cluster.id
-        self.api_client.set_pull_secret(cluster.id, self.config.pull_secret)
-        self.set_cluster_proxy(cluster.id)
+        day1_cluster = self._day1_cluster.get_details()
 
-        self.config_etc_hosts(api_vip_ip, api_vip_dnsname)
+        self._api_vip_ip = day1_cluster.api_vip
+        api_vip_dnsname = "api." + self._day1_cluster.name + "." + day1_cluster.base_dns_domain
+        self._config.day1_cluster_name = day1_cluster.name
+        params = {"openshift_version": self._config.openshift_version, "api_vip_dnsname": api_vip_dnsname}
+        cluster = self.api_client.create_day2_cluster(self._day1_cluster.name + "-day2", openshift_cluster_id, **params)
+        self._config.cluster_id = cluster.id
 
-        self.config.tf_folder = os.path.join(
-            utils.TerraformControllerUtil.get_folder(self.config.day1_cluster_name), consts.Platforms.BARE_METAL
-        )
-        self.configure_terraform(self.config.tf_folder, self.config.day2_workers_count, api_vip_ip)
-
-        static_network_config = None
-        if self._infra_env_config.is_static_ip:
-            static_network_config = static_network.generate_day2_static_network_data_from_tf(
-                self.config.tf_folder, self.config.day2_workers_count
-            )
-
-        # Generate image
-        infra_env = self.api_client.create_infra_env(
-            cluster_id=cluster.id,
-            name=self.config.day1_cluster_name + "_infra-env",
-            ssh_public_key=self.config.ssh_public_key,
-            static_network_config=static_network_config,
-            pull_secret=self.config.pull_secret,
-            openshift_version=openshift_version,
-        )
-        self.config.infra_env_id = infra_env.id
-        # Download image
-        iso_download_url = infra_env.download_url
-        log.info(f"Downloading image {iso_download_url} to {iso_download_path}")
-
-        utils.download_file(iso_download_url, iso_download_path, False)
-
-    def start_install_and_wait_for_installed(self, libvirt_controller: NodeController):
-        cluster_name = self.config.day1_cluster_name
-        # Running twice as a workaround for an issue with terraform not spawning a new node on first apply.
-        for _ in range(2):
-            with utils.file_lock_context():
-                utils.run_command(
-                    f"make _apply_terraform CLUSTER_NAME={cluster_name} PLATFORM={consts.Platforms.BARE_METAL}"
-                )
-        time.sleep(5)
-
-        num_nodes_to_wait = self.config.day2_workers_count
-        installed_status = consts.NodesStatus.DAY2_INSTALLED
-
-        tfvars = utils.get_tfvars(self.config.tf_folder)
-        tf_network_name = tfvars["libvirt_network_name"]
-
-        libvirt_controller.wait_till_nodes_are_ready(network_name=tf_network_name)
-
-        # Wait for day2 nodes
-        waiting.wait(
-            lambda: self.are_libvirt_nodes_in_cluster_hosts(),
-            timeout_seconds=consts.NODES_REGISTERED_TIMEOUT,
-            sleep_seconds=10,
-            waiting_for="Nodes to be registered in inventory service",
-        )
-        self.set_nodes_hostnames_if_needed(tf_network_name)
-        wait_till_all_hosts_are_in_status(
-            client=self.api_client,
-            cluster_id=self.config.cluster_id,
-            nodes_count=self.config.day2_workers_count,
-            statuses=[consts.NodesStatus.KNOWN],
-            interval=30,
+        self._config.cluster_name = ClusterName(
+            prefix=self._day1_cluster._config.cluster_name.prefix,
+            suffix=self._day1_cluster._config.cluster_name.suffix + cluster.name.replace(day1_cluster.name, ""),
         )
 
-        # Start day2 nodes installation
-        log.info("Start installing all known nodes in the cluster %s", self.config.cluster_id)
-        kubeconfig = utils.get_kubeconfig_path(self.config.day1_cluster_name)
-        ocp_ready_nodes = self.get_ocp_cluster_ready_nodes_num(kubeconfig)
-        hosts = self.api_client.get_cluster_hosts(self.config.cluster_id)
-        [
-            self.api_client.install_day2_host(self.config.infra_env_id, host["id"])
-            for host in hosts
-            if host["status"] == "known"
-        ]
+        return cluster.id
 
-        log.info(
-            "Waiting until all nodes of cluster %s have been installed (reached added-to-existing-cluster)",
-            self.config.cluster_id,
-        )
-        wait_till_all_hosts_are_in_status(
-            client=self.api_client,
-            cluster_id=self.config.cluster_id,
-            nodes_count=num_nodes_to_wait,
-            statuses=[installed_status],
-            interval=30,
-        )
+    def update_existing(self) -> str:
+        return self._create()
 
-        log.info("Waiting until installed nodes has actually been added to the OCP cluster")
-        waiting.wait(
-            lambda: self.wait_nodes_join_ocp_cluster(ocp_ready_nodes, self.config.day2_workers_count, kubeconfig),
-            timeout_seconds=consts.NODES_REGISTERED_TIMEOUT,
-            sleep_seconds=30,
-            waiting_for="Day2 nodes to be added to OCP cluster",
-            expected_exceptions=Exception,
+    def prepare_for_installation(self):
+        self._config.day1_cluster_id = self._day1_cluster.id
+
+        day2_cluster = self.get_details()
+        self._config.cluster_id = day2_cluster.id
+        self._day1_cluster.set_pull_secret(self._config.pull_secret, cluster_id=day2_cluster.id)
+        self.set_cluster_proxy(day2_cluster.id)
+        self.config_etc_hosts(self._api_vip_ip, day2_cluster.api_vip_dns_name)
+
+        self.nodes.controller.tf_folder = os.path.join(
+            utils.TerraformControllerUtil.get_folder(self._day1_cluster.name), consts.Platforms.BARE_METAL
         )
-        log.info("%d worker nodes were successfully added to OCP cluster", self.config.day2_workers_count)
+        self.configure_terraform(self._config.day2_workers_count, self._api_vip_ip)
+        self._day1_cluster.download_image()
+        self.download_image(
+            iso_download_path=self._day1_cluster.iso_download_path,
+            static_network_config=self.nodes.controller.get_day2_static_network_data(),
+        )
 
     def set_cluster_proxy(self, cluster_id: str):
         """
         Set cluster proxy - copy proxy configuration from another (e.g. day 1) cluster,
         or allow setting/overriding it via command arguments
         """
-        if self.config.proxy:
-            http_proxy = self.config.proxy.http_proxy
-            https_proxy = self.config.proxy.https_proxy
-            no_proxy = self.config.proxy.no_proxy
+        if self._config.proxy:
+            http_proxy = self._config.proxy.http_proxy
+            https_proxy = self._config.proxy.https_proxy
+            no_proxy = self._config.proxy.no_proxy
             self.api_client.set_cluster_proxy(cluster_id, http_proxy, https_proxy, no_proxy)
 
-    def config_etc_hosts(self, api_vip_ip: str, api_vip_dnsname: str):
+    @classmethod
+    def config_etc_hosts(cls, api_vip_ip: str, api_vip_dnsname: str):
         with open("/etc/hosts", "r") as f:
             hosts_lines = f.readlines()
         for i, line in enumerate(hosts_lines):
@@ -164,14 +110,14 @@ class Day2Cluster(ABC):
         with open("/etc/hosts", "w") as f:
             f.writelines(hosts_lines)
 
-    def configure_terraform(self, tf_folder: str, num_worker_nodes: int, api_vip_ip: str):
-        tfvars = utils.get_tfvars(tf_folder)
+    def configure_terraform(self, num_worker_nodes: int, api_vip_ip: str):
+        tfvars = utils.get_tfvars(self.nodes.controller.tf_folder)
         self.configure_terraform_workers_nodes(tfvars, num_worker_nodes)
         tfvars["api_vip"] = api_vip_ip
-        utils.set_tfvars(tf_folder, tfvars)
+        utils.set_tfvars(self.nodes.controller.tf_folder, tfvars)
 
     def configure_terraform_workers_nodes(self, tfvars: Any, num_worker_nodes: int):
-        num_workers = tfvars["worker_count"] + num_worker_nodes
+        num_workers = num_worker_nodes
         tfvars["worker_count"] = num_workers
         self.set_workers_addresses_by_type(
             tfvars, num_worker_nodes, "libvirt_master_ips", "libvirt_worker_ips", "libvirt_worker_macs"
@@ -184,8 +130,9 @@ class Day2Cluster(ABC):
             "libvirt_secondary_worker_macs",
         )
 
+    @classmethod
     def set_workers_addresses_by_type(
-        self, tfvars: Any, num_worker_nodes: int, master_ip_type: str, worker_ip_type: str, worker_mac_type: str
+        cls, tfvars: Any, num_worker_nodes: int, master_ip_type: str, worker_ip_type: str, worker_mac_type: str
     ):
 
         old_worker_ips_list = tfvars[worker_ip_type]
@@ -212,38 +159,35 @@ class Day2Cluster(ABC):
         old_worker_mac_addresses = tfvars[worker_mac_type]
         tfvars[worker_mac_type] = old_worker_mac_addresses + static_network.generate_macs(num_worker_nodes)
 
-    def get_ocp_cluster_nodes(self, kubeconfig: str):
-        res = subprocess.check_output(f"oc --kubeconfig={kubeconfig} get nodes --output=json", shell=True)
-        return json.loads(res)["items"]
+    def wait_for_day2_nodes(self):
+        def are_libvirt_nodes_in_cluster_hosts() -> bool:
+            try:
+                hosts = self.api_client.get_cluster_hosts(self.id)
+            except BaseException:
+                log.exception(f"Failed to get cluster hosts: {self.id}")
+                return False
+            return len(hosts) >= self._config.day2_workers_count
 
-    def is_ocp_node_ready(self, node_status: any) -> bool:
-        if not node_status:
-            return False
-        for condition in node_status["conditions"]:
-            if condition["status"] == "True" and condition["type"] == "Ready":
-                return True
-        return False
+        waiting.wait(
+            lambda: are_libvirt_nodes_in_cluster_hosts(),
+            timeout_seconds=consts.NODES_REGISTERED_TIMEOUT,
+            sleep_seconds=10,
+            waiting_for="Nodes to be registered in inventory service",
+        )
 
-    def are_libvirt_nodes_in_cluster_hosts(self) -> bool:
-        try:
-            hosts = self.api_client.get_cluster_hosts(self.config.cluster_id)
-        except Exception:
-            log.exception("Failed to get cluster hosts: %s", self.config.cluster_id)
-            return False
-        return len(hosts) >= self.config.day2_workers_count
-
-    def set_nodes_hostnames_if_needed(self, network_name: str):
-        if self.config.is_ipv6 or self._infra_env_config.is_static_ip:
-            tf = utils.TerraformUtils(working_dir=self.config.tf_folder)
-            libvirt_nodes = utils.extract_nodes_from_tf_state(tf.get_state(), network_name, consts.NodeRoles.WORKER)
+    def set_nodes_hostnames_if_needed(self):
+        if self._config.is_ipv6 or self._config.is_static_ip:
+            tf_state = self.nodes.controller.tf.get_state()
+            network_name = self.nodes.controller.network_name
+            libvirt_nodes = utils.extract_nodes_from_tf_state(tf_state, network_name, consts.NodeRoles.WORKER)
             log.info(
-                "Set hostnames of day2 cluster %s in case of static network configuration or "
+                f"Set hostnames of day2 cluster {self.id} in case of static network configuration or "
                 "to work around libvirt for Terrafrom not setting hostnames of IPv6 hosts",
-                self.config.cluster_id,
             )
-            self.update_hosts(self.api_client, self.config.cluster_id, libvirt_nodes)
+            self.update_hosts(self.api_client, self.id, libvirt_nodes)
 
-    def update_hosts(self, client: InventoryClient, cluster_id: str, libvirt_nodes: dict):
+    @classmethod
+    def update_hosts(cls, client: InventoryClient, cluster_id: str, libvirt_nodes: dict):
         """
         Update names of the hosts in a cluster from a dictionary of libvirt nodes.
 
@@ -269,22 +213,103 @@ class Day2Cluster(ABC):
                         infra_env_id=host["infra_env_id"], host_id=host["id"], host_name=libvirt_metadata["name"]
                     )
 
-    def wait_nodes_join_ocp_cluster(self, num_orig_nodes: int, num_new_nodes: int, kubeconfig: Any) -> bool:
-        self.approve_workers_on_ocp_cluster(kubeconfig)
-        return self.get_ocp_cluster_ready_nodes_num(kubeconfig) == num_orig_nodes + num_new_nodes
+    @JunitTestCase()
+    def start_install_and_wait_for_installed(self):
+        # Running twice as a workaround for an issue with terraform not spawning a new node on first apply.
+        for _ in range(2):
+            with utils.file_lock_context():
+                res = utils.run_command(
+                    f"make _apply_terraform CLUSTER_NAME={self._day1_cluster.name} "
+                    f"PLATFORM={consts.Platforms.BARE_METAL}"
+                )
+                log.info(res[0])
+        time.sleep(5)
 
-    def get_ocp_cluster_ready_nodes_num(self, kubeconfig: Any) -> int:
-        nodes = self.get_ocp_cluster_nodes(kubeconfig)
-        return len([node for node in nodes if self.is_ocp_node_ready(node["status"])])
+        num_nodes_to_wait = self._config.day2_workers_count
+        installed_status = consts.NodesStatus.DAY2_INSTALLED
+        self.nodes.wait_till_nodes_are_ready()
 
-    def approve_workers_on_ocp_cluster(self, kubeconfig: Any):
-        csrs = self.get_ocp_cluster_csrs(kubeconfig)
+        self.wait_for_day2_nodes()
+        self.set_nodes_hostnames_if_needed()
+
+        wait_till_all_hosts_are_in_status(
+            client=self.api_client,
+            cluster_id=self._config.cluster_id,
+            nodes_count=self._config.day2_workers_count,
+            statuses=[consts.NodesStatus.KNOWN],
+            interval=30,
+        )
+
+        ocp_ready_nodes = self.get_ocp_cluster_ready_nodes_num()
+        self._install_day2_cluster(num_nodes_to_wait, installed_status)
+        self.wait_nodes_to_be_in_ocp(ocp_ready_nodes)
+
+    def wait_nodes_to_be_in_ocp(self, ocp_ready_nodes):
+        def wait_nodes_join_ocp_cluster(num_orig_nodes: int, num_new_nodes: int) -> bool:
+            self.approve_workers_on_ocp_cluster()
+            return self.get_ocp_cluster_ready_nodes_num() == num_orig_nodes + num_new_nodes
+
+        log.info("Waiting until installed nodes has actually been added to the OCP cluster")
+        waiting.wait(
+            lambda: wait_nodes_join_ocp_cluster(ocp_ready_nodes, self._config.day2_workers_count),
+            timeout_seconds=consts.NODES_REGISTERED_TIMEOUT,
+            sleep_seconds=30,
+            waiting_for="Day2 nodes to be added to OCP cluster",
+            expected_exceptions=Exception,
+        )
+        log.info(f"{self._config.day2_workers_count} worker nodes were successfully added to OCP cluster")
+
+    def approve_workers_on_ocp_cluster(self):
+        csrs = self.get_ocp_cluster_csrs(self._day1_cluster.kubeconfig_path)
         for csr in csrs:
             if not csr["status"]:
                 csr_name = csr["metadata"]["name"]
-                subprocess.check_output(f"oc --kubeconfig={kubeconfig} adm certificate approve {csr_name}", shell=True)
+                subprocess.check_output(
+                    f"oc --kubeconfig={self._day1_cluster.kubeconfig_path} adm certificate approve {csr_name}",
+                    shell=True,
+                )
                 log.info("CSR %s for node %s has been approved", csr_name, csr["spec"]["username"])
 
-    def get_ocp_cluster_csrs(self, kubeconfig: Any) -> Any:
+    @classmethod
+    def get_ocp_cluster_csrs(cls, kubeconfig: Any) -> Any:
         res = subprocess.check_output(f"oc --kubeconfig={kubeconfig} get csr --output=json", shell=True)
         return json.loads(res)["items"]
+
+    def _install_day2_cluster(self, num_nodes_to_wait: int, installed_status: str):
+        # Start day2 nodes installation
+        log.info(f"Start installing all known nodes in the cluster {self.id}")
+        hosts = self.api_client.get_cluster_hosts(self.id)
+
+        for host in hosts:
+            if host["status"] == "known":
+                self.api_client.install_day2_host(self._day1_cluster._infra_env_config.infra_env_id, host["id"])
+
+        log.info(
+            f"Waiting until all nodes of cluster {self.id} have been installed (reached " "added-to-existing-cluster)",
+        )
+
+        wait_till_all_hosts_are_in_status(
+            client=self.api_client,
+            cluster_id=self.id,
+            nodes_count=num_nodes_to_wait,
+            statuses=[installed_status],
+            interval=30,
+        )
+
+    def get_ocp_cluster_ready_nodes_num(self) -> int:
+        nodes = self.get_ocp_cluster_nodes(self._day1_cluster.kubeconfig_path)
+        return len([node for node in nodes if self.is_ocp_node_ready(node["status"])])
+
+    @classmethod
+    def get_ocp_cluster_nodes(cls, kubeconfig: str):
+        res = subprocess.check_output(f"oc --kubeconfig={kubeconfig} get nodes --output=json", shell=True)
+        return json.loads(res)["items"]
+
+    @classmethod
+    def is_ocp_node_ready(cls, node_status: any) -> bool:
+        if not node_status:
+            return False
+        for condition in node_status["conditions"]:
+            if condition["status"] == "True" and condition["type"] == "Ready":
+                return True
+        return False

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -81,9 +81,14 @@ class Day2Cluster(BaseCluster):
         )
         self.configure_terraform(self._config.day2_workers_count, self._api_vip_ip)
         self._day1_cluster.download_image()
+
+        static_network_config = None
+        if self._day1_cluster._infra_env_config.is_static_ip:
+            static_network_config = self.nodes.controller.get_day2_static_network_data()
+
         self.download_image(
             iso_download_path=self._day1_cluster.iso_download_path,
-            static_network_config=self.nodes.controller.get_day2_static_network_data(),
+            static_network_config=static_network_config,
         )
 
     def set_cluster_proxy(self, cluster_id: str):
@@ -176,7 +181,7 @@ class Day2Cluster(BaseCluster):
         )
 
     def set_nodes_hostnames_if_needed(self):
-        if self._config.is_ipv6 or self._config.is_static_ip:
+        if self._config.is_ipv6 or self._day1_cluster._infra_env_config.is_static_ip:
             tf_state = self.nodes.controller.tf.get_state()
             network_name = self.nodes.controller.network_name
             libvirt_nodes = utils.extract_nodes_from_tf_state(tf_state, network_name, consts.NodeRoles.WORKER)

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -122,8 +122,7 @@ class Day2Cluster(BaseCluster):
         utils.set_tfvars(self.nodes.controller.tf_folder, tfvars)
 
     def configure_terraform_workers_nodes(self, tfvars: Any, num_worker_nodes: int):
-        num_workers = num_worker_nodes
-        tfvars["worker_count"] = num_workers
+        tfvars["worker_count"] = tfvars["worker_count"] + num_worker_nodes
         self.set_workers_addresses_by_type(
             tfvars, num_worker_nodes, "libvirt_master_ips", "libvirt_worker_ips", "libvirt_worker_macs"
         )

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -308,7 +308,8 @@ class Day2Cluster(BaseCluster):
         )
 
     def get_ocp_cluster_ready_nodes_num(self) -> int:
-        nodes = self.get_ocp_cluster_nodes(self._day1_cluster.kubeconfig_path)
+        kubeconfig = utils.get_kubeconfig_path(self._config.day1_cluster_name)
+        nodes = self.get_ocp_cluster_nodes(kubeconfig)
         return len([node for node in nodes if self.is_ocp_node_ready(node["status"])])
 
     @classmethod

--- a/src/assisted_test_infra/test_infra/helper_classes/nodes.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/nodes.py
@@ -225,3 +225,6 @@ class Nodes:
 
     def _are_nodes_network_prepared(self):
         return all(node.macs and node.ips for node in self.nodes)
+
+    def wait_till_nodes_are_ready(self, network_name: str = None):
+        self.controller.wait_till_nodes_are_ready(network_name)

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -393,21 +393,13 @@ class BaseTest:
 
     @pytest.fixture
     @JunitFixtureTestCase()
-    def day2_cluster(
-        self,
-        api_client: InventoryClient,
-        request: FixtureRequest,
-        day2_cluster_configuration: Day2ClusterConfig,
-        infra_env_configuration: InfraEnvConfig,
-    ):
+    def day2_cluster(self, request: FixtureRequest, cluster: Cluster, day2_cluster_configuration: Day2ClusterConfig):
         log.debug(f"--- SETUP --- Creating Day2 cluster for test: {request.node.name}\n")
-        cluster = Day2Cluster(
-            api_client=api_client,
-            config=day2_cluster_configuration,
-            infra_env_config=infra_env_configuration,
+        day2_cluster = Day2Cluster(
+            config=day2_cluster_configuration, cluster=cluster, infra_env_config=InfraEnvConfig()
         )
 
-        yield cluster
+        yield day2_cluster
 
     @pytest.fixture
     @JunitFixtureTestCase()

--- a/src/tests/test_day2.py
+++ b/src/tests/test_day2.py
@@ -1,7 +1,6 @@
 from junit_report import JunitTestSuite
 
 from tests.base_test import BaseTest
-from tests.config import global_variables
 
 
 class TestDay2(BaseTest):
@@ -9,13 +8,6 @@ class TestDay2(BaseTest):
     # Install day1 cluster and deploy day2 nodes (cloud flow).
     # Or, deploy day2 nodes on an installed cluster if CLUSTER_ID env var is specified.
     @JunitTestSuite()
-    def test_deploy_day2_nodes_cloud(self, cluster, day2_cluster, controller):
-        if not global_variables.cluster_id:
-            cluster.nodes.destroy_all_nodes()
-            cluster.nodes.prepare_nodes()
-            cluster.prepare_for_installation()
-            cluster.start_install_and_wait_for_installed()
-
-        day2_cluster.config.day1_cluster_id = cluster.id
-        day2_cluster.prepare_for_installation(iso_download_path=cluster.get_iso_download_path())
-        day2_cluster.start_install_and_wait_for_installed(controller)
+    def test_deploy_day2_nodes_cloud(self, day2_cluster):
+        day2_cluster.prepare_for_installation()
+        day2_cluster.start_install_and_wait_for_installed()


### PR DESCRIPTION
Make common code between Day1 `Cluster` and `Day2Cluster` classes available in a new `BaseCluster` class

There are a lot of small hacks due to the fact that day2 cluster re-use the terraform stack of the day1 cluster, these hacks will disappear in a next PR where the day2 cluster will have its own terraform stack.