### PR TITLE
Setting minikube registry addon to use images from quay.io

### DIFF
--- a/scripts/hub-cluster/minikube.sh
+++ b/scripts/hub-cluster/minikube.sh
@@ -29,7 +29,7 @@ function _init_minikube() {
     for i in {1..5}
     do
         minikube delete
-        minikube start --driver=kvm2 --memory="${MINIKUBE_RAM_MB}" --cpus=4 --force --wait-timeout=15m0s --disk-size="${MINIKUBE_DISK_SIZE}" --addons=registry || true
+        minikube start --driver=kvm2 --memory="${MINIKUBE_RAM_MB}" --cpus=4 --force --wait-timeout=15m0s --disk-size="${MINIKUBE_DISK_SIZE}" || true
 
         if minikube status ; then
             break
@@ -40,6 +40,7 @@ function _init_minikube() {
     done
 
     minikube status
+    minikube addons enable registry --images="Registry=quay.io/libpod/registry:2.8"
     minikube update-context
     minikube tunnel --cleanup &> /dev/null &
 }


### PR DESCRIPTION
In local environments, we sometimes hit the rate-limitter of docker hub when doing a lot of ``make destroy run``. This is because the registry addon of minikube relies on images that are not in ghcr.io but from docker-hub.

This change uses images from quay.io for the registry, as a simple fix.