### PR TITLE
MGMT-13210: only pull relevant OS images

### DIFF
--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -29,6 +29,7 @@ export SERVICE_BASE_URL=${SERVICE_BASE_URL:-"http://${SERVICE_URL}:${SERVICE_POR
 export EXTERNAL_PORT=${EXTERNAL_PORT:-y}
 export OCP_SERVICE_PORT=$(( 7000 + $NAMESPACE_INDEX ))
 export OPENSHIFT_INSTALL_RELEASE_IMAGE=${OPENSHIFT_INSTALL_RELEASE_IMAGE:-}
+export OPENSHIFT_VERSIONS=${OPENSHIFT_VERSIONS:-}
 export ENABLE_KUBE_API=${ENABLE_KUBE_API:-false}
 export ENABLE_KUBE_API_CMD="ENABLE_KUBE_API=${ENABLE_KUBE_API}"
 export DEBUG_SERVICE_NAME=assisted-service-debug
@@ -58,15 +59,16 @@ fi
 mkdir -p build
 
 if [ "${OPENSHIFT_INSTALL_RELEASE_IMAGE}" != "" ]; then
-    export RELEASE_IMAGES=$(skipper run ./scripts/override_release_images.py --src ./assisted-service/data/default_release_images.json)
-    if [ -z "${OS_IMAGES:-}" ]; then
-        export OS_IMAGES=$(skipper run ./scripts/override_os_images.py --src ./assisted-service/data/default_os_images.json)
-    fi
+    RELEASE_IMAGES=$(skipper run ./scripts/override_release_images.py --src ./assisted-service/data/default_release_images.json)
+    export RELEASE_IMAGES
 
     if [ "${DEPLOY_TARGET}" == "onprem" ]; then
         (cd assisted-service; skipper make generate-configuration)
     fi
 fi
+
+OS_IMAGES=$(skipper run ./scripts/override_os_images.py --src ./assisted-service/data/default_os_images.json)
+export OS_IMAGES
 
 if [ "${DEPLOY_TARGET}" == "onprem" ]; then
     if [ -n "${INSTALLER_IMAGE:-}" ]; then

--- a/src/assisted_test_infra/test_infra/utils/release_image_utils.py
+++ b/src/assisted_test_infra/test_infra/utils/release_image_utils.py
@@ -1,8 +1,6 @@
 import json
 import logging
 
-import semver
-
 from assisted_test_infra.test_infra import utils
 
 
@@ -20,26 +18,6 @@ def extract_installer(release_image: str, dest: str):
             f"oc adm release extract --registry-config '{pull_secret}'"
             f" --command=openshift-install --to={dest} {release_image}"
         )
-
-
-def extract_version(release_image):
-    """
-    Extracts the version number from the release image.
-
-    Args:
-        release_image: The release image to extract the version from.
-    """
-    logging.info(f"Extracting version number from {release_image}")
-    with utils.pull_secret_file() as pull_secret:
-        stdout, _, _ = utils.run_command(
-            f"oc adm release info --registry-config '{pull_secret}' '{release_image}' -ojson"
-        )
-
-    ocp_full_version = json.loads(stdout).get("metadata", {}).get("version", "")
-    ocp_semver = semver.VersionInfo.parse(ocp_full_version)
-    ocp_version = f"{ocp_semver.major}.{ocp_semver.minor}"
-
-    return ocp_version
 
 
 def extract_rhcos_url_from_ocp_installer(installer_binary_path: str):

--- a/src/service_client/logger.py
+++ b/src/service_client/logger.py
@@ -95,7 +95,7 @@ def add_stream_handler(logger: logging.Logger):
     fmt = SensitiveFormatter(
         "%(asctime)s  %(name)s %(levelname)-10s - %(thread)d - %(message)s \t" "(%(pathname)s:%(lineno)d)"
     )
-    ch = ColorizingStreamHandler(sys.stdout)
+    ch = ColorizingStreamHandler(sys.stderr)
     ch.setFormatter(fmt)
     logger.addHandler(ch)
 


### PR DESCRIPTION
Currently we load all images from ``data/default_os_images.json`` in prow CI. It makes for a very long setup time for the image-service.

At least some of those images are not relevant to our CI at all, because we don't have a way to get the matching HW - namely the images for zSystems and PowerPC.

In addition, we don't need to load images for 4.8, 4.9, 4.10, etc. for most of the jobs as we rather use 4.11/4.12. So it should be beneficial to only load the relevant image based on existence of ``OPENSHIFT_VERSION`` or ``OPENSHIFT_INSTALL_RELEASE_IMAGE`` env-vars.