### PR TITLE
NO-ISSUE: disable dns in secondary network

### DIFF
--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -84,6 +84,9 @@ resource "libvirt_network" "secondary_net" {
   bridge    = var.libvirt_secondary_network_if
   addresses = var.provisioning_cidr_addresses
   autostart = true
+  dns {
+    enabled = false
+  }
 }
 
 module "masters" {


### PR DESCRIPTION
we don't want to resolve DNS through secondary network, thus disabling it.

It caused a flake in https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-day2-periodic/1614461188786098176