### PR TITLE
MGMT-13341: Use assisted service client wheel

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -51,7 +51,7 @@ COPY --from=quay.io/ocp-splat/govc:v0.29.0 /govc /usr/local/bin
 WORKDIR /home/assisted-test-infra
 
 COPY requirements.txt requirements-dev.txt ./
-COPY --from=service /clients/assisted-service-client-*.tar.gz /build/pip/
+COPY --from=service /clients/assisted_service_client-*.whl /build/pip/
 RUN pip3 install --upgrade pip && \
       pip3 install --no-cache-dir -I -r ./requirements.txt -r ./requirements-dev.txt && \
       pip3 install --upgrade /build/pip/*


### PR DESCRIPTION
Currently, the sdist version fails to install because of an update of
setuptools: https://github.com/pypa/setuptools/issues/3772.

The wheel is not affected by this change.

Depending on the outcome of the setuptools ticket, we may have to
follow-up to provide a valid version scheme for the sdist package (or
just remove it?).
