### PR TITLE
Revert "Bump terraform-provider-libvirt to v0.7.1"

### DIFF
--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.7.1"
+      version = "0.6.14"
     }
   }
 }

--- a/terraform_files/baremetal_host/main.tf
+++ b/terraform_files/baremetal_host/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.7.1"
+      version = "0.6.14"
     }
   }
 }

--- a/terraform_files/baremetal_infra_env/main.tf
+++ b/terraform_files/baremetal_infra_env/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.7.1"
+      version = "0.6.14"
     }
   }
 }

--- a/terraform_files/none/main.tf
+++ b/terraform_files/none/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.7.1"
+      version = "0.6.14"
     }
   }
 }


### PR DESCRIPTION
Reverts openshift/assisted-test-infra#1883

The new provider introduced a regression where DNS gets enabled by default on networks which causes DNS issues on some CI jobs, reverting until this is fixed upstream