### PR TITLE
Fix podman container names on gather

### DIFF
--- a/scripts/download_logs.sh
+++ b/scripts/download_logs.sh
@@ -25,7 +25,7 @@ function download_service_logs() {
     podman ps -a || true
 
     for service in "assisted-installer-db" "assisted-installer-image-service" "assisted-installer-service" "assisted-installer-ui"; do
-      podman logs ${service} >${LOGS_DEST}/logs_${service}_${DEPLOY_TARGET}.log || true
+      podman logs ${service} >${LOGS_DEST}/logs_${service}_${DEPLOY_TARGET}.log 2>&1 || true
     done
   else
     CRS=node,pod,svc,deployment,pv,pvc

--- a/scripts/download_logs.sh
+++ b/scripts/download_logs.sh
@@ -24,7 +24,7 @@ function download_service_logs() {
   if [ "${DEPLOY_TARGET:-}" = "onprem" ]; then
     podman ps -a || true
 
-    for service in "assisted-service" "assisted-image-service" "assisted-installer-ui" "postgres"; do
+    for service in "assisted-installer-db" "assisted-installer-image-service" "assisted-installer-service" "assisted-installer-ui"; do
       podman logs ${service} >${LOGS_DEST}/logs_${service}_${DEPLOY_TARGET}.log || true
     done
   else


### PR DESCRIPTION
For some reason, the names are not matching the actual container names used. It should be prefixed with ``assisted-installer`` (podman's pod name) and continue with the names ``db``, ``ui``, ``image-service`` and ``service``.
See:
https://github.com/openshift/assisted-service/blob/a1c6df56391b517f4bbf167ba841ffe040950ebd/deploy/podman/pod.yml#L8