### PR TITLE
MGMT-12477: Validate that cluster platform is exists in `supported_platforms` API call result

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -892,6 +892,7 @@ class Cluster(Entity):
     @JunitTestCase()
     def prepare_for_installation(self, **kwargs):
         super(Cluster, self).prepare_for_installation(is_static_ip=self._infra_env_config.is_static_ip, **kwargs)
+        assert self.get_details().platform.type in self.api_client.get_cluster_supported_platforms(self.id)
 
         self.nodes.wait_for_networking()
         self._set_hostnames_and_roles()

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -553,3 +553,6 @@ class InventoryClient(object):
     def get_vips_from_cluster(self, cluster_id: str) -> Dict[str, str]:
         cluster_info = self.cluster_get(cluster_id)
         return dict(api_vip=cluster_info.api_vip, ingress_vip=cluster_info.ingress_vip)
+
+    def get_cluster_supported_platforms(self, cluster_id: str) -> List[str]:
+        return self.client.get_cluster_supported_platforms(cluster_id)

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -349,6 +349,8 @@ class BaseTest:
             nodes=prepare_nodes_network,
         )
 
+        assert api_client.get_cluster_supported_platforms(cluster.id) == [consts.Platforms.NONE]
+
         if self._does_need_proxy_server(prepare_nodes_network):
             self.__set_up_proxy_server(cluster, cluster_configuration, proxy_server)
 


### PR DESCRIPTION
We do not call the `/v2/clusters/{cluster_id}/supported-platforms` during the installation and as a result we do not verify that the installed platform do exist in the `supported-platforms` list.

This PR adds 2 calls to that API with that expected results:

- When there are no hosts - platform should be none
- When hosts are exist, validate that the cluster.platform is exists in the supported platforms list.

/cc @osherdp @adriengentil 