### PR TITLE
MGMT-12996: fix os-override when no OCP version specified

### DIFF
--- a/scripts/override_os_images.py
+++ b/scripts/override_os_images.py
@@ -18,6 +18,9 @@ def get_os_image(os_images, ocp_version, cpu_architecture="x86_64"):
 
 
 def extract_version(release_image: str) -> str:
+    if not release_image:
+        return ""
+
     full_ocp_version = utils.extract_version(release_image)
     return f"{full_ocp_version.major}.{full_ocp_version.minor}"
 


### PR DESCRIPTION
In the case that the user didn't specified ``OPENSHIFT_VERSION`` nor ``OPENSHIFT_INSTALL_RELEASE_IMAGE``, we still try to extract the version of a ``None`` version.

This allows computation to continue so that we won't get the following case (when those two are not defined):
```
++ skipper run ./scripts/override_os_images.py --src
./assisted-service/data/default_os_images.json
[skipper] Using build container: assisted-test-infra:latest
+ OS_IMAGES='Traceback (most recent call last):
  File "/home/assisted-test-infra/./scripts/override_os_images.py", line
62, in <module>
    main()
  File "/home/assisted-test-infra/./scripts/override_os_images.py", line
45, in main
    or
extract_version(os.environ.get("OPENSHIFT_INSTALL_RELEASE_IMAGE"))
       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/assisted-test-infra/./scripts/override_os_images.py", line
21, in extract_version
    full_ocp_version = utils.extract_version(release_image)
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File
"/home/assisted-test-infra/src/assisted_test_infra/test_infra/utils/utils.py",
line 477, in extract_version
    stdout, _, _ = run_command(f"oc adm release info --registry-config
'\''{pull_secret}'\'' '\''{release_image}'\'' -ojson")
                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File
"/home/assisted-test-infra/src/assisted_test_infra/test_infra/utils/utils.py",
line 86, in run_command
    raise RuntimeError(f"command: {command} exited with an error: {err}
" f"code: {process.returncode}")
RuntimeError: command: ['\''oc'\'', '\''adm'\'', '\''release'\'',
'\''info'\'', '\''--registry-config'\'', '\''/tmp/tmph9uevoyz'\'',
'\'''\'', '\''-ojson'\''] exited with an error: error: "" is not a valid
image reference: repository name must have at least one component code:
1
```