### PR TITLE
MGMT-13438: Fix NetworkType trigger overrides parametrized values

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -120,6 +120,9 @@ class Cluster(Entity):
         if self._config.vip_dhcp_allocation is not None:
             extra_vars["vip_dhcp_allocation"] = self._config.vip_dhcp_allocation
 
+        if self._config.network_type is not None:
+            extra_vars["network_type"] = self._config.network_type
+
         cluster = self.api_client.create_cluster(
             self._config.cluster_name.get(),
             ssh_public_key=self._config.ssh_public_key,
@@ -130,7 +133,6 @@ class Cluster(Entity):
             user_managed_networking=self._config.user_managed_networking,
             high_availability_mode=self._config.high_availability_mode,
             olm_operators=[{"name": name} for name in self._config.olm_operators],
-            network_type=self._config.network_type,
             disk_encryption=disk_encryption,
             tags=self._config.cluster_tags or None,
             **extra_vars,

--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -89,7 +89,7 @@ class _EnvVariables(DataPool, ABC):
     master_cpu_mode: EnvVar = EnvVar(["MASTER_CPU_MODE"], default=env_defaults.DEFAULT_TF_CPU_MODE)
     iso_download_path: EnvVar = EnvVar(["ISO_DOWNLOAD_PATH", "ISO"])  # todo replace ISO env var->ISO_DOWNLOAD_PATH
     hyperthreading: EnvVar = EnvVar(["HYPERTHREADING"])
-    network_type: EnvVar = EnvVar(["NETWORK_TYPE"], default=env_defaults.DEFAULT_NETWORK_TYPE)
+    network_type: EnvVar = EnvVar(["NETWORK_TYPE"])
     disk_encryption_mode: EnvVar = EnvVar(["DISK_ENCRYPTION_MODE"], default=env_defaults.DEFAULT_DISK_ENCRYPTION_MODE)
     disk_encryption_roles: EnvVar = EnvVar(
         ["DISK_ENCRYPTION_ROLES"], default=env_defaults.DEFAULT_DISK_ENCRYPTION_ROLES

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -1,7 +1,6 @@
 from typing import Dict
 
 from frozendict import frozendict
-from packaging import version
 
 from consts import consts, resources
 from triggers.env_trigger import Trigger
@@ -33,11 +32,6 @@ _default_triggers = frozendict(
             user_managed_networking=True,
             master_memory=resources.DEFAULT_MASTER_SNO_MEMORY,
             master_vcpu=resources.DEFAULT_MASTER_SNO_CPU,
-            network_type=None,
-        ),
-        "let_service_choose_network_type": Trigger(
-            condition=lambda config: version.parse(config.openshift_version)
-            >= version.parse(consts.OpenshiftVersion.VERSION_4_12.value),
             network_type=None,
         ),
         "ipv4": Trigger(


### PR DESCRIPTION
 When running test with NetworkType set as parametrized and `OpenshiftVersion < 4.12, NetworkType` is set to None instead of the desired value 

e.g the following test will result creating cluster with NetowkType=None

```python
@pytest.mark.parametrize("network_type", [consts.NetworkType.OpenShiftSDN])
def test_install(self, cluster, network_type): 
    cluster.prepare_for_installation()
    cluster.start_install_and_wait_for_installed()
```

/cc @osherdp @adriengentil 