### PR TITLE
MGMT-13379: dedicated terraform stack for day2 cluster

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -174,8 +174,11 @@ class TerraformController(LibvirtController):
         tfvars["bootstrap_in_place"] = self._config.bootstrap_in_place
 
         vips = self.get_ingress_and_api_vips()
-        tfvars["api_vip"] = vips["api_vip"]
-        tfvars["ingress_vip"] = vips["ingress_vip"]
+        tfvars["api_vip"] = self._config.api_vip or vips["api_vip"]
+        tfvars["ingress_vip"] = self._config.ingress_vip or vips["ingress_vip"]
+        if self._config.base_cluster_domain:
+            tfvars["base_cluster_domain"] = self._config.base_cluster_domain
+
         tfvars["running"] = running
         tfvars["libvirt_master_macs"] = static_network.generate_macs(self._params.master_count)
         tfvars["libvirt_worker_macs"] = static_network.generate_macs(self._params.worker_count)
@@ -289,7 +292,7 @@ class TerraformController(LibvirtController):
 
     def _try_to_delete_nodes(self):
         log.info("Start running terraform delete")
-        self.tf.destroy()
+        self.tf.destroy(force=False)
 
     def destroy_all_nodes(self, delete_tf_folder=False):
         """Runs terraform destroy and then cleans it with virsh cleanup to delete

--- a/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
@@ -1,13 +1,18 @@
 from abc import ABC, abstractmethod
 from pathlib import Path
-from typing import Optional, Union
+from typing import Any, Optional, Union
 
 from assisted_service_client import models
 from junit_report import JunitTestCase
 
+import consts
 from assisted_test_infra.test_infra import BaseClusterConfig, BaseInfraEnvConfig, Nodes
+from assisted_test_infra.test_infra.controllers.node_controllers import Node
+from assisted_test_infra.test_infra.helper_classes.cluster_host import ClusterHost
 from assisted_test_infra.test_infra.helper_classes.entity import Entity
 from assisted_test_infra.test_infra.helper_classes.infra_env import InfraEnv
+from assisted_test_infra.test_infra.tools import static_network
+from assisted_test_infra.test_infra.utils.waiting import wait_till_all_hosts_are_in_status
 from service_client import InventoryClient, log
 
 
@@ -37,6 +42,20 @@ class BaseCluster(Entity, ABC):
 
     def get_details(self) -> Union[models.infra_env.InfraEnv, models.cluster.Cluster]:
         return self.api_client.cluster_get(self.id)
+
+    def delete(self):
+        self.deregister_infraenv()
+        if self.id:
+            self.api_client.delete_cluster(self.id)
+            self._config.cluster_id = None
+
+    def deregister_infraenv(self):
+        if self._infra_env:
+            self._infra_env.deregister()
+        self._infra_env = None
+
+    def cancel_install(self):
+        self.api_client.cancel_cluster_install(cluster_id=self.id)
 
     @abstractmethod
     def start_install_and_wait_for_installed(self, **kwargs):
@@ -103,3 +122,57 @@ class BaseCluster(Entity, ABC):
 
     def get_iso_download_path(self, iso_download_path: str = None):
         return iso_download_path or self._infra_env_config.iso_download_path
+
+    def set_hostnames_and_roles(self):
+        cluster_id = self.id
+        hosts = self.to_cluster_hosts(self.api_client.get_cluster_hosts(cluster_id))
+        nodes = self.nodes.get_nodes(refresh=True)
+
+        for host in hosts:
+            if host.has_hostname():
+                continue
+
+            name = self.find_matching_node_name(host, nodes)
+            assert name is not None, (
+                f"Failed to find matching node for host with mac address {host.macs()}"
+                f" nodes: {[(n.name, n.ips, n.macs) for n in nodes]}"
+            )
+            if self.nodes.nodes_count == 1:
+                role = None
+            else:
+                role = consts.NodeRoles.MASTER if consts.NodeRoles.MASTER in name else consts.NodeRoles.WORKER
+            self._infra_env.update_host(host_id=host.get_id(), host_role=role, host_name=name)
+
+    @staticmethod
+    def to_cluster_hosts(hosts: list[dict[str, Any]]) -> list[ClusterHost]:
+        return [ClusterHost(models.Host(**h)) for h in hosts]
+
+    def find_matching_node_name(self, host: ClusterHost, nodes: list[Node]) -> Union[str, None]:
+        # Looking for node matches the given host by its mac address (which is unique)
+        for node in nodes:
+            for mac in node.macs:
+                if mac.lower() in host.macs():
+                    return node.name
+
+        # IPv6 static ips
+        if self._infra_env_config.is_static_ip:
+            mappings = static_network.get_name_to_mac_addresses_mapping(self.nodes.controller.tf_folder)
+            for mac in host.macs():
+                for name, macs in mappings.items():
+                    if mac in macs:
+                        return name
+
+        return None
+
+    @JunitTestCase()
+    def wait_until_hosts_are_discovered(self, allow_insufficient=False, nodes_count: int = None):
+        statuses = [consts.NodesStatus.PENDING_FOR_INPUT, consts.NodesStatus.KNOWN]
+        if allow_insufficient:
+            statuses.append(consts.NodesStatus.INSUFFICIENT)
+        wait_till_all_hosts_are_in_status(
+            client=self.api_client,
+            cluster_id=self.id,
+            nodes_count=nodes_count or self.nodes.nodes_count,
+            statuses=statuses,
+            timeout=consts.NODES_REGISTERED_TIMEOUT,
+        )

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_day2_cluster_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_day2_cluster_config.py
@@ -1,13 +1,18 @@
 from abc import ABC
 from dataclasses import dataclass
 
+from assisted_service_client import models
+
+from assisted_test_infra.test_infra import helper_classes
 from assisted_test_infra.test_infra.helper_classes.config.base_cluster_config import BaseClusterConfig
 
 
 @dataclass
 class BaseDay2ClusterConfig(BaseClusterConfig, ABC):
-    day1_cluster_id: str = None
-    day1_cluster_name: str = None
+    day1_cluster: "helper_classes.cluster.Cluster" = None
+    day1_cluster_details: models.cluster.Cluster = None
+    day1_base_cluster_domain: str = None
+    day1_api_vip_dnsname: str = None
     day2_workers_count: int = None
     infra_env_id: str = None
     tf_folder: str = None

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_nodes_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_nodes_config.py
@@ -2,7 +2,7 @@ import warnings
 from abc import ABC
 from dataclasses import dataclass
 from pathlib import Path
-from typing import List
+from typing import List, Optional
 
 import consts
 
@@ -34,6 +34,10 @@ class BaseNodesConfig(BaseConfig, ABC):
     worker_disk_size_gib: str = None  # disk size in GB.
     worker_disk_count: int = None
     worker_boot_devices: List[str] = None
+
+    api_vip: Optional[str] = None
+    ingress_vip: Optional[str] = None
+    base_cluster_domain: Optional[str] = None
 
     network_mtu: int = None
     tf_platform: str = None  # todo - make all tf dependent platforms (e.g. vsphere, nutanix) inherit from BaseTerraformConfig  # noqa E501

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -1,8 +1,5 @@
-import ipaddress
 import json
-import os
 import subprocess
-import time
 import uuid
 from typing import Any
 
@@ -10,11 +7,10 @@ import waiting
 from junit_report import JunitTestCase
 
 import consts
-from assisted_test_infra.test_infra import BaseInfraEnvConfig, ClusterName, utils
+from assisted_test_infra.test_infra import BaseInfraEnvConfig, utils
 from assisted_test_infra.test_infra.helper_classes.base_cluster import BaseCluster
-from assisted_test_infra.test_infra.helper_classes.cluster import Cluster
 from assisted_test_infra.test_infra.helper_classes.config.base_day2_cluster_config import BaseDay2ClusterConfig
-from assisted_test_infra.test_infra.tools import static_network
+from assisted_test_infra.test_infra.helper_classes.nodes import Nodes
 from assisted_test_infra.test_infra.utils.waiting import wait_till_all_hosts_are_in_status
 from service_client import log
 from service_client.assisted_service_api import InventoryClient
@@ -23,77 +19,57 @@ from service_client.assisted_service_api import InventoryClient
 class Day2Cluster(BaseCluster):
     _config: BaseDay2ClusterConfig
 
-    def __init__(self, config: BaseDay2ClusterConfig, infra_env_config: BaseInfraEnvConfig, cluster: Cluster):
-        self._day1_cluster: Cluster = cluster
-        self._api_vip = None
+    def __init__(
+        self,
+        api_client: InventoryClient,
+        config: BaseDay2ClusterConfig,
+        infra_env_config: BaseInfraEnvConfig,
+        day2_nodes: Nodes,
+    ):
+        self._kubeconfig_path = utils.get_kubeconfig_path(config.day1_cluster.name)
+        self.name = config.cluster_name.get()
 
-        super().__init__(self._day1_cluster.api_client, config, infra_env_config, self._day1_cluster.nodes)
-
-        self._kubeconfig_path = utils.get_kubeconfig_path(self._config.day1_cluster_name)
-
-    def wait_until_hosts_are_discovered(self, allow_insufficient=False, nodes_count: int = None):
-        statuses = [consts.NodesStatus.PENDING_FOR_INPUT, consts.NodesStatus.KNOWN]
-        if allow_insufficient:
-            statuses.append(consts.NodesStatus.INSUFFICIENT)
-        wait_till_all_hosts_are_in_status(
-            client=self.api_client,
-            cluster_id=self.id,
-            nodes_count=nodes_count or self.nodes.nodes_count,
-            statuses=statuses,
-            timeout=consts.NODES_REGISTERED_TIMEOUT,
-        )
+        super().__init__(api_client, config, infra_env_config, day2_nodes)
 
     def _create(self) -> str:
-        if not self._day1_cluster.is_installed:
-            self._day1_cluster.prepare_for_installation()
-            self._day1_cluster.start_install_and_wait_for_installed()
-
         openshift_cluster_id = str(uuid.uuid4())
-        day1_cluster = self._day1_cluster.get_details()
+        params = {
+            "openshift_version": self._config.openshift_version,
+            "api_vip_dnsname": self._config.day1_api_vip_dnsname,
+        }
 
-        self._api_vip = day1_cluster.api_vip
-        api_vip_dnsname = "api." + self._day1_cluster.name + "." + day1_cluster.base_dns_domain
-        self._config.day1_cluster_name = day1_cluster.name
-        params = {"openshift_version": self._config.openshift_version, "api_vip_dnsname": api_vip_dnsname}
-        cluster = self.api_client.create_day2_cluster(self._day1_cluster.name + "-day2", openshift_cluster_id, **params)
+        cluster = self.api_client.create_day2_cluster(self.name, openshift_cluster_id, **params)
+
         self._config.cluster_id = cluster.id
-
-        self._config.cluster_name = ClusterName(
-            prefix=self._day1_cluster._config.cluster_name.prefix,
-            suffix=self._day1_cluster._config.cluster_name.suffix + cluster.name.replace(day1_cluster.name, ""),
-        )
-
         return cluster.id
 
     def update_existing(self) -> str:
-        return self._create()
+        raise NotImplementedError("Creating Day2Cluster object from an existing cluster is not implemented.")
 
     def prepare_for_installation(self):
-        self._config.day1_cluster_id = self._day1_cluster.id
+        """Prepare the day2 worker nodes. When this method finishes, the hosts are in 'known' status."""
 
-        day2_cluster = self.get_details()
-        self._config.cluster_id = day2_cluster.id
-        self._day1_cluster.set_pull_secret(self._config.pull_secret, cluster_id=day2_cluster.id)
-        self.set_cluster_proxy(day2_cluster.id)
-        self.config_etc_hosts(self._api_vip, day2_cluster.api_vip_dns_name)
+        self.set_pull_secret(self._config.pull_secret)
+        self.set_cluster_proxy()
+        self.config_etc_hosts(self._config.day1_cluster_details.api_vip, self._config.day1_api_vip_dnsname)
 
-        self.nodes.controller.tf_folder = os.path.join(
-            utils.TerraformControllerUtil.get_folder(self._day1_cluster.name), consts.Platforms.BARE_METAL
+        # spawn VMs
+        super(Day2Cluster, self).prepare_for_installation(
+            is_static_ip=self._config.day1_cluster._infra_env_config.is_static_ip
         )
-        self.configure_terraform()
-        self._day1_cluster.download_image()
+        self.nodes.wait_for_networking()
+        self.set_hostnames_and_roles()
 
-        static_network_config = None
-        if self._day1_cluster._infra_env_config.is_static_ip:
-            static_network_config = self.nodes.controller.get_day2_static_network_data()
-
-        tfvars = utils.get_tfvars(self.nodes.controller.tf_folder)
-        self.download_image(
-            iso_download_path=tfvars["worker_image_path"],
-            static_network_config=static_network_config,
+        # wait for host to be known
+        wait_till_all_hosts_are_in_status(
+            client=self.api_client,
+            cluster_id=self._config.cluster_id,
+            nodes_count=self._config.day2_workers_count,
+            statuses=[consts.NodesStatus.KNOWN],
+            interval=30,
         )
 
-    def set_cluster_proxy(self, cluster_id: str):
+    def set_cluster_proxy(self):
         """
         Set cluster proxy - copy proxy configuration from another (e.g. day 1) cluster,
         or allow setting/overriding it via command arguments
@@ -102,10 +78,10 @@ class Day2Cluster(BaseCluster):
             http_proxy = self._config.proxy.http_proxy
             https_proxy = self._config.proxy.https_proxy
             no_proxy = self._config.proxy.no_proxy
-            self.api_client.set_cluster_proxy(cluster_id, http_proxy, https_proxy, no_proxy)
+            self.api_client.set_cluster_proxy(self.id, http_proxy, https_proxy, no_proxy)
 
-    @classmethod
-    def config_etc_hosts(cls, api_vip: str, api_vip_dnsname: str):
+    @staticmethod
+    def config_etc_hosts(api_vip: str, api_vip_dnsname: str):
         with open("/etc/hosts", "r") as f:
             hosts_lines = f.readlines()
         for i, line in enumerate(hosts_lines):
@@ -117,145 +93,10 @@ class Day2Cluster(BaseCluster):
         with open("/etc/hosts", "w") as f:
             f.writelines(hosts_lines)
 
-    def configure_terraform(self):
-        """
-        Use same terraform as the one used to spawn the day1 cluster,
-        update the variables accordingly in order to spawn the day2 worker nodes.
-        """
-        tfvars = utils.get_tfvars(self.nodes.controller.tf_folder)
-        self.configure_terraform_workers_nodes(tfvars)
-        tfvars["api_vip"] = self._api_vip
-        tfvars["running"] = True
-        utils.set_tfvars(self.nodes.controller.tf_folder, tfvars)
-
-    def configure_terraform_workers_nodes(self, tfvars: Any):
-        num_worker_nodes = self._config.day2_workers_count
-        tfvars["worker_count"] = tfvars["worker_count"] + num_worker_nodes
-        self.set_workers_addresses_by_type(
-            tfvars, num_worker_nodes, "libvirt_master_ips", "libvirt_worker_ips", "libvirt_worker_macs"
-        )
-        self.set_workers_addresses_by_type(
-            tfvars,
-            num_worker_nodes,
-            "libvirt_secondary_master_ips",
-            "libvirt_secondary_worker_ips",
-            "libvirt_secondary_worker_macs",
-        )
-
-    @classmethod
-    def set_workers_addresses_by_type(
-        cls, tfvars: Any, num_worker_nodes: int, master_ip_type: str, worker_ip_type: str, worker_mac_type: str
-    ):
-        old_worker_ips_list = tfvars[worker_ip_type]
-        last_master_addresses = tfvars[master_ip_type][-1]
-
-        if last_master_addresses:
-            if old_worker_ips_list:
-                worker_starting_ip = ipaddress.ip_address(old_worker_ips_list[-1][0])
-            else:
-                worker_starting_ip = ipaddress.ip_address(last_master_addresses[0])
-
-            worker_ips_list = old_worker_ips_list + utils.create_ip_address_nested_list(
-                num_worker_nodes, worker_starting_ip + 1
-            )
-        else:
-            log.info(
-                "IPv6-only environment. IP addresses are left empty and will be allocated by libvirt "
-                "DHCP because of a bug in Terraform plugin"
-            )
-            worker_ips_list = old_worker_ips_list + utils.create_empty_nested_list(num_worker_nodes)
-
-        tfvars[worker_ip_type] = worker_ips_list
-
-        old_worker_mac_addresses = tfvars[worker_mac_type]
-        tfvars[worker_mac_type] = old_worker_mac_addresses + static_network.generate_macs(num_worker_nodes)
-
-    def wait_for_day2_nodes(self):
-        def are_libvirt_nodes_in_cluster_hosts() -> bool:
-            try:
-                hosts = self.api_client.get_cluster_hosts(self.id)
-            except BaseException:
-                log.exception(f"Failed to get cluster hosts: {self.id}")
-                return False
-            return len(hosts) >= self._config.day2_workers_count
-
-        waiting.wait(
-            lambda: are_libvirt_nodes_in_cluster_hosts(),
-            timeout_seconds=consts.NODES_REGISTERED_TIMEOUT,
-            sleep_seconds=10,
-            waiting_for="Nodes to be registered in inventory service",
-        )
-
-    def set_nodes_hostnames_if_needed(self):
-        if self._config.is_ipv6 or self._day1_cluster._infra_env_config.is_static_ip:
-            tf_state = self.nodes.controller.tf.get_state()
-            network_name = self.nodes.controller.network_name
-            libvirt_nodes = utils.extract_nodes_from_tf_state(tf_state, network_name, consts.NodeRoles.WORKER)
-            log.info(
-                f"Set hostnames of day2 cluster {self.id} in case of static network configuration or "
-                "to work around libvirt for Terrafrom not setting hostnames of IPv6 hosts",
-            )
-            self.update_hosts(self.api_client, self.id, libvirt_nodes)
-
-    @classmethod
-    def update_hosts(cls, client: InventoryClient, cluster_id: str, libvirt_nodes: dict):
-        """
-        Update names of the hosts in a cluster from a dictionary of libvirt nodes.
-
-        An entry from the dictionary is matched to a host by the host's MAC address (of any NIC).
-        Entries that do not match any host in the cluster are ignored.
-
-        Args:
-            client: An assisted service client
-            cluster_id: ID of the cluster to update
-            libvirt_nodes: A dictionary that may contain data about cluster hosts
-        """
-        inventory_hosts = client.get_cluster_hosts(cluster_id)
-
-        for libvirt_mac, libvirt_metadata in libvirt_nodes.items():
-            for host in inventory_hosts:
-                inventory = json.loads(host["inventory"])
-
-                if libvirt_mac.lower() in map(
-                    lambda interface: interface["mac_address"].lower(),
-                    inventory["interfaces"],
-                ):
-                    client.update_host(
-                        infra_env_id=host["infra_env_id"], host_id=host["id"], host_name=libvirt_metadata["name"]
-                    )
-
     @JunitTestCase()
     def start_install_and_wait_for_installed(self):
-        # Running twice as a workaround for an issue with terraform not spawning a new node on first apply.
-        for _ in range(2):
-            with utils.file_lock_context():
-                res = utils.run_command(
-                    f"make _apply_terraform CLUSTER_NAME={self._day1_cluster.name} "
-                    f"PLATFORM={consts.Platforms.BARE_METAL}"
-                )
-                log.info(res[0])
-        time.sleep(5)
-
-        num_nodes_to_wait = self._config.day2_workers_count
-        installed_status = consts.NodesStatus.DAY2_INSTALLED
-
-        # make sure we use the same network as defined in the terraform stack
-        tfvars = utils.get_tfvars(self.nodes.controller.tf_folder)
-        self.nodes.wait_till_nodes_are_ready(network_name=tfvars["libvirt_network_name"])
-
-        self.wait_for_day2_nodes()
-        self.set_nodes_hostnames_if_needed()
-
-        wait_till_all_hosts_are_in_status(
-            client=self.api_client,
-            cluster_id=self._config.cluster_id,
-            nodes_count=self._config.day2_workers_count,
-            statuses=[consts.NodesStatus.KNOWN],
-            interval=30,
-        )
-
         ocp_ready_nodes = self.get_ocp_cluster_ready_nodes_num()
-        self._install_day2_cluster(num_nodes_to_wait, installed_status)
+        self._install_day2_cluster()
         self.wait_nodes_to_be_in_ocp(ocp_ready_nodes)
 
     def wait_nodes_to_be_in_ocp(self, ocp_ready_nodes):
@@ -284,12 +125,12 @@ class Day2Cluster(BaseCluster):
                 )
                 log.info("CSR %s for node %s has been approved", csr_name, csr["spec"]["username"])
 
-    @classmethod
-    def get_ocp_cluster_csrs(cls, kubeconfig: Any) -> Any:
+    @staticmethod
+    def get_ocp_cluster_csrs(kubeconfig: Any) -> Any:
         res = subprocess.check_output(f"oc --kubeconfig={kubeconfig} get csr --output=json", shell=True)
         return json.loads(res)["items"]
 
-    def _install_day2_cluster(self, num_nodes_to_wait: int, installed_status: str):
+    def _install_day2_cluster(self):
         # Start day2 nodes installation
         log.info(f"Start installing all known nodes in the cluster {self.id}")
         hosts = self.api_client.get_cluster_hosts(self.id)
@@ -305,8 +146,8 @@ class Day2Cluster(BaseCluster):
         wait_till_all_hosts_are_in_status(
             client=self.api_client,
             cluster_id=self.id,
-            nodes_count=num_nodes_to_wait,
-            statuses=[installed_status],
+            nodes_count=self._config.day2_workers_count,
+            statuses=[consts.NodesStatus.DAY2_INSTALLED],
             interval=30,
         )
 
@@ -314,13 +155,13 @@ class Day2Cluster(BaseCluster):
         nodes = self.get_ocp_cluster_nodes(self._kubeconfig_path)
         return len([node for node in nodes if self.is_ocp_node_ready(node["status"])])
 
-    @classmethod
-    def get_ocp_cluster_nodes(cls, kubeconfig: str):
+    @staticmethod
+    def get_ocp_cluster_nodes(kubeconfig: str):
         res = subprocess.check_output(f"oc --kubeconfig={kubeconfig} get nodes --output=json", shell=True)
         return json.loads(res)["items"]
 
-    @classmethod
-    def is_ocp_node_ready(cls, node_status: any) -> bool:
+    @staticmethod
+    def is_ocp_node_ready(node_status: any) -> bool:
         if not node_status:
             return False
         for condition in node_status["conditions"]:

--- a/terraform_files/baremetal/variables-libvirt.tf
+++ b/terraform_files/baremetal/variables-libvirt.tf
@@ -255,3 +255,9 @@ variable "libvirt_dns_records" {
   description = "DNS records to be added to the libvirt network"
   default     = {}
 }
+
+variable "base_cluster_domain" {
+  type        = string
+  description = "Set base cluster domain. Defaults to <cluster_name>.<cluster_domain> if left unset."
+  default     = ""
+}


### PR DESCRIPTION
In the scope of testing heterogeneous clusters, the day2 cluster must use
its own terraform stack. To implement that, I updated the code to create
day2 clusters in the same way we create day1 clusters, using the fixtures.