### PR TITLE
MGMT-13476: Tune dnf to download packages faster

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -12,6 +12,10 @@ RUN chmod g+w /etc/passwd && \
     echo 'echo default:x:$(id -u):$(id -g):Default Application User:/alabama:/sbin/nologin\ >> /etc/passwd' > /usr/local/bin/fix_uid.sh && \
     chmod g+rwx /usr/local/bin/fix_uid.sh
 
+# tune dnf to download more packages in parallel and from the closest mirror
+RUN echo "fastestmirror=1" >> /etc/dnf/dnf.conf && \
+    echo "max_parallel_downloads=10" >> /etc/dnf/dnf.conf
+
 # CRB repo is required for libvirt-devel
 RUN dnf -y install --enablerepo=crb \
   make \

--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -306,7 +306,21 @@ function additional_configs() {
     sudo firewall-cmd --zone=libvirt --add-port=7500/tcp
 }
 
+function config_dnf() {
+    echo "Tune dnf configuration"
+    local dnf_config_file="/etc/dnf/dnf.conf"
+
+    if ! grep -q "fastestmirror" "${dnf_config_file}"; then
+        echo "fastestmirror=1" | sudo tee --append "${dnf_config_file}"
+    fi
+
+    if ! grep -q "max_parallel_downloads" "${dnf_config_file}"; then
+        echo "max_parallel_downloads=10" | sudo tee --append "${dnf_config_file}"
+    fi
+}
+
 if [ $# -eq 0 ]; then
+    config_dnf
     config_additional_modules
     install_packages
     install_libvirt


### PR DESCRIPTION
Enable fastestmirror and increase max_parallel_downloads to 10. As a
side effect, we have a chance to select different mirrors from time to
time, which should mitigate issues with the default mirrors.
