### PR TITLE
[release-ocm-2.7] Backport fix_uid.sh script

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -7,6 +7,11 @@ ENV TOOLS=/tools/
 ENV PATH="$TOOLS:$PATH"
 RUN mkdir $TOOLS --mode g+xw
 
+# TODO: Remove once OpenShift CI supports it out of the box (see https://access.redhat.com/articles/4859371)
+RUN chmod g+w /etc/passwd && \
+    echo 'echo default:x:$(id -u):$(id -g):Default Application User:/alabama:/sbin/nologin\ >> /etc/passwd' > /usr/local/bin/fix_uid.sh && \
+    chmod g+rwx /usr/local/bin/fix_uid.sh
+
 # CRB repo is required for libvirt-devel
 RUN dnf -y install --enablerepo=crb \
   make \


### PR DESCRIPTION
Backport selectively fix_uid.sh script that was introduced in a larger PR: https://github.com/openshift/assisted-test-infra/pull/1949

Should fix vsphere and nutanix jobs depending on it in `release-ocm-2.7`
branch: https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-release-ocm-2.7-e2e-vsphere-assisted-kube-api-periodic/1617673768342130688