### PR TITLE
[release-ocm-2.7] Update default tag for index and service

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -42,9 +42,9 @@ CONTAINER_RUNTIME_COMMAND := $(or ${CONTAINER_COMMAND}, ${CONTAINER_RUNTIME_COMM
 LINT_CODE_STYLING_DIRS := src/tests src/triggers src/assisted_test_infra/test_infra src/assisted_test_infra/download_logs src/service_client src/consts src/virsh_cleanup src/cli
 
 # assisted-service
-SERVICE := $(or $(SERVICE), quay.io/edge-infrastructure/assisted-service:latest)
+SERVICE := $(or $(SERVICE), quay.io/edge-infrastructure/assisted-service:ocm-2.7)
 SERVICE_NAME := $(or $(SERVICE_NAME),assisted-service)
-INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/edge-infrastructure/assisted-service-index:latest)
+INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/edge-infrastructure/assisted-service-index:ocm-2.7)
 REMOTE_SERVICE_URL := $(or $(REMOTE_SERVICE_URL), "")
 
 # terraform


### PR DESCRIPTION
`e2e-metal-assisted-ha-kube-api-ipv6`, `e2e-metal-assisted-kube-api-late-binding-single-node`  and `e2e-metal-assisted-kube-api-late-unbinding-single-node` jobs are currently permafailing.

I suspect it's because the index not being aligned with branch version.