### PR TITLE
Use sudo when installing oc client

### DIFF
--- a/scripts/install_k8s_clients.sh
+++ b/scripts/install_k8s_clients.sh
@@ -23,7 +23,7 @@ function install_oc() {
 
     echo "Installing oc..."
     for i in {1..4}; do
-        curl --retry 3 -SL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.12/openshift-client-linux.tar.gz | tar -xz -C /usr/local/bin && break
+        curl --retry 3 -SL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.12/openshift-client-linux.tar.gz | sudo tar -xz -C /usr/local/bin && break
         echo "oc installation failed. Retrying again in 5 seconds..."
         sleep 5
     done


### PR DESCRIPTION
use sudo for installation of oc clients to prevent permission denied errors