### PR TITLE
NO-ISSUE: Fix parsing olm operator env var list

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/operators_utils.py
+++ b/src/assisted_test_infra/test_infra/utils/operators_utils.py
@@ -15,10 +15,6 @@ def get_env(env, default=None):
     return res
 
 
-def parse_olm_operators_from_env():
-    return get_env("OLM_OPERATORS", default="").lower().split()
-
-
 def _are_operators_in_status(
     cluster_id: str,
     client: InventoryClient,

--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -1,4 +1,5 @@
 import json
+import re
 from abc import ABC
 from dataclasses import dataclass
 from distutils.util import strtobool
@@ -63,7 +64,9 @@ class _EnvVariables(DataPool, ABC):
     ai_base_version: EnvVar = EnvVar(["AI_BASE_VERSION"], default=consts.DEFAULT_AI_BASE_VERSION)
     deployment_service: EnvVar = EnvVar(["DEPLOYMENT_SERVICE"], default=consts.DEFAULT_DEPLOYMENT_SERVICE)
     spoke_namespace: str = EnvVar(["SPOKE_NAMESPACE"], default=consts.DEFAULT_SPOKE_NAMESPACE)
-    olm_operators: EnvVar = EnvVar(["OLM_OPERATORS"], loader=lambda operators: operators.lower().split(), default="")
+    olm_operators: EnvVar = EnvVar(
+        ["OLM_OPERATORS"], loader=lambda operators: re.split(r"\s|,", operators.lower()), default=[]
+    )
     platform: EnvVar = EnvVar(["PLATFORM"])
     tf_platform: EnvVar = EnvVar(["TF_PLATFORM", "PLATFORM"], default=env_defaults.DEFAULT_PLATFORM)
     user_managed_networking: EnvVar = EnvVar(


### PR DESCRIPTION
Allow to pass multiple OLM operators using environment variables 
e.g.
```bash
OLM_OPERATORS=lvm,cnv make test
```
or
```bash
OLM_OPERATORS=lvm cnv make test
```

/cc @osherdp @adriengentil 