### PR TITLE
Revert "Makefile: _destroy_terraform should actually run terraform"

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -212,14 +212,10 @@ _apply_terraform:
 		cd build/terraform/$(CLUSTER_NAME)/$(PLATFORM) && \
 		terraform apply -auto-approve -input=false -state=terraform.tfstate -state-out=terraform.tfstate -var-file=terraform.tfvars.json
 
-_destroy_terraform:
-	cd build/terraform/$(CLUSTER_NAME)/$(PLATFORM) && \
-	terraform destroy -auto-approve -input=false -state=terraform.tfstate -state-out=terraform.tfstate -var-file=terraform.tfvars.json
-
 destroy_nodes:
-	skipper make $(SKIPPER_PARAMS) _destroy_virsh _destroy_terraform
+	skipper make $(SKIPPER_PARAMS) _destroy_terraform
 
-_destroy_virsh:
+_destroy_terraform:
 	python3 ${DEBUG_FLAGS} -m virsh_cleanup -f test-infra
 
 #######


### PR DESCRIPTION
Reverts openshift/assisted-test-infra#2027

This breaks few other innocent jobs and doesn't work on vsphere/nutanix 