### PR TITLE
terraform: save tfvars json in build dir

### DIFF
--- a/src/assisted_test_infra/test_infra/tools/terraform_utils.py
+++ b/src/assisted_test_infra/test_infra/tools/terraform_utils.py
@@ -33,7 +33,7 @@ class TerraformUtils:
         self.tf = _Terraform(
             working_dir=working_dir,
             state=consts.TFSTATE_FILE,
-            var_file=consts.TFVARS_JSON_NAME,
+            var_file=self.var_file_path,
             is_env_vars_included=True,
         )
 


### PR DESCRIPTION
When filename is passed to var_file it would put it in /tmp dir. We want tfvars files to be persistent in build dir so that terraform destroy in teardown step could them, otherwise it would be discarded as we're now running in a different skipper container