### PR TITLE
Add test which destroys targets via terraform

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,10 +217,16 @@ _destroy_terraform:
 	terraform destroy -auto-approve -input=false -state=terraform.tfstate -state-out=terraform.tfstate -var-file=terraform.tfvars.json
 
 destroy_nodes:
-	skipper make $(SKIPPER_PARAMS) _destroy_virsh _destroy_terraform
+	skipper make $(SKIPPER_PARAMS) _destroy_virsh _destroy_terraform_controller
 
 _destroy_virsh:
 	python3 ${DEBUG_FLAGS} -m virsh_cleanup -f test-infra
+
+destroy_terraform_controller:
+	TEST=./src/tests/test_targets.py TEST_FUNC=test_destroy_terraform $(MAKE) test
+
+destroy_nutanix: destroy_terraform_controller
+destroy_vsphere: destroy_terraform_controller
 
 #######
 # Run #

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -40,6 +40,9 @@ class TerraformController(LibvirtController):
         warnings.warn("cluster_name is deprecated. Use Controller.entity_name instead.", DeprecationWarning)
         return self._entity_name.get()
 
+    def get_all_vars(self):
+        return {**self._config.get_all(), **self._entity_config.get_all(), "cluster_name": self.cluster_name}
+
     def _get_params_from_config(self) -> Munch:
         return self._terraform_params(**self._config.get_all())
 

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
@@ -22,25 +22,28 @@ class VSphereController(NodeController):
         super().__init__(config, cluster_config)
         self.cluster_name = cluster_config.cluster_name.get()
         folder = TerraformControllerUtil.create_folder(self.cluster_name, platform=config.tf_platform)
-        self._tf = terraform_utils.TerraformUtils(working_dir=folder, terraform_init=False)
+        self.tf = terraform_utils.TerraformUtils(working_dir=folder, terraform_init=False)
+
+    def get_all_vars(self):
+        return {**self._config.get_all(), **self._entity_config.get_all(), "cluster_name": self.cluster_name}
 
     def prepare_nodes(self):
         if not os.path.exists(self._entity_config.iso_download_path):
             utils.recreate_folder(os.path.dirname(self._entity_config.iso_download_path), force_recreate=False)
             # if file not exist lets create dummy
             utils.touch(self._entity_config.iso_download_path)
-        config = {**self._config.get_all(), **self._entity_config.get_all(), "cluster_name": self.cluster_name}
+        config = self.get_all_vars()
         # The ISO file isn't available now until preparing for installation
         del config["iso_download_path"]
 
         self._create_folder(self._config.vsphere_parent_folder)
-        self._tf.set_and_apply(**config)
+        self.tf.set_and_apply(**config)
         return self.list_nodes()
 
     def notify_iso_ready(self) -> None:
         self.shutdown_all_nodes()
-        config = {**self._config.get_all(), **self._entity_config.get_all(), "cluster_name": self.cluster_name}
-        self._tf.set_and_apply(**config)
+        config = self.get_all_vars()
+        self.tf.set_and_apply(**config)
 
     def list_nodes(self) -> List[Node]:
         vms = self.__get_vms()
@@ -72,7 +75,7 @@ class VSphereController(NodeController):
         return ips, macs
 
     def destroy_all_nodes(self) -> None:
-        self._tf.destroy(force=False)
+        self.tf.destroy(force=False)
 
     def start_node(self, node_name: str, check_ips: bool) -> None:
         def start(vm) -> task:
@@ -194,7 +197,7 @@ class VSphereController(NodeController):
         return next((vm for vm in self.__get_vms() if vm["attributes"]["name"] == node_name), None)
 
     def __get_vms(self) -> List[Dict[str, Any]]:
-        vms_object_type = self._tf.get_resources(resource_type="vsphere_virtual_machine")
+        vms_object_type = self.tf.get_resources(resource_type="vsphere_virtual_machine")
 
         if not vms_object_type:
             return list()

--- a/src/assisted_test_infra/test_infra/tools/terraform_utils.py
+++ b/src/assisted_test_infra/test_infra/tools/terraform_utils.py
@@ -65,9 +65,12 @@ class TerraformUtils:
             log.error(message)
             raise Exception(message)
 
-    def set_and_apply(self, refresh: bool = True, **kwargs) -> None:
+    def set_vars(self, **kwargs) -> None:
         defined_variables = self.select_defined_variables(**kwargs)
         self.update_variables_file(defined_variables)
+
+    def set_and_apply(self, refresh: bool = True, **kwargs) -> None:
+        self.set_vars(**kwargs)
         self.init_tf()
         self.apply(refresh=refresh)
 

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -338,6 +338,17 @@ class BaseTest:
 
         return TerraformController(controller_configuration, entity_config=cluster_configuration)
 
+    def get_terraform_controller(
+        self, controller_configuration: BaseNodesConfig, cluster_configuration: ClusterConfig
+    ) -> TerraformController:
+        if cluster_configuration.platform == consts.Platforms.VSPHERE:
+            return VSphereController(controller_configuration, cluster_configuration)
+
+        if cluster_configuration.platform == consts.Platforms.NUTANIX:
+            return NutanixController(controller_configuration, cluster_configuration)
+
+        return TerraformController(controller_configuration, entity_config=cluster_configuration)
+
     @pytest.fixture
     def day2_controller(
         self, day2_cluster_configuration: Day2ClusterConfig, day2_controller_configuration: BaseNodesConfig


### PR DESCRIPTION
terraform.tfvars.json is generated on the flight and not stored on the file system.

After gather steps we call 'test_destroy_terraform' test to fetch active clusters, regenerate terraform.tfvars.json and run terraform destroy using python interface.

This fixes deprovision for terraform-controlled platforms - Nutanix and VSphere