### PR TITLE
NO-ISSUE: update libvirt hook to be lighter

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -127,9 +127,7 @@ function allow_libvirt_cross_network_traffic() {
 #!/usr/bin/env sh
 (
     flock 3
-    iptables-save -c | egrep -v 'LIBVIRT_FW[IO] .* REJECT' >/tmp/iptables.txt
-    iptables-restore </tmp/iptables.txt
-    rm /tmp/iptables.txt
+    iptables -S | grep -E "LIBVIRT_FW[IO] .* REJECT" | sed 's/^-A/iptables -D/g' | sh
 ) 3>/tmp/iptables.lock
 EOF
     sudo chmod +x "${hook_filename}"


### PR DESCRIPTION
At some point of time, my machine was consuming 100% CPU on
iptables-restore/iptables-save and I had to reboot the machine to
recover it.

This change deletes only the rules that need to be deleted instead of
doing a full save/restore of all iptables rules. I expect this process
to be lighter.
