### PR TITLE
MGMT-12442: Sync iso images between heterogeneous hosts

### DIFF
--- a/ansible_files/ansible.cfg
+++ b/ansible_files/ansible.cfg
@@ -1,4 +1,4 @@
 [defaults]
 host_key_checking = False
 remote_tmp = /tmp/ansible
-verbosity = 3
+verbosity = 2

--- a/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
+++ b/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
@@ -74,3 +74,27 @@
   hosts: secondary[0]
   roles:
     - name: common/setup_libvirtd
+
+- name: Create directory were boot ISO will be placed
+  hosts: heterogeneous
+  vars:
+    iso_images_shared_directory: "/tmp/test_images" # value of IMAGE_FOLDER in test-infra
+  tasks:
+    - name: Create shared directory {{ iso_images_shared_directory }}
+      ansible.builtin.file:
+        path: "{{ iso_images_shared_directory }}"
+        state: directory
+        mode: '0755'
+
+    - name: Set shared directory as fact
+      ansible.builtin.set_fact:
+        iso_images_shared_directory: "{{ iso_images_shared_directory }}"
+
+- name: Setup shared filesystem to sync boot ISO images between hosts
+  hosts: primary[0]
+  roles:
+    - name: common/setup_sftp_share
+      vars:
+        rclone_remote_name: "iso-images"
+        remote_host_ip: "{{ hostvars[groups['secondary'][0]].access_private_ipv4 }}"
+        shared_directory: "{{ iso_images_shared_directory }}"

--- a/ansible_files/roles/common/setup_sftp_share/defaults/main.yml
+++ b/ansible_files/roles/common/setup_sftp_share/defaults/main.yml
@@ -1,0 +1,4 @@
+ssh_user: root
+rclone_config_file: /etc/rclone.conf
+rclone_remote_name: share_dir
+rclone_type_sftp: sftp

--- a/ansible_files/roles/common/setup_sftp_share/tasks/main.yml
+++ b/ansible_files/roles/common/setup_sftp_share/tasks/main.yml
@@ -1,0 +1,41 @@
+- name: Install EPEL
+  ansible.builtin.dnf:
+    enablerepo: powertools
+    name:
+      - epel-release
+
+- name: Install fuse and rclone
+  ansible.builtin.dnf:
+    enablerepo: powertools
+    name:
+      - fuse
+      - rclone
+    update_cache: true # as we enabled EPEL previously
+    state: present
+
+- name: Create rclone configuration
+  ansible.builtin.command:
+    cmd: >-
+      rclone config create
+        --non-interactive
+        --config {{ rclone_config_file }}
+        {{ rclone_remote_name }}
+        {{ rclone_type_sftp }}
+        host={{ remote_host_ip }}
+        user={{ ssh_user }}
+        key_file={{ ssh_private_key_path }}
+    creates: "{{ rclone_config_file }}"
+
+- name: Create systemd service file to mount share on {{ shared_directory }}
+  ansible.builtin.template:
+    src: "rclone.service.j2"
+    dest: "/etc/systemd/system/rclone-{{ rclone_remote_name }}.service"
+    owner: "{{ ansible_user_id }}"
+    group: "{{ ansible_user_gid }}"
+    mode: '0655'
+
+- name: Mount the share on {{ shared_directory }}
+  ansible.builtin.systemd:
+    state: restarted
+    daemon_reload: true
+    name: "rclone-{{ rclone_remote_name }}"

--- a/ansible_files/roles/common/setup_sftp_share/templates/rclone.service.j2
+++ b/ansible_files/roles/common/setup_sftp_share/templates/rclone.service.j2
@@ -1,0 +1,19 @@
+[Unit]
+Description=rclone: Remote FUSE filesystem for cloud storage config {{ rclone_config_file }}
+Documentation=man:rclone(1)
+After=network-online.target
+Wants=network-online.target
+
+[Service]
+Type=notify
+ExecStart=rclone mount \
+            --config {{ rclone_config_file }} \
+            --allow-other \
+            --log-level INFO \
+            --stats 1m \
+            --stats-one-line \
+            {{ rclone_remote_name }}:{{ shared_directory }} {{ shared_directory }}
+ExecStop=fusermount -u {{ shared_directory }}
+
+[Install]
+WantedBy=default.target

--- a/ansible_files/roles/common/setup_ssh_key_pair/defaults/main.yml
+++ b/ansible_files/roles/common/setup_ssh_key_pair/defaults/main.yml
@@ -1,1 +1,1 @@
-cluster_ssh_private_key_path: "~/.ssh/id_cluster"
+ssh_private_key_path: "~/.ssh/id_cluster"

--- a/ansible_files/roles/common/setup_ssh_key_pair/tasks/main.yml
+++ b/ansible_files/roles/common/setup_ssh_key_pair/tasks/main.yml
@@ -1,14 +1,14 @@
 - name: Generate an OpenSSH keypair
-  local_action:
-    module: community.crypto.openssh_keypair
-    path: /tmp/{{ cluster_ssh_private_key_path | basename }}
+  community.crypto.openssh_keypair:
+    path: /tmp/{{ ssh_private_key_path | basename }}
+  delegate_to: localhost
   register: ssh_key_pair
   run_once: true
 
 - name: Copy private key to remote host
-  copy:
+  ansible.builtin.copy:
     src: "{{ ssh_key_pair.filename }}"
-    dest: "{{ cluster_ssh_private_key_path }}"
+    dest: "{{ ssh_private_key_path }}"
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
     mode: '0600'
@@ -26,3 +26,7 @@
     owner: "{{ ansible_user_id }}"
     group: "{{ ansible_user_gid }}"
     mode: '0600'
+
+- name: Set ssh_private_key_path as fact
+  ansible.builtin.set_fact:
+    ssh_private_key_path: "{{ ssh_private_key_path }}"

--- a/ansible_files/roles/common/setup_ssh_key_pair/templates/config.j2
+++ b/ansible_files/roles/common/setup_ssh_key_pair/templates/config.j2
@@ -4,7 +4,7 @@ host {{ hostvars[host].inventory_hostname }}
     {% set private_ips = hostvars[host].ansible_all_ipv4_addresses | sort | ansible.utils.ipaddr('private') -%}
     Hostname {{ private_ips | first | default(hostvars[host].ansible_all_ipv4_addresses[0]) }}
     User {{ hostvars[host].ansible_user }}
-    IdentityFile {{ cluster_ssh_private_key_path }}
+    IdentityFile {{ ssh_private_key_path }}
     StrictHostKeyChecking no
 
 {% endfor %}


### PR DESCRIPTION
Create a shared mount between the heterogenous hosts, so when the ISO image is downloaded on the primary, the secondary (ARM machine) hosts as also access to it automatically.

This changes creates a new role to setup the sshfs mount, fixes some linter issues in the ssh role and lower the ansible log level.