### PR TITLE
MGMT-12442: Setup libvirt hook on ARM machine

### DIFF
--- a/ansible_files/roles/common/setup_libvirtd/files/allow-cross-network-traffic.sh
+++ b/ansible_files/roles/common/setup_libvirtd/files/allow-cross-network-traffic.sh
@@ -1,0 +1,5 @@
+#!/usr/bin/env sh
+(
+    flock 3
+    iptables -S | grep -E "LIBVIRT_FW[IO] .* REJECT" | sed -e 's/^-A/iptables -D/g' -e 's/$/ || true/g' | sh
+) 3>/tmp/iptables.lock

--- a/ansible_files/roles/common/setup_libvirtd/handlers/main.yml
+++ b/ansible_files/roles/common/setup_libvirtd/handlers/main.yml
@@ -1,4 +1,4 @@
-- name: Start libvirtd service
+- name: Restart libvirtd service
   ansible.builtin.systemd:
     name: libvirtd.service
-    state: started
+    state: restarted

--- a/ansible_files/roles/common/setup_libvirtd/tasks/main.yml
+++ b/ansible_files/roles/common/setup_libvirtd/tasks/main.yml
@@ -4,4 +4,20 @@
       - libvirt-daemon-kvm
     state: present
   notify:
-    - Start libvirtd service
+    - Restart libvirtd service
+
+- name: Create libvirt network hook directory
+  ansible.builtin.file:
+    path: /etc/libvirt/hooks/network.d
+    state: directory
+    mode: '0755'
+
+- name: Install libvirt network hook to allow cross network traffic
+  ansible.builtin.copy:
+    src: allow-cross-network-traffic.sh
+    dest: /etc/libvirt/hooks/network.d/allow-cross-network-traffic.sh
+    owner: root
+    group: root
+    mode: '0755'
+  notify:
+    - Restart libvirtd service

--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -1,6 +1,8 @@
 #!/bin/bash
 set -euo pipefail
 
+SCRIPT_DIR=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 export EXTERNAL_PORT=${EXTERNAL_PORT:-y}
 export ADD_USER_TO_SUDO=${ADD_USER_TO_SUDO:-n}
 readonly PODMAN_MINIMUM_VERSION="3.2.0"
@@ -120,16 +122,14 @@ function allow_libvirt_cross_network_traffic() {
     # HUB cluster located in another libvirt network (e.g.: to retrieve the
     # rootfs).
     echo "Installing libvirt network hook to allow cross network traffic"
+
+    hook_src="${SCRIPT_DIR}/../ansible_files/roles/common/setup_libvirtd/files/allow-cross-network-traffic.sh"
+
     hook_dir="/etc/libvirt/hooks/network.d"
     hook_filename="${hook_dir}/allow-cross-network-traffic.sh"
     sudo mkdir -p "${hook_dir}"
-    sudo tee "${hook_filename}" << EOF
-#!/usr/bin/env sh
-(
-    flock 3
-    iptables -S | grep -E "LIBVIRT_FW[IO] .* REJECT" | sed -e 's/^-A/iptables -D/g' -e 's/$/ || true/g' | sh
-) 3>/tmp/iptables.lock
-EOF
+
+    sudo cp "${hook_src}" "${hook_filename}"
     sudo chmod +x "${hook_filename}"
 }
 


### PR DESCRIPTION
The libvirt hook is required on the secondary (aka ARM) host in order to
allow traffic with the libvirt hosts on the primary machine.
