### PR TITLE
MGMT-13642: bump python-libvirt library to handle build failure

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jedi==0.18.2
 Jinja2===3.1.2
 junit-report==0.2.7
 kubernetes==25.3.0
-libvirt-python==8.10.0
+libvirt-python==9.0.0
 munch==2.5.0
 netaddr==0.8.0
 netifaces==0.11.0


### PR DESCRIPTION
When trying to build assisted-test-infra container image, it fails for the following error:
```
  × Running setup.py install for libvirt-python did not run
successfully.
  │ exit code: 1
  ╰─> [38 lines of output]
      running install
      running build
      running build_py
      Missing type converters:
      int *:1
      ERROR: failed virDomainFDAssociate
...
```

Apparently it was fixed by
https://gitlab.com/libvirt/libvirt-python/-/tags/v9.0.0 so this bumps the library version.