### PR TITLE
NO-ISSUE: Best effort deletion of iptables rules

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -127,7 +127,7 @@ function allow_libvirt_cross_network_traffic() {
 #!/usr/bin/env sh
 (
     flock 3
-    iptables -S | grep -E "LIBVIRT_FW[IO] .* REJECT" | sed 's/^-A/iptables -D/g' | sh
+    iptables -S | grep -E "LIBVIRT_FW[IO] .* REJECT" | sed -e 's/^-A/iptables -D/g' -e 's/$/ || true/g' | sh
 ) 3>/tmp/iptables.lock
 EOF
     sudo chmod +x "${hook_filename}"


### PR DESCRIPTION
From time to time, the hook can fail with the following error:

```
Error: error creating libvirt domain: Hook script execution failed:
internal error: Child process (LC_ALL=C
PATH=/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin
/etc/libvirt/hooks/network test-infra-net-b4cf9b98 port-created begin -)
unexpected exit status 1: iptables: Bad rule (does a matching rule exist
in that chain?).
```

It is likekly due to rules being deleted between the time we list the
rules and the time we try to delete them in the hook.

This change makes the deletion of the rules best-effort.

x-ref: https://ci-jenkins-csb-kniqe.apps.ocp-c1.prod.psi.redhat.com/job/ocp-assisted-installer-virt-tf/5991/testReport/test_proxy/TestProxy/Run_assisted_installer_Functional_API_Tests___test_incorrect_http_proxy_values_http_proxy_params0_OCP_35294_/
