### PR TITLE
MGMT-12442: Use arm plan to run heterogeneous test

### DIFF
--- a/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
+++ b/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
@@ -84,6 +84,17 @@
       ansible.builtin.import_role:
         name: common/setup_ipip_tunnel
 
+- name: Check tunnel connectivity
+  hosts: all
+  tasks:
+    - name: Ping peer
+      ansible.builtin.command:
+        cmd: "ping -c 1 -w 2 {{ ipip_tunnel_ipv4 | ansible.utils.ipaddr('peer') }}"
+      retries: 10
+      delay: 1
+      register: result
+      until: result.rc == 0
+
 - name: Share a unique SSH key pair among the created devices
   hosts: heterogeneous
   roles:
@@ -115,7 +126,7 @@
     - name: common/setup_sftp_share
       vars:
         rclone_remote_name: "iso-images"
-        remote_host_ip: "{{ hostvars[groups['secondary'][0]].access_private_ipv4 }}"
+        remote_host_ip: "{{ ipip_tunnel_ipv4 | ansible.utils.ipaddr('peer') }}"
         shared_directory: "{{ iso_images_shared_directory }}"
 
 - name: Export day2 heterogeneous configuration to assisted-test-infra
@@ -126,4 +137,5 @@
         name: test-infra/export-heterogeneous-day2-configuration
       delegate_to: localhost
       vars:
-        assisted_service_url: "{{ hostvars[groups['primary'][0]].access_private_ipv4 }}"
+        assisted_service_url: "{{ ipip_tunnel_ipv4 | ansible.utils.ipaddr('peer') }}"
+        access_libvirt_ip: "{{ ipip_tunnel_ipv4 | ansible.utils.ipv4('address') }}"

--- a/ansible_files/roles/common/setup_ipip_tunnel/tasks/main.yml
+++ b/ansible_files/roles/common/setup_ipip_tunnel/tasks/main.yml
@@ -14,4 +14,5 @@
     ip4: "{{ ipip_tunnel_ipv4 }}"
     routes4: "{{ ipip_route_to_network_ipv4 }} {{ ipip_tunnel_ipv4 | ansible.utils.ipaddr('peer') }}"
     autoconnect: true
+    zone: "trusted"
     state: present

--- a/ansible_files/roles/equinix/export_primary_device_connection_details/files/fix-uid.sh
+++ b/ansible_files/roles/equinix/export_primary_device_connection_details/files/fix-uid.sh
@@ -1,0 +1,16 @@
+# Ensure our UID, which is randomly generated, is in /etc/passwd. This is required
+# to be able to SSH.
+if ! whoami &> /dev/null; then
+    if [ -x "$(command -v nss_wrapper.pl)" ]; then
+        grep -v -e ^default -e ^$(id -u) /etc/passwd > "/tmp/passwd"
+        echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> "/tmp/passwd"
+        export LD_PRELOAD=libnss_wrapper.so
+        export NSS_WRAPPER_PASSWD=/tmp/passwd
+        export NSS_WRAPPER_GROUP=/etc/group
+    elif [[ -w /etc/passwd ]]; then
+        echo "${USER_NAME:-default}:x:$(id -u):0:${USER_NAME:-default} user:${HOME}:/sbin/nologin" >> "/etc/passwd"
+    else
+        echo "No nss wrapper, /etc/passwd is not writeable, and user matching this uid is not found."
+        exit 1
+    fi
+fi

--- a/ansible_files/roles/equinix/export_primary_device_connection_details/files/packet-conf.sh
+++ b/ansible_files/roles/equinix/export_primary_device_connection_details/files/packet-conf.sh
@@ -1,0 +1,4 @@
+source "${SHARED_DIR}/fix-uid.sh"
+source "${SHARED_DIR}/ci-machine-config.sh"
+
+export SSHOPTS=(-o 'ConnectTimeout=5' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -o 'ServerAliveInterval=90' -o LogLevel=ERROR -i "${SSH_KEY_FILE}")

--- a/ansible_files/roles/equinix/export_primary_device_connection_details/tasks/main.yml
+++ b/ansible_files/roles/equinix/export_primary_device_connection_details/tasks/main.yml
@@ -3,9 +3,21 @@
     msg: Group primary must exits and contain exactly 1 host
   when: groups[primary_device_group_name] is not defined or (groups[primary_device_group_name] | length != 1)
 
-- name: "Export connection details of primary device"
-  ansible.builtin.template:
-    src: "ci-machine-config.sh.j2"
-    dest: "{{ shared_dir }}/ci-machine-config.sh"
-    mode: 0644
+- block:
+  - name: "Export connection details of primary device"
+    ansible.builtin.template:
+      src: "ci-machine-config.sh.j2"
+      dest: "{{ shared_dir }}/ci-machine-config.sh"
+      mode: 0644
+
+  - name: Write fix uid file
+    ansible.builtin.copy:
+      src: fix-uid.sh
+      dest: "{{ shared_dir }}/fix-uid.sh"
+
+  - name: Write Packet common configuration file
+    ansible.builtin.copy:
+      src: packet-conf.sh
+      dest: "{{ shared_dir }}/packet-conf.sh"
+
   when: shared_dir is defined

--- a/ansible_files/roles/equinix/heterogeneous_create_infra/defaults/main.yaml
+++ b/ansible_files/roles/equinix/heterogeneous_create_infra/defaults/main.yaml
@@ -3,7 +3,7 @@ secondary_device_group_name: "secondary"
 equinix_ssh_user: "root"
 equinix_plans: "{{
       {
-       primary_device_group_name : 'c3.small.x86',
-       secondary_device_group_name : 'c3.small.x86'
+       primary_device_group_name : 'c3.medium.x86',
+       secondary_device_group_name : 'c3.large.arm64'
       }
   }}"

--- a/ansible_files/roles/test-infra/export-heterogeneous-day2-configuration/templates/assisted-additional-config.j2
+++ b/ansible_files/roles/test-infra/export-heterogeneous-day2-configuration/templates/assisted-additional-config.j2
@@ -1,10 +1,8 @@
 export SERVICE_URL="{{ assisted_service_url }}"
 
-export DAY2_CPU_ARCHITECTURE="{{ ansible_architecture  }}"
+export DAY2_CPU_ARCHITECTURE="{{ ansible_architecture }}"
 
-{% set private_ips = ansible_all_ipv4_addresses | sort | ansible.utils.ipaddr('private') -%}
-{% set remote_ip = private_ips | first | default(ansible_all_ipv4_addresses[0]) -%}
-export DAY2_LIBVIRT_URI="qemu+ssh://{{ ssh_user }}@{{ remote_ip }}/system?keyfile={{ ssh_private_key_path }}"
+export DAY2_LIBVIRT_URI="qemu+ssh://{{ ssh_user }}@{{ access_libvirt_ip }}/system?no_verify=1&keyfile={{ ssh_private_key_path }}"
 
 {# split prefix (e.g: /20) into /24 subnets -#}
 {% set subnet_size_ipv4 = internal_network_prefix_ipv4 | ansible.utils.ipsubnet(subnet_length_ipv4)  -%}

--- a/terraform_files/equinix-ci-machine/main.tf
+++ b/terraform_files/equinix-ci-machine/main.tf
@@ -27,7 +27,10 @@ resource "equinix_metal_device" "ci_devices" {
 
   provisioner "remote-exec" {
     inline = [
-      "cloud-init status --wait"
+      # Wait for cloud-init to complete.
+      # Ignore any errors because some equinix machines fail in cloud-init but
+      # it is without consequenses.
+      "cloud-init status --wait || true"
     ]
   }
 }


### PR DESCRIPTION
Few tactical changes to made the e2e test to work:
- Add `packet-setup.sh` to make it compatible with `assisted-baremetal-*` steps (should be cleaned up once [MGMT-11816](https://issues.redhat.com/browse/MGMT-11816) is implemented)
- `cloud-init status --wait` should always pass because cloud-init always fails with `c3.large.arm64` (reported to Equinix)
- Add a check that pings the tunnel ips to ensure the tunnel is setup properly
- [workaround] Use the tunnel ip has much a possible (rclone, virsh) to allow the secondary machine to reach the primary machine, it's probably due to firewalld installed with test-infra, but I don't see any misconfiguration