### PR TITLE
Fix ssh waiter - catch SSHException

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/nodes.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/nodes.py
@@ -4,6 +4,7 @@ from typing import Dict, Iterator, List
 
 import waiting
 from munch import Munch
+from paramiko import SSHException
 from scp import SCPException
 
 import consts
@@ -238,7 +239,7 @@ class Nodes:
                 for node in self.nodes:
                     if node.ssh_connection is None:
                         return False
-            except (TimeoutError, SCPException):
+            except (TimeoutError, SCPException, SSHException):
                 return False
             return True
 


### PR DESCRIPTION
During test_proxy we hit on SSHException("Invalid key") parmiko tries to connect , looks like re-try when hit on failures with differnt method on failure, we should catch ssh exception and hanlde it to make the waiter return bool value