### PR TITLE
MGMT-12442: Make service URL cutomizable

### DIFF
--- a/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
+++ b/ansible_files/equinix_heterogeneous_create_infra_playbook.yml
@@ -125,3 +125,5 @@
       ansible.builtin.import_role:
         name: test-infra/export-heterogeneous-day2-configuration
       delegate_to: localhost
+      vars:
+        assisted_service_url: "{{ hostvars[groups['primary'][0]].access_private_ipv4 }}"

--- a/ansible_files/roles/test-infra/export-heterogeneous-day2-configuration/templates/assisted-additional-config.j2
+++ b/ansible_files/roles/test-infra/export-heterogeneous-day2-configuration/templates/assisted-additional-config.j2
@@ -1,3 +1,5 @@
+export SERVICE_URL="{{ assisted_service_url }}"
+
 export DAY2_CPU_ARCHITECTURE="{{ ansible_architecture  }}"
 
 {% set private_ips = ansible_all_ipv4_addresses | sort | ansible.utils.ipaddr('private') -%}

--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -8,13 +8,13 @@ export SERVICE_NAME=assisted-service
 
 case ${DEPLOY_TARGET} in
     kind)
-        export SERVICE_URL=$(hostname)
+        export SERVICE_URL=${SERVICE_URL:-$(hostname)}
         export SERVICE_PORT=80
         export IMAGE_SERVICE_PORT=80
         export EXTERNAL_PORT=no
         ;;
     *)
-        export SERVICE_URL=$(get_main_ip)
+        export SERVICE_URL=${SERVICE_URL:-$(get_main_ip)}
         export SERVICE_PORT=$(( 6000 + $NAMESPACE_INDEX ))
         export IMAGE_SERVICE_PORT=$(( 6016 + $NAMESPACE_INDEX ))
         ;;


### PR DESCRIPTION
In the context of heterogeneous cluster, we want the service URL to
target the private IP of the primary Equinix machine in order to pull
the ingnition from the secondary machine.
