### PR TITLE
MGMT-12442: Fix DHCP limit range XSLT

### DIFF
--- a/terraform_files/limit_ip_dhcp_range.xsl
+++ b/terraform_files/limit_ip_dhcp_range.xsl
@@ -14,7 +14,7 @@
     <xsl:copy>
       <xsl:attribute name="start">
         <!-- Transform start range of e.g. "192.168.122.2" to "192.168.122.128" -->
-        <xsl:value-of select="concat(substring-before(@end,'.2'),'.128')" />
+        <xsl:value-of select="concat(substring(@start, 1, string-length(@start) - 2),'.128')" />
       </xsl:attribute>
       <xsl:apply-templates select="@*[not(local-name()='start')]|node()"/>
     </xsl:copy>
@@ -25,7 +25,7 @@
     <xsl:copy>
       <xsl:attribute name="end">
         <!-- Transform end range of e.g. "1001:db8::fe" to "1001:db8::63" -->
-        <xsl:value-of select="concat(substring-before(@end,'::fe'),'::63')" />
+        <xsl:value-of select="concat(substring(@end, 1, string-length(@end) - 2),'63')" />
       </xsl:attribute>
       <xsl:apply-templates select="@*[not(local-name()='end')]|node()"/>
     </xsl:copy>


### PR DESCRIPTION
When we have a network `172.16.20.2`, the current transformation is
invalid and gives `172.16.128` in output.

This change fixes this problem by replacing only the last characters
of a given IP.
