### PR TITLE
NO-ISSUE: Removing old Makefile target

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -217,7 +217,7 @@ _destroy_terraform:
 	terraform destroy -auto-approve -input=false -state=terraform.tfstate -state-out=terraform.tfstate -var-file=terraform.tfvars.json
 
 destroy_nodes:
-	skipper make $(SKIPPER_PARAMS) _destroy_virsh _destroy_terraform_controller
+	skipper make $(SKIPPER_PARAMS) _destroy_virsh
 
 _destroy_virsh:
 	python3 ${DEBUG_FLAGS} -m virsh_cleanup -f test-infra


### PR DESCRIPTION
Removing `_destroy_terraform_controller` target from `destroy_nodes` as it refers to an old unrelevant target 