### PR TITLE
Fix hardcoded _get_disk_scsi_identifier

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -282,7 +282,8 @@ class LibvirtController(NodeController, ABC):
         """
         :return: Returns `b` if, for example, the disks' target.dev is `sdb`
         """
-        return re.findall(r"^sd(.*)$", disk.target)[0]
+        regex_by = disk.target[:2]
+        return re.findall(rf"^{regex_by}(.*)$", disk.target)[0]
 
     def _get_available_scsi_identifier(self, node):
         """


### PR DESCRIPTION
Current code assumes that disks begins with sdX .
CI fails because we are trying to access index 0 by default when lookup returns none . The disks that we have are vdX.

I created a lookup based on the target keys and sd as hardcoded.