### PR TITLE
Day2 post installation triggers node reboot while addding csr

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -104,6 +104,8 @@ class Day2Cluster(BaseCluster):
     def start_install_and_wait_for_installed(self):
         ocp_ready_nodes = self.get_ocp_cluster_ready_nodes_num()
         self._install_day2_cluster()
+        # post installation nodes day2 nodes rebooted
+        self.nodes.wait_till_nodes_are_ssh_ready()
         self.wait_nodes_to_be_in_ocp(ocp_ready_nodes)
 
     def wait_nodes_to_be_in_ocp(self, ocp_ready_nodes):


### PR DESCRIPTION
Current flow for day2 installation try to approve workers csr while the node is rebooting and we keep trying in the waiter.
Added sshable waiter after day2 installation to verify that node really returns from reboot and approve the csr when node is up and running.

We have failures in kni-auto with day2 and it might be a timeing issue depends on reboot time of the installed node.