### PR TITLE
Revert "Allow reading unregistered cluster details"

### DIFF
--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -159,7 +159,7 @@ class InventoryClient(object):
         return self.client.v2_list_clusters(get_unregistered_clusters=True)
 
     def cluster_get(self, cluster_id: str) -> models.cluster.Cluster:
-        return self.client.v2_get_cluster(cluster_id=cluster_id, get_unregistered_clusters=True)
+        return self.client.v2_get_cluster(cluster_id=cluster_id)
 
     def get_infra_env_by_cluster_id(self, cluster_id: str) -> List[Union[models.infra_env.InfraEnv, Dict[str, Any]]]:
         infra_envs = self.infra_envs_list()


### PR DESCRIPTION
Reverts openshift/assisted-test-infra#2081

Apparently only admin users can read unregistered clusters, which makes QE tests fail (as they also go into this path of getting cluster details).

Reverting for now. Later on I'll prepare a patch which only requests unregistered clusters when asked for (and not for all cases).