### PR TITLE
Allow reading unregistered cluster details

### DIFF
--- a/src/assisted_test_infra/download_logs/download_logs.py
+++ b/src/assisted_test_infra/download_logs/download_logs.py
@@ -133,7 +133,7 @@ def download_logs(
     retry_interval: int = RETRY_INTERVAL,
 ):
     if "hosts" not in cluster or len(cluster["hosts"]) == 0:
-        cluster["hosts"] = client.get_cluster_hosts(cluster_id=cluster["id"])
+        cluster["hosts"] = client.get_cluster_hosts(cluster_id=cluster["id"], get_unregistered_clusters=True)
 
     output_folder = get_logs_output_folder(dest, cluster)
     if not is_update_needed(output_folder, update_by_events, client, cluster):

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -125,8 +125,8 @@ class InventoryClient(object):
         result = self.client.v2_import_cluster(new_import_cluster_params=cluster)
         return result
 
-    def get_cluster_hosts(self, cluster_id: str) -> List[Dict[str, Any]]:
-        cluster_details = self.cluster_get(cluster_id)
+    def get_cluster_hosts(self, cluster_id: str, get_unregistered_clusters: bool = False) -> List[Dict[str, Any]]:
+        cluster_details = self.cluster_get(cluster_id, get_unregistered_clusters=get_unregistered_clusters)
         return list(map(lambda host: host.to_dict(), cluster_details.hosts))
 
     def get_infra_env_hosts(self, infra_env_id: str) -> List[Dict[str, Any]]:
@@ -158,8 +158,8 @@ class InventoryClient(object):
     def get_all_clusters(self) -> List[Dict[str, Any]]:
         return self.client.v2_list_clusters(get_unregistered_clusters=True)
 
-    def cluster_get(self, cluster_id: str) -> models.cluster.Cluster:
-        return self.client.v2_get_cluster(cluster_id=cluster_id)
+    def cluster_get(self, cluster_id: str, get_unregistered_clusters: bool = False) -> models.cluster.Cluster:
+        return self.client.v2_get_cluster(cluster_id=cluster_id, get_unregistered_clusters=get_unregistered_clusters)
 
     def get_infra_env_by_cluster_id(self, cluster_id: str) -> List[Union[models.infra_env.InfraEnv, Dict[str, Any]]]:
         infra_envs = self.infra_envs_list()


### PR DESCRIPTION
Sometimes when downloading artifacts for failed clusters we get 404 for getting cluster's hosts.
I suspect the reason to be that we allow fetching of unregistered cluster, but do not use that argument when fetching full details of the clusters (to take the hosts for them).

It's looking something like:
```
18:10:49    File
   "/mnt-assisted-log/workspace/download_logs/assisted-test-infra/src/assisted_test_infra/download_logs/download_logs.py",
line 136, in download_logs
18:10:49      cluster["hosts"] =
   client.get_cluster_hosts(cluster_id=cluster["id"])
18:10:49
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
18:10:49    File
   "/mnt-assisted-log/workspace/download_logs/assisted-test-infra/src/service_client/assisted_service_api.py",
line 129, in get_cluster_hosts
18:10:49      cluster_details = self.cluster_get(cluster_id)
18:10:49                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
18:10:49    File
   "/mnt-assisted-log/workspace/download_logs/assisted-test-infra/src/service_client/assisted_service_api.py",
line 162, in cluster_get
18:10:49      return self.client.v2_get_cluster(cluster_id=cluster_id)
18:10:49             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
18:10:49    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/assisted_service_client/api/installer_api.py",
line 2570, in v2_get_cluster
18:10:49      (data) = self.v2_get_cluster_with_http_info(cluster_id,
   **kwargs)  # noqa: E501
18:10:49
   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
18:10:49    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/assisted_service_client/api/installer_api.py",
line 2643, in v2_get_cluster_with_http_info
18:10:49      return self.api_client.call_api(
18:10:49             ^^^^^^^^^^^^^^^^^^^^^^^^^
18:10:49    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/assisted_service_client/api_client.py",
line 325, in call_api
18:10:49      return self.__call_api(resource_path, method,
18:10:49             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
18:10:49    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/assisted_service_client/api_client.py",
line 157, in __call_api
18:10:49      response_data = self.request(
18:10:49                      ^^^^^^^^^^^^^
18:10:49    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/assisted_service_client/api_client.py",
line 347, in request
18:10:49      return self.rest_client.GET(url,
18:10:49             ^^^^^^^^^^^^^^^^^^^^^^^^^
18:10:49    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/assisted_service_client/rest.py",
line 234, in GET
18:10:49      return self.request("GET", url,
18:10:49             ^^^^^^^^^^^^^^^^^^^^^^^^
18:10:49    File
   "/root/.pyenv/versions/3.11.0/lib/python3.11/site-packages/assisted_service_client/rest.py",
line 228, in request
18:10:49      raise ApiException(http_resp=r)
18:10:49  assisted_service_client.rest.ApiException: (404)
18:10:49  Reason: Not Found
```

This allows ``cluster_get`` to list also unregistered (deleted) clusters with the  ``get_unregistered_clusters`` parameter, and activating it when downloading logs.

This implements https://github.com/openshift/assisted-test-infra/pull/2081 in a more backwards-compatible way.