### PR TITLE
bump skipper to v2.0.0

### DIFF
--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -180,7 +180,7 @@ function install_packages() {
 
 function install_skipper() {
     echo "Installing skipper and adding ~/.local/bin to PATH"
-    pip3 install strato-skipper==1.34.0 --user
+    pip3 install strato-skipper==2.0.0 --user
 
     #grep -qxF "export PATH=~/.local/bin:$PATH" ~/.bashrc || echo "export PATH=~/.local/bin:$PATH" >> ~/.bashrc
     #export PATH="$PATH:~/.local/bin"


### PR DESCRIPTION
Not much in the release notes, but it did get a major code change:
https://github.com/Stratoscale/skipper/releases/tag/2.0.0