### PR TITLE
Improve usability of download-logs

### DIFF
--- a/scripts/download_logs.sh
+++ b/scripts/download_logs.sh
@@ -18,6 +18,14 @@ ENABLE_KUBE_API=${ENABLE_KUBE_API:-"false"}
 DEBUG_FLAGS=${DEBUG_FLAGS:-""}
 export LOGGER_NAME="download_logs"
 
+if [[ "${ADDITIONAL_PARAMS}" != *"--cluster-id"* ]] && [[ "${ADDITIONAL_PARAMS}" != *"--download-all"* ]]; then
+  if [ -z ${CLUSTER_ID} ]; then
+    ADDITIONAL_PARAMS="${ADDITIONAL_PARAMS} --download-all"
+  else
+    ADDITIONAL_PARAMS="${ADDITIONAL_PARAMS} --cluster-id ${CLUSTER_ID}"
+  fi
+fi
+
 function download_service_logs() {
   mkdir -p ${LOGS_DEST} || true
 
@@ -58,7 +66,7 @@ function download_cluster_logs() {
         SERVICE_URL=$(KUBECONFIG=${HOME}/.kube/config minikube service assisted-service -n ${NAMESPACE} --url)
       fi
     fi
-    skipper run -e JUNIT_REPORT_DIR "python3 ${DEBUG_FLAGS} -m src.assisted_test_infra.download_logs ${SERVICE_URL} ${LOGS_DEST} --cluster-id ${CLUSTER_ID} ${ADDITIONAL_PARAMS}"
+    skipper run -e JUNIT_REPORT_DIR "python3 ${DEBUG_FLAGS} -m src.assisted_test_infra.download_logs ${SERVICE_URL} ${LOGS_DEST} ${ADDITIONAL_PARAMS}"
   fi
 }
 


### PR DESCRIPTION
Making it possible to run it as either:
* ``make download_cluster_logs`` - then it downloads logs for all available clusters.
* ``make download_cluster_logs CLUSTER_ID=...`` - then it downloads logs for the specified cluster ID.

Without this change ``make download_clsuter_logs`` just tries to do:
```
skipper run ... src.assisted_test_infra.download_logs ... --cluster-id # parameter value left empty
```

which doesn't download any log.