### PR TITLE
Do not download kubeconfig if must-gather wasn't requested

### DIFF
--- a/src/assisted_test_infra/download_logs/download_logs.py
+++ b/src/assisted_test_infra/download_logs/download_logs.py
@@ -240,12 +240,11 @@ def download_logs(
                         log.info(f"Going to retry in {retry_interval} seconds")
                         time.sleep(retry_interval)
 
-        kubeconfig_path = os.path.join(output_folder, "kubeconfig-noingress")
+        if must_gather:
+            with SuppressAndLog(assisted_service_client.rest.ApiException):
+                kubeconfig_path = os.path.join(output_folder, "kubeconfig-noingress")
+                client.download_kubeconfig_no_ingress(cluster["id"], kubeconfig_path)
 
-        with SuppressAndLog(assisted_service_client.rest.ApiException):
-            client.download_kubeconfig_no_ingress(cluster["id"], kubeconfig_path)
-
-            if must_gather:
                 config_etc_hosts(
                     cluster["name"],
                     cluster["base_dns_domain"],


### PR DESCRIPTION
Currently test-infra tries to download ``kubeconfig-ingress`` even if we're not using it for gathering must-gather logs.

In triage logs download process we're having this kind of behavior, even though it doesn't succeed due to roles scheme. It produces a warning like:
```
18:23:56  2023-03-21 16:23:55,895  download_logs WARNING    -
   140242975606592 - Suppressed ApiException from download_logs:246 :
		   (403)
18:23:56  Reason: Forbidden
18:23:56  HTTP response headers: ...
18:23:56  HTTP response body:
   b'{"code":403,"message":"<user>: Unauthorized to access
route (insufficient role read-only-admin)"}'
```

This only does the download if configured to try and gather must-gather, making it produce less warning logs.