### PR TITLE
Fix stale references to infra-envs

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -86,7 +86,7 @@ class Cluster(BaseCluster):
         self._update_existing_cluster_config(self.api_client, self._config.cluster_id)
 
         # Assuming single or no infra_env - TODO need to change when adding multi-infra_env support to test_infra
-        for infra_env in self.api_client.get_infra_env_by_cluster_id(self.id):
+        for infra_env in self.api_client.get_infra_envs_by_cluster_id(self.id):
             self._infra_env_config.infra_env_id = infra_env.get("id")
             self._infra_env = InfraEnv(self.api_client, self._infra_env_config, self.nodes)
             log.info(f"Found infra-env {self._infra_env.id} for cluster {self.id}")

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -161,7 +161,7 @@ class InventoryClient(object):
     def cluster_get(self, cluster_id: str, get_unregistered_clusters: bool = False) -> models.cluster.Cluster:
         return self.client.v2_get_cluster(cluster_id=cluster_id, get_unregistered_clusters=get_unregistered_clusters)
 
-    def get_infra_env_by_cluster_id(self, cluster_id: str) -> List[Union[models.infra_env.InfraEnv, Dict[str, Any]]]:
+    def get_infra_envs_by_cluster_id(self, cluster_id: str) -> List[Union[models.infra_env.InfraEnv, Dict[str, Any]]]:
         infra_envs = self.infra_envs_list()
         return [infra_env for infra_env in infra_envs if infra_env["cluster_id"] == cluster_id]
 


### PR DESCRIPTION
Currently the method for fetching infra-env objects is as follows:
* Listing all existing clusters (including ones that are logically removed)
* Fetching cluster object from API (mainly to get the associated hosts which are not retrived in the first stage)
* Fetching infra-env objects from API based on IDs in the host objects

The problem is step 3, as infra-env objects might get deleted in the meantime, meaning those IDs no longer reference to existing infra-envs.

To minimize the problem, this change ignores infra-env IDs in the host objects, and just do another request for the infra-envs that are associated with a certain cluster ID.
It guarantees a more recent representation of current DB state, but more importantly we shouldn't get 404 for requesting those objects. Later on we download events for those infra-envs, but this action is suppressed in case of API errors.