### PR TITLE
Add SSHException catch when ssh_connection

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
@@ -1,6 +1,7 @@
 from pathlib import Path
 from typing import Callable, Optional
 
+from paramiko import SSHException
 from scp import SCPException
 
 import consts
@@ -65,7 +66,7 @@ class Node:
                 connection.connect()
                 return connection
 
-            except (TimeoutError, SCPException) as e:
+            except (TimeoutError, SCPException, SSHException) as e:
                 log.warning("Could not SSH through IP %s: %s", ip, str(e))
                 exception = e
 


### PR DESCRIPTION
In some cases when trying to init ssh connection we may get paramiko.ssh_exception.SSHException: Invalid key

While trying to connect to multiple ips we may catch it to prevent raising it back till we complete ssh tries