### PR TITLE
Don't crash on non-binding infra-envs

### DIFF
--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -163,7 +163,7 @@ class InventoryClient(object):
 
     def get_infra_envs_by_cluster_id(self, cluster_id: str) -> List[Union[models.infra_env.InfraEnv, Dict[str, Any]]]:
         infra_envs = self.infra_envs_list()
-        return [infra_env for infra_env in infra_envs if infra_env["cluster_id"] == cluster_id]
+        return [infra_env for infra_env in infra_envs if infra_env.get("cluster_id") == cluster_id]
 
     def update_infra_env(self, infra_env_id: str, infra_env_update_params):
         log.info("Updating infra env %s with values %s", infra_env_id, infra_env_update_params)


### PR DESCRIPTION
When searching for all infra-envs binding to a particular cluster, we
should ignore infra-envs that are not binding to any cluster, instead of
crashing

See failure http://assisted-jenkins.usersys.redhat.com/job/download_logs/51070/console