### PR TITLE
MGMT-14411: Fix for OCM 2.8 test failures

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ CONTAINER_RUNTIME_COMMAND := $(or ${CONTAINER_COMMAND}, ${CONTAINER_RUNTIME_COMM
 LINT_CODE_STYLING_DIRS := src/tests src/triggers src/assisted_test_infra/test_infra src/assisted_test_infra/download_logs src/service_client src/consts src/virsh_cleanup src/cli
 
 # assisted-service
-SERVICE := $(or $(SERVICE), quay.io/edge-infrastructure/assisted-service:latest)
+SERVICE := $(or $(SERVICE), quay.io/edge-infrastructure/assisted-service:ocm-2.8)
 SERVICE_NAME := $(or $(SERVICE_NAME),assisted-service)
-INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/edge-infrastructure/assisted-service-index:latest)
+INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/edge-infrastructure/assisted-service-index:ocm-2.8)
 REMOTE_SERVICE_URL := $(or $(REMOTE_SERVICE_URL), "")
 
 # terraform


### PR DESCRIPTION
During the tests `e2e-metal-assisted-kube-api-late-binding-single-node` and `e2e-metal-assisted-kube-api-late-unbinding-single-node`
    The installation of the Assisted Service Operator fails on the hub due to a catalog source error

    ```
    {
            "message": "constraints not satisfiable: no operators found in channel ocm-2.8 of package assisted-service-operator in the catalog referenced by subscription assisted-service-operator, subscription assisted-service-operator exists",
            "reason": "ConstraintsNotSatisfiable",
            "status": "True",
            "type": "ResolutionFailed"
     }
    ```

    This PR addresses that issue by making sure that the correct version of the assisted service and the correct version of assisted-service-index are used in the test.
    Prior to this PR, the service was using the latest image, as was the index.