### PR TITLE
MGMT-14563: Make deploy_nodes target to deploy nodes without networking

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -270,8 +270,11 @@ deploy_nodes_with_install: start_load_balancer
 deploy_nodes: start_load_balancer
 	TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_deploy_nodes $(MAKE) test
 
+deploy_nodes_with_networking: start_load_balancer
+	TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_deploy_networking_with_nodes $(MAKE) test
+
 deploy_static_network_config_nodes:
-	make deploy_nodes ADDITIONAL_PARAMS="'--with-static-network-config'"
+	make deploy_nodesdeploy_nodes_with_networking ADDITIONAL_PARAMS="'--with-static-network-config'"
 
 .PHONY: deploy_ibip
 deploy_ibip:
@@ -286,7 +289,7 @@ ifdef BIP_BUTANE_CONFIG
 endif
 	skipper make $(SKIPPER_PARAMS) _test TEST=./src/tests/test_bootstrap_in_place.py TEST_FUNC=$(or ${TEST_FUNC},'test_bootstrap_in_place_sno')
 
-redeploy_nodes: destroy_nodes deploy_nodes
+redeploy_nodes: destroy_nodes deploy_nodes_with_networking
 
 redeploy_nodes_with_install: destroy_nodes deploy_nodes_with_install
 

--- a/README.md
+++ b/README.md
@@ -238,6 +238,14 @@ make all
 To run the flow without the installation stage:
 
 ```bash
+make run deploy_nodes_with_networking
+```
+
+### Run base flow without configuring networking 
+
+Deploy the nodes without the network configuration and without the installation stage:
+
+```bash
 make run deploy_nodes
 ```
 

--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -794,16 +794,15 @@ class Cluster(BaseCluster):
             and self._config.platform != consts.Platforms.NONE
         )
 
-    @JunitTestCase()
-    def prepare_for_installation(self, **kwargs):
-        super(Cluster, self).prepare_for_installation(is_static_ip=self._infra_env_config.is_static_ip, **kwargs)
+    def prepare_nodes(self, is_static_ip: bool = False, **kwargs):
+        super(Cluster, self).prepare_nodes(is_static_ip=self._infra_env_config.is_static_ip, **kwargs)
         assert self.get_details().platform.type in self.api_client.get_cluster_supported_platforms(self.id)
-
-        self.nodes.wait_for_networking()
         self.set_hostnames_and_roles()
         if self._high_availability_mode != consts.HighAvailabilityMode.NONE:
             self.set_host_roles(len(self.nodes.get_masters()), len(self.nodes.get_workers()))
 
+    def prepare_networking(self):
+        self.nodes.wait_for_networking()
         self.set_network_params(controller=self.nodes.controller)
 
         # in case of None platform we need to specify dns records before hosts are ready

--- a/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/day2_cluster.py
@@ -46,7 +46,7 @@ class Day2Cluster(BaseCluster):
     def update_existing(self) -> str:
         raise NotImplementedError("Creating Day2Cluster object from an existing cluster is not implemented.")
 
-    def prepare_for_installation(self):
+    def prepare_nodes(self, is_static_ip: bool = False, **kwargs):
         """Prepare the day2 worker nodes. When this method finishes, the hosts are in 'known' status."""
 
         self.set_pull_secret(self._config.pull_secret)
@@ -61,9 +61,7 @@ class Day2Cluster(BaseCluster):
         )
 
         # spawn VMs
-        super(Day2Cluster, self).prepare_for_installation(
-            is_static_ip=self._config.day1_cluster._infra_env_config.is_static_ip
-        )
+        super(Day2Cluster, self).prepare_nodes(is_static_ip=self._config.day1_cluster._infra_env_config.is_static_ip)
         self.nodes.wait_for_networking()
         self.set_hostnames_and_roles()
 

--- a/src/assisted_test_infra/test_infra/helper_classes/entity.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/entity.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from typing import Optional, Union
 
 from assisted_service_client import models
+from junit_report import JunitTestCase
 
 import consts
 from assisted_test_infra.test_infra import BaseEntityConfig
@@ -56,7 +57,8 @@ class Entity(ABC):
                 raise KeyError(f"The key {k} is not present in {self._config.__class__.__name__}")
             setattr(self._config, k, v)
 
-    def prepare_for_installation(self, is_static_ip: bool = False, **kwargs):
+    @JunitTestCase()
+    def prepare_nodes(self, is_static_ip: bool = False, **kwargs):
         self.update_config(**kwargs)
 
         log.info(
@@ -83,6 +85,14 @@ class Entity(ABC):
 
         self.nodes.start_all(check_ips=not (is_static_ip and self._config.is_ipv6))
         self.wait_until_hosts_are_discovered(allow_insufficient=True)
+
+    def prepare_networking(self):
+        pass
+
+    @JunitTestCase()
+    def prepare_for_installation(self, **kwargs):
+        self.prepare_nodes(is_static_ip=kwargs.pop("is_static_ip", False), **kwargs)
+        self.prepare_networking()
 
     def _set_ipxe_url(self):
         ipxe_server_url = (

--- a/src/tests/test_targets.py
+++ b/src/tests/test_targets.py
@@ -16,6 +16,10 @@ from tests.config import ClusterConfig, InfraEnvConfig
 class TestMakefileTargets(BaseTest):
     @JunitTestSuite()
     def test_target_deploy_nodes(self, cluster):
+        cluster.prepare_nodes()
+
+    @JunitTestSuite()
+    def test_target_deploy_networking_with_nodes(self, cluster):
         cluster.prepare_for_installation()
 
     @JunitTestSuite()


### PR DESCRIPTION
Currently `deploy_nodes` target is deploying nodes and preparing the networking. 
Due to QE request we need to split this targets and allowing deploy the nodes without setting the network configurations.

In this PR:

- `prepare_for_installation`  function was split into two new functions - `prepare_nodes` and `prepare_networking`
- `deploy_nodes`  target is deploying the nodes without setting up the networking
- `deploy_nodes_with_networking` target was added - same logic as the previous `deploy_nodes`

/cc @osherdp @lalon4 
