### PR TITLE
NO-ISSUE: ensure ADDITIONAL_MANIFEST_DIR exists

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -276,8 +276,11 @@ deploy_static_network_config_nodes:
 .PHONY: deploy_ibip
 deploy_ibip:
 ifdef ADDITIONAL_MANIFEST_DIR
-	rm -rf ${INSTALL_MANIFEST_DIR}; mkdir ${INSTALL_MANIFESTS_DIR}
-	mv ${ADDITIONAL_MANIFEST_DIR}/* ${INSTALL_MANIFESTS_DIR}/
+	@is_empty_dir=$(shell ls -A ${ADDITIONAL_MANIFEST_DIR}); \
+	if [ -n "$$is_empty_dir" ]; then \
+		rm -rf ${INSTALL_MANIFEST_DIR}; mkdir ${INSTALL_MANIFESTS_DIR}; \
+		mv ${ADDITIONAL_MANIFEST_DIR}/* ${INSTALL_MANIFESTS_DIR}/; \
+	fi
 endif
 	# To deploy with a worker node, set TEST_FUNC=test_bip_add_worker
 ifdef BIP_BUTANE_CONFIG


### PR DESCRIPTION
In Makefile, ensure ADDITIONAL_MANIFEST_DIR exists before trying to move its content.

Needed for trying to resolve the issue in
e2e-metal-single-node-live-iso job[*]

```
mv /root/sno-additional-manifests/* /home/sno/sno-additional-manifests/
mv: cannot stat '/root/sno-additional-manifests/*': No such file or directory
make: *** [Makefile:280: deploy_ibip] Error 1
```

Note: could be related to https://github.com/openshift/release/pull/39064

[*] https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/origin-ci-test/pr-logs/pull/openshift_assisted-test-infra/2143/pull-ci-openshift-assisted-test-infra-master-e2e-metal-single-node-live-iso/1655682994788110336/build-log.txt