### PR TITLE
Update old image used by upgrade agent test

### DIFF
--- a/src/tests/test_upgrade_agent.py
+++ b/src/tests/test_upgrade_agent.py
@@ -27,7 +27,7 @@ class TestUpgradeAgent(BaseTest):
     @classmethod
     def _get_previous_agent_image(cls) -> str:
         """Returns the reference to the previous agent image."""
-        return os.environ.get("PREVIOUS_AGENT_IMAGE", "quay.io/edge-infrastructure/assisted-installer-agent:v2.9.0")
+        return os.environ.get("PREVIOUS_AGENT_IMAGE", "quay.io/edge-infrastructure/assisted-installer-agent:v2.20.1")
 
     @classmethod
     def _get_broken_agent_image(cls) -> str:


### PR DESCRIPTION
The upgrade agent prepares a cluster for installation with an old agent image and then checks that it can be upgraded to the latest one. But that old image is no longer capable to move the cluster to ready because of changes to the DNS resolution validation. To address that issue this patch changes the test to use a newer old image.

Related: https://issues.redhat.com//browse/MGMT-14526
Related: https://github.com/openshift/assisted-service/pull/5208
Related: https://github.com/openshift/assisted-installer-agent/pull/542