### PR TITLE
MGMT-14737: Add base terraform controller for both vsphere and nutanix.

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/__init__.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/__init__.py
@@ -5,4 +5,11 @@ from .node_controller import NodeController
 from .terraform_controller import TerraformController
 from .vsphere_controller import VSphereController
 
-__all__ = ["TerraformController", "NodeController", "VSphereController", "Disk", "Node", "LibvirtController"]
+__all__ = [
+    "TerraformController",
+    "NodeController",
+    "VSphereController",
+    "Disk",
+    "Node",
+    "LibvirtController",
+]

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -124,7 +124,6 @@ class NodeController(ABC):
     def is_active(self, node_name) -> bool:
         pass
 
-    @abstractmethod
     def set_boot_order(self, node_name, cd_first=False) -> None:
         pass
 

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/nutanix_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/nutanix_controller.py
@@ -1,46 +1,21 @@
 import ipaddress
 import random
 import subprocess
-from typing import Any, Callable, Dict, List, Tuple, Union
+from typing import List, Tuple, Union
 
 from nutanix_api import NutanixApiClient, NutanixCluster, NutanixSubnet, NutanixVM
 from nutanix_api.nutanix_vm import PowerState, VMBootDevices
 
-from assisted_test_infra.test_infra import BaseClusterConfig
-from assisted_test_infra.test_infra.controllers.node_controllers.disk import Disk
-from assisted_test_infra.test_infra.controllers.node_controllers.node import Node
-from assisted_test_infra.test_infra.controllers.node_controllers.node_controller import NodeController
+from assisted_test_infra.test_infra.controllers.node_controllers.tf_controller import TFController
 from assisted_test_infra.test_infra.helper_classes.config.base_nutanix_config import BaseNutanixConfig
-from assisted_test_infra.test_infra.tools import terraform_utils
-from assisted_test_infra.test_infra.utils import TerraformControllerUtil, utils
 from service_client import log
 
 
-class NutanixController(NodeController):
+class NutanixController(TFController):
     _config: BaseNutanixConfig
 
-    def __init__(self, config: BaseNutanixConfig, cluster_config: BaseClusterConfig):
-        super().__init__(config, cluster_config)
-        self.cluster_name = cluster_config.cluster_name.get()
-        folder = TerraformControllerUtil.create_folder(self.cluster_name, platform=config.tf_platform)
-        self.tf = terraform_utils.TerraformUtils(working_dir=folder, terraform_init=False)
-        self._nutanix_client = None
-
-    def get_all_vars(self):
-        return {**self._config.get_all(), **self._entity_config.get_all(), "cluster_name": self.cluster_name}
-
-    def prepare_nodes(self):
-        config = self.get_all_vars()
-        self._nutanix_client = self._create_nutanix_client()
-        self.tf.set_and_apply(**config)
-        nodes = self.list_nodes()
-        for node in nodes:
-            self.set_boot_order(node.name)
-
-        return nodes
-
-    def _get_nutanix_vm(self, tf_vm_name: str) -> Union[NutanixVM, None]:
-        nutanix_vms = NutanixVM.list_entities(self._nutanix_client)
+    def _get_provider_vm(self, tf_vm_name: str) -> Union[NutanixVM, None]:
+        nutanix_vms = NutanixVM.list_entities(self._provider_client)
         _, macs = self.get_node_ips_and_macs(tf_vm_name)
 
         for vm in nutanix_vms:
@@ -50,44 +25,11 @@ class NutanixController(NodeController):
 
         raise ValueError(f"Can't find node with name: {tf_vm_name}")
 
-    def _nutanix_vm_to_node(self, terraform_vm_state: Dict[str, Any]) -> Node:
-        return Node(
-            name=terraform_vm_state["attributes"]["name"],
-            private_ssh_key_path=self._config.private_ssh_key_path,
-            node_controller=self,
-        )
-
-    def list_nodes(self) -> List[Node]:
-        tf_vms = self._get_tf_vms()
-        return list(map(self._nutanix_vm_to_node, tf_vms))
-
-    def get_cpu_cores(self, node_name: str) -> int:
-        return self._get_vm(node_name)["attributes"]["num_sockets"]
-
-    def get_ram_kib(self, node_name: str) -> int:
-        return self._get_vm(node_name)["attributes"]["memory_size_mib"] * 1024
-
-    def get_node_ips_and_macs(self, node_name) -> Tuple[List[str], List[str]]:
-        vm_attributes = self._get_vm(node_name)["attributes"]
-        ips = []
-        macs = []
-
-        for nic in vm_attributes["nic_list"]:
-            for ips_list in nic["ip_endpoint_list"]:
-                ips.append(ips_list["ip"])
-
-            macs.append(nic["mac_address"])
-
-        return ips, macs
-
-    def destroy_all_nodes(self) -> None:
-        self.tf.destroy(force=False)
-
     def start_node(self, node_name: str, check_ips: bool) -> None:
         """
         :raises ValueError if node_name does not exist
         """
-        vm = self._get_nutanix_vm(node_name)
+        vm = self._get_provider_vm(node_name)
         if vm.power_state != PowerState.ON.value:
             log.info(f"Powering on nutanix node {node_name}")
             vm.power_on()
@@ -97,16 +39,8 @@ class NutanixController(NodeController):
                 f"but the vm is already on - vm.power_state={vm.power_state}"
             )
 
-    def start_all_nodes(self) -> List[Node]:
-        nodes = self.list_nodes()
-
-        for node in nodes:
-            self.start_node(node.name, check_ips=False)
-
-        return self.list_nodes()
-
     def shutdown_node(self, node_name: str) -> None:
-        vm = self._get_nutanix_vm(node_name)
+        vm = self._get_provider_vm(node_name)
         if vm.power_state != PowerState.OFF.value:
             log.info(f"Powering off nutanix node {node_name}")
             vm.power_on()
@@ -116,14 +50,8 @@ class NutanixController(NodeController):
                 f"but the vm is already off - vm.power_state={vm.power_state}"
             )
 
-    def shutdown_all_nodes(self) -> None:
-        nodes = self.list_nodes()
-
-        for node in nodes:
-            self.shutdown_node(node.name)
-
     def restart_node(self, node_name: str) -> None:
-        vm = self._get_nutanix_vm(tf_vm_name=node_name)
+        vm = self._get_provider_vm(tf_vm_name=node_name)
         vm.power_off()
         vm.power_on()
 
@@ -136,7 +64,7 @@ class NutanixController(NodeController):
             return {"api_vip": self._entity_config.api_vip, "ingress_vip": self._entity_config.ingress_vip}
 
         nutanix_subnet = next(
-            s for s in NutanixSubnet.list_entities(self._nutanix_client) if s.name == self._config.nutanix_subnet
+            s for s in NutanixSubnet.list_entities(self._provider_client) if s.name == self._config.nutanix_subnet
         )
 
         free_ips = set()
@@ -162,33 +90,18 @@ class NutanixController(NodeController):
         log.info(f"Found 2 optional VIPs: {free_ips}")
         return {"api_vip": free_ips.pop(), "ingress_vip": free_ips.pop()}
 
-    def set_dns(self, api_ip: str, ingress_ip: str) -> None:
-        utils.add_dns_record(
-            cluster_name=self.cluster_name,
-            base_dns_domain=self._entity_config.base_dns_domain,
-            api_ip=api_ip,
-            ingress_ip=ingress_ip,
-        )
-
     def set_boot_order(self, node_name, cd_first=False) -> None:
-        vm = self._get_nutanix_vm(tf_vm_name=node_name)
+        vm = self._get_provider_vm(tf_vm_name=node_name)
         if cd_first:
             vm.update_boot_order(VMBootDevices.default_boot_order())
         else:
             vm.update_boot_order([VMBootDevices.DISK, VMBootDevices.CDROM, VMBootDevices.NETWORK])
 
-    def _get_vm(self, node_name: str) -> Dict[str, Any]:
-        return next((vm for vm in self._get_tf_vms() if vm["attributes"]["name"] == node_name), None)
+    @property
+    def terraform_vm_resource_type(self) -> str:
+        return "nutanix_virtual_machine"
 
-    def _get_tf_vms(self) -> List[Dict[str, Any]]:
-        vms_object_type = self.tf.get_resources(resource_type="nutanix_virtual_machine")
-
-        if not vms_object_type:
-            return list()
-
-        return [vm_instance for vms_objects in vms_object_type for vm_instance in vms_objects["instances"]]
-
-    def _create_nutanix_client(self) -> NutanixApiClient:
+    def _get_provider_client(self) -> NutanixApiClient:
         nutanix_client = NutanixApiClient(
             self._config.nutanix_username,
             self._config.nutanix_password,
@@ -204,67 +117,26 @@ class NutanixController(NodeController):
 
         return nutanix_client
 
-    def format_node_disk(self, node_name: str, disk_index: int = 0) -> None:
-        raise NotImplementedError
-
-    def list_disks(self, node_name: str) -> List[Disk]:
-        raise NotImplementedError
-
     def is_active(self, node_name) -> bool:
         # TODO[vrutkovs]: use Nutanix API to determine if node is running
         # Currently its assumed to be always on
         return True
 
-    def format_all_node_disks(self) -> None:
-        raise NotImplementedError
+    def get_cpu_cores(self, node_name: str) -> int:
+        return self._get_vm(node_name)["attributes"]["num_sockets"]
 
-    def list_networks(self) -> List[Any]:
-        raise NotImplementedError
+    def get_ram_kib(self, node_name: str) -> int:
+        return self._get_vm(node_name)["attributes"]["memory_size_mib"] * 1024
 
-    def list_leases(self, network_name: str) -> List[Any]:
-        raise NotImplementedError
+    def get_node_ips_and_macs(self, node_name) -> Tuple[List[str], List[str]]:
+        vm_attributes = self._get_vm(node_name)["attributes"]
+        ips = []
+        macs = []
 
-    def attach_test_disk(self, node_name: str, disk_size: int, bootable=False, persistent=False, with_wwn=False):
-        raise NotImplementedError
+        for nic in vm_attributes["nic_list"]:
+            for ips_list in nic["ip_endpoint_list"]:
+                ips.append(ips_list["ip"])
 
-    def detach_all_test_disks(self, node_name: str):
-        raise NotImplementedError
+            macs.append(nic["mac_address"])
 
-    def get_cluster_network(self) -> str:
-        raise NotImplementedError
-
-    def setup_time(self) -> str:
-        raise NotImplementedError
-
-    def set_per_device_boot_order(self, node_name, key: Callable[[Disk], int]) -> None:
-        raise NotImplementedError
-
-    def get_host_id(self, node_name: str) -> str:
-        raise NotImplementedError
-
-    def set_cpu_cores(self, node_name: str, core_count: int) -> None:
-        raise NotImplementedError
-
-    def set_ram_kib(self, node_name: str, ram_kib: int) -> None:
-        raise NotImplementedError
-
-    def attach_interface(self, node_name, network_xml: str):
-        raise NotImplementedError
-
-    def add_interface(self, node_name, network_name, target_interface: str) -> str:
-        raise NotImplementedError
-
-    def undefine_interface(self, node_name: str, mac: str):
-        raise NotImplementedError
-
-    def create_network(self, network_xml: str):
-        raise NotImplementedError
-
-    def get_network_by_name(self, network_name: str):
-        raise NotImplementedError
-
-    def destroy_network(self, network):
-        raise NotImplementedError
-
-    def set_single_node_ip(self, ip):
-        raise NotImplementedError
+        return ips, macs

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
@@ -1,0 +1,167 @@
+from abc import ABC, abstractmethod
+from typing import Any, Callable, Dict, List, Tuple
+
+from assisted_test_infra.test_infra import BaseClusterConfig
+from assisted_test_infra.test_infra.controllers.node_controllers import Disk, Node
+from assisted_test_infra.test_infra.controllers.node_controllers.node_controller import NodeController
+from assisted_test_infra.test_infra.helper_classes.config import BaseNodesConfig
+from assisted_test_infra.test_infra.tools import terraform_utils
+from assisted_test_infra.test_infra.utils import TerraformControllerUtil, utils
+
+
+class TFController(NodeController, ABC):
+    _entity_config: BaseClusterConfig
+
+    def __init__(self, config: BaseNodesConfig, cluster_config: BaseClusterConfig):
+        super().__init__(config, cluster_config)
+        self.cluster_name = cluster_config.cluster_name.get()
+        folder = TerraformControllerUtil.create_folder(self.cluster_name, platform=config.tf_platform)
+        self.tf = terraform_utils.TerraformUtils(working_dir=folder, terraform_init=False)
+        self._provider_client = None
+
+    @property
+    @abstractmethod
+    def terraform_vm_resource_type(self) -> str:
+        pass
+
+    def _get_tf_vms(self) -> List[Dict[str, Any]]:
+        vms_object_type = self.tf.get_resources(resource_type=self.terraform_vm_resource_type)
+
+        if not vms_object_type:
+            return list()
+
+        return [vm_instance for vms_objects in vms_object_type for vm_instance in vms_objects["instances"]]
+
+    def get_all_vars(self):
+        return {**self._config.get_all(), **self._entity_config.get_all(), "cluster_name": self.cluster_name}
+
+    @abstractmethod
+    def _get_provider_client(self) -> object:
+        pass
+
+    def prepare_nodes(self):
+        config = self.get_all_vars()
+        self._provider_client = self._get_provider_client()
+        self.tf.set_and_apply(**config)
+        nodes = self.list_nodes()
+        for node in nodes:
+            self.set_boot_order(node.name)
+
+        return nodes
+
+    def _tf_vm_to_node(self, terraform_vm_state: Dict[str, Any]) -> Node:
+        return Node(
+            name=terraform_vm_state["attributes"]["name"],
+            private_ssh_key_path=self._config.private_ssh_key_path,
+            node_controller=self,
+        )
+
+    def list_nodes(self) -> List[Node]:
+        tf_vms = self._get_tf_vms()
+        return list(map(self._tf_vm_to_node, tf_vms))
+
+    def _get_vm(self, node_name: str) -> Dict[str, Any]:
+        return next((vm for vm in self._get_tf_vms() if vm["attributes"]["name"] == node_name), None)
+
+    @abstractmethod
+    def get_cpu_cores(self, node_name: str) -> int:
+        pass
+
+    @abstractmethod
+    def get_ram_kib(self, node_name: str) -> int:
+        pass
+
+    @abstractmethod
+    def get_node_ips_and_macs(self, node_name) -> Tuple[List[str], List[str]]:
+        pass
+
+    def destroy_all_nodes(self) -> None:
+        self.tf.destroy(force=False)
+
+    def start_all_nodes(self) -> List[Node]:
+        nodes = self.list_nodes()
+
+        for node in nodes:
+            self.start_node(node.name, check_ips=False)
+
+        return self.list_nodes()
+
+    def shutdown_all_nodes(self) -> None:
+        nodes = self.list_nodes()
+
+        for node in nodes:
+            self.shutdown_node(node.name)
+
+    def set_dns(self, api_ip: str, ingress_ip: str) -> None:
+        utils.add_dns_record(
+            cluster_name=self.cluster_name,
+            base_dns_domain=self._entity_config.base_dns_domain,
+            api_ip=api_ip,
+            ingress_ip=ingress_ip,
+        )
+
+    def get_ingress_and_api_vips(self) -> dict:
+        if self._entity_config.api_vip and self._entity_config.ingress_vip:
+            return {"api_vip": self._entity_config.api_vip, "ingress_vip": self._entity_config.ingress_vip}
+
+        return None
+
+    def format_node_disk(self, node_name: str, disk_index: int = 0) -> None:
+        pass
+
+    def list_disks(self, node_name: str) -> List[Disk]:
+        pass
+
+    def format_all_node_disks(self) -> None:
+        pass
+
+    def list_networks(self) -> List[Any]:
+        pass
+
+    def list_leases(self, network_name: str) -> List[Any]:
+        pass
+
+    def attach_test_disk(self, node_name: str, disk_size: int, bootable=False, persistent=False, with_wwn=False):
+        pass
+
+    def detach_all_test_disks(self, node_name: str):
+        pass
+
+    def get_cluster_network(self) -> str:
+        pass
+
+    def setup_time(self) -> str:
+        pass
+
+    def set_per_device_boot_order(self, node_name, key: Callable[[Disk], int]) -> None:
+        pass
+
+    def get_host_id(self, node_name: str) -> str:
+        pass
+
+    def set_cpu_cores(self, node_name: str, core_count: int) -> None:
+        pass
+
+    def set_ram_kib(self, node_name: str, ram_kib: int) -> None:
+        pass
+
+    def attach_interface(self, node_name, network_xml: str):
+        pass
+
+    def add_interface(self, node_name, network_name, target_interface: str) -> str:
+        pass
+
+    def undefine_interface(self, node_name: str, mac: str):
+        pass
+
+    def create_network(self, network_xml: str):
+        pass
+
+    def get_network_by_name(self, network_name: str):
+        pass
+
+    def destroy_network(self, network):
+        pass
+
+    def set_single_node_ip(self, ip):
+        pass

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
@@ -1,31 +1,24 @@
 import os
 import time
-from typing import Any, Callable, Dict, List, Tuple
+from typing import Any, Callable, List, Tuple
 
-import libvirt
 from pyVim import task
 from pyVim.connect import Disconnect, SmartConnect
 from pyVmomi import vim
 
-from assisted_test_infra.test_infra import BaseClusterConfig
-from assisted_test_infra.test_infra.controllers.node_controllers.disk import Disk
 from assisted_test_infra.test_infra.controllers.node_controllers.node import Node
-from assisted_test_infra.test_infra.controllers.node_controllers.node_controller import NodeController
-from assisted_test_infra.test_infra.helper_classes.config.base_vsphere_config import BaseVSphereConfig
-from assisted_test_infra.test_infra.tools import terraform_utils
-from assisted_test_infra.test_infra.utils import TerraformControllerUtil, utils
+from assisted_test_infra.test_infra.controllers.node_controllers.tf_controller import TFController
+from assisted_test_infra.test_infra.utils import utils
 from service_client import log
 
 
-class VSphereController(NodeController):
-    def __init__(self, config: BaseVSphereConfig, cluster_config: BaseClusterConfig):
-        super().__init__(config, cluster_config)
-        self.cluster_name = cluster_config.cluster_name.get()
-        folder = TerraformControllerUtil.create_folder(self.cluster_name, platform=config.tf_platform)
-        self.tf = terraform_utils.TerraformUtils(working_dir=folder, terraform_init=False)
+class VSphereController(TFController):
+    def _get_provider_client(self) -> object:
+        return None
 
-    def get_all_vars(self):
-        return {**self._config.get_all(), **self._entity_config.get_all(), "cluster_name": self.cluster_name}
+    @property
+    def terraform_vm_resource_type(self) -> str:
+        return "vsphere_virtual_machine"
 
     def prepare_nodes(self):
         if not os.path.exists(self._entity_config.iso_download_path):
@@ -45,26 +38,14 @@ class VSphereController(NodeController):
         config = self.get_all_vars()
         self.tf.set_and_apply(**config)
 
-    def list_nodes(self) -> List[Node]:
-        vms = self.__get_vms()
-
-        def vsphere_vm_to_node(terraform_vm_state):
-            return Node(
-                name=terraform_vm_state["attributes"]["name"],
-                private_ssh_key_path=self._config.private_ssh_key_path,
-                node_controller=self,
-            )
-
-        return list(map(vsphere_vm_to_node, vms))
-
     def get_cpu_cores(self, node_name: str) -> int:
-        return self.__get_vm(node_name)["attributes"]["num_cpus"]
+        return self._get_vm(node_name)["attributes"]["num_cpus"]
 
     def get_ram_kib(self, node_name: str) -> int:
-        return self.__get_vm(node_name)["attributes"]["memory"] * 1024
+        return self._get_vm(node_name)["attributes"]["memory"] * 1024
 
     def get_node_ips_and_macs(self, node_name) -> Tuple[List[str], List[str]]:
-        vm_attributes = self.__get_vm(node_name)["attributes"]
+        vm_attributes = self._get_vm(node_name)["attributes"]
 
         ips = vm_attributes["guest_ip_addresses"]
         macs = []
@@ -87,7 +68,7 @@ class VSphereController(NodeController):
         nodes = self.list_nodes()
 
         for node in nodes:
-            self.start_node(node.name)
+            self.start_node(node.name, False)
 
         return self.list_nodes()
 
@@ -111,98 +92,10 @@ class VSphereController(NodeController):
 
         self.__run_on_vm(node_name, reboot)
 
-    def get_ingress_and_api_vips(self) -> dict:
-        if self._entity_config.api_vip and self._entity_config.ingress_vip:
-            return {"api_vip": self._entity_config.api_vip, "ingress_vip": self._entity_config.ingress_vip}
-
-        return None
-
-    def set_dns(self, api_ip: str, ingress_ip: str) -> None:
-        utils.add_dns_record(
-            cluster_name=self.cluster_name,
-            base_dns_domain=self._entity_config.base_dns_domain,
-            api_ip=api_ip,
-            ingress_ip=ingress_ip,
-        )
-
-    def format_node_disk(self, node_name: str, disk_index: int = 0) -> None:
-        raise NotImplementedError
-
-    def list_disks(self, node_name: str) -> List[Disk]:
-        raise NotImplementedError
-
     def is_active(self, node_name) -> bool:
         # TODO[vrutkovs]: use vSphere API to determine if node is running
         # Currently its assumed to be always on
         return True
-
-    def format_all_node_disks(self) -> None:
-        raise NotImplementedError
-
-    def list_networks(self) -> List[Any]:
-        raise NotImplementedError
-
-    def list_leases(self, network_name: str) -> List[Any]:
-        raise NotImplementedError
-
-    def attach_test_disk(self, node_name: str, disk_size: int, bootable=False, persistent=False, with_wwn=False):
-        raise NotImplementedError
-
-    def detach_all_test_disks(self, node_name: str):
-        raise NotImplementedError
-
-    def get_cluster_network(self) -> str:
-        raise NotImplementedError
-
-    def setup_time(self) -> str:
-        raise NotImplementedError
-
-    def set_boot_order(self, node_name, cd_first=False) -> None:
-        raise NotImplementedError
-
-    def set_per_device_boot_order(self, node_name, key: Callable[[Disk], int]) -> None:
-        raise NotImplementedError
-
-    def get_host_id(self, node_name: str) -> str:
-        raise NotImplementedError
-
-    def set_cpu_cores(self, node_name: str, core_count: int) -> None:
-        raise NotImplementedError
-
-    def set_ram_kib(self, node_name: str, ram_kib: int) -> None:
-        raise NotImplementedError
-
-    def attach_interface(self, node_name, network_xml: str) -> Tuple[libvirt.virNetwork, str]:
-        raise NotImplementedError
-
-    def add_interface(self, node_name, network_name, target_interface: str) -> str:
-        raise NotImplementedError
-
-    def undefine_interface(self, node_name: str, mac: str):
-        raise NotImplementedError
-
-    def create_network(self, network_xml: str) -> libvirt.virNetwork:
-        raise NotImplementedError
-
-    def get_network_by_name(self, network_name: str) -> libvirt.virNetwork:
-        raise NotImplementedError
-
-    def destroy_network(self, network: libvirt.virNetwork):
-        raise NotImplementedError
-
-    def set_single_node_ip(self, ip):
-        raise NotImplementedError
-
-    def __get_vm(self, node_name: str) -> Dict[str, Any]:
-        return next((vm for vm in self.__get_vms() if vm["attributes"]["name"] == node_name), None)
-
-    def __get_vms(self) -> List[Dict[str, Any]]:
-        vms_object_type = self.tf.get_resources(resource_type="vsphere_virtual_machine")
-
-        if not vms_object_type:
-            return list()
-
-        return [vm_instance for vms_objects in vms_object_type for vm_instance in vms_objects["instances"]]
 
     def _create_folder(self, name: str):
         connection = self.__new_connection()

--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -70,7 +70,9 @@ class _EnvVariables(DataPool, ABC):
     platform: EnvVar = EnvVar(["PLATFORM"])
     tf_platform: EnvVar = EnvVar(["TF_PLATFORM", "PLATFORM"], default=env_defaults.DEFAULT_PLATFORM)
     user_managed_networking: EnvVar = EnvVar(
-        ["USER_MANAGED_NETWORKING"], default=env_defaults.DEFAULT_USER_MANAGED_NETWORKING
+        ["USER_MANAGED_NETWORKING"],
+        loader=lambda x: bool(strtobool(x)),
+        default=env_defaults.DEFAULT_USER_MANAGED_NETWORKING,
     )
     high_availability_mode: EnvVar = EnvVar(default=env_defaults.DEFAULT_HIGH_AVAILABILITY_MODE)
     download_image: EnvVar = EnvVar(


### PR DESCRIPTION
This PR is prerequisite to OCI controller https://github.com/openshift/assisted-test-infra/pull/2170
After merge the code will be removed from the draft PR.

This controller will replace in the future the current `TerraformController` + `LibvirtController`.
The hierarchy should be as followed:

```
├── NodeController
    ├── TFController
    │   ├── NutanixController
    │   ├── VsphereController
    │   ├── OciController  --> Not implemented yet (will be on https://github.com/openshift/assisted-test-infra/pull/2170)
    │   └── LibvirtController  --> Not implemented yet
    │
    └──  LibvirtController  --> Will be deprecated in the future 
         └──  TerraformController  --> Will be deprecated in the future
```

/cc @eliorerz 