### PR TITLE
Use `latest` agent image in upgrade test

### DIFF
--- a/src/tests/test_upgrade_agent.py
+++ b/src/tests/test_upgrade_agent.py
@@ -27,7 +27,7 @@ class TestUpgradeAgent(BaseTest):
     @classmethod
     def _get_other_agent_image(cls) -> str:
         """Returns the reference to the other agent image."""
-        return os.environ.get("OTHER_AGENT_IMAGE", "quay.io/edge-infrastructure/assisted-installer-agent:v2.20.1")
+        return os.environ.get("OTHER_AGENT_IMAGE", "quay.io/edge-infrastructure/assisted-installer-agent:latest")
 
     @classmethod
     def _get_current_agent_image(


### PR DESCRIPTION
This patch changes the upgrade agent test so that it uses the `latest` tag instead of a fixed version number.

Related: https://issues.redhat.com//browse/MGMT-14526
Related: https://github.com/openshift/assisted-test-infra/pull/2171