### PR TITLE
Don't use non existing image for agent upgrade test

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -21,7 +21,10 @@ from assisted_test_infra.test_infra.helper_classes.infra_env import InfraEnv
 from assisted_test_infra.test_infra.helper_classes.nodes import Nodes
 from assisted_test_infra.test_infra.tools import terraform_utils
 from assisted_test_infra.test_infra.utils import logs_utils, network_utils, operators_utils
-from assisted_test_infra.test_infra.utils.waiting import wait_till_all_hosts_are_in_status
+from assisted_test_infra.test_infra.utils.waiting import (
+    wait_till_all_hosts_are_in_status,
+    wait_till_all_hosts_use_agent_image,
+)
 from service_client import InventoryClient, log
 
 
@@ -187,6 +190,13 @@ class Cluster(BaseCluster):
             nodes_count=nodes_count or self.nodes.nodes_count,
             statuses=statuses,
             timeout=consts.DISCONNECTED_TIMEOUT,
+        )
+
+    def wait_until_hosts_use_agent_image(self, image: str) -> None:
+        wait_till_all_hosts_use_agent_image(
+            client=self.api_client,
+            cluster_id=self.id,
+            image=image,
         )
 
     @JunitTestCase()

--- a/src/assisted_test_infra/test_infra/utils/waiting.py
+++ b/src/assisted_test_infra/test_infra/utils/waiting.py
@@ -1,4 +1,4 @@
-from typing import List, Tuple
+from typing import Any, Dict, List, Tuple
 
 import waiting
 
@@ -45,6 +45,13 @@ def _are_hosts_in_status(
         host_statuses(hosts),
     )
     return False
+
+
+def _are_hosts_using_agent_image(hosts: List[Dict[str, Any]], image: str) -> bool:
+    for host in hosts:
+        if host.get("discovery_agent_version") != image:
+            return False
+    return True
 
 
 def host_statuses(hosts) -> List[Tuple[int, str, str, str, str, str]]:
@@ -103,6 +110,26 @@ def wait_till_all_hosts_are_in_status(
         timeout_seconds=timeout,
         sleep_seconds=interval,
         waiting_for=f"Nodes to be in of the statuses {statuses}",
+    )
+
+
+def wait_till_all_hosts_use_agent_image(
+    client: Any,
+    cluster_id: str,
+    image: str,
+    timeout: int = consts.NODES_REGISTERED_TIMEOUT,
+    interval: int = consts.DEFAULT_CHECK_STATUSES_INTERVAL,
+) -> None:
+    log.info("Wait till all nodes are using agent image %s", image)
+
+    waiting.wait(
+        lambda: _are_hosts_using_agent_image(
+            hosts=client.get_cluster_hosts(cluster_id),
+            image=image,
+        ),
+        timeout_seconds=timeout,
+        sleep_seconds=interval,
+        waiting_for=f"Nodes to be using agent image {image}",
     )
 
 


### PR DESCRIPTION
Currently the agent upgrade test uses a non existing image to ensure that all the hosts have stopped using the previous image. This causes timeouts because when hosts try to register using that non existing image they fail and then wait for one hour. To avoid that this patch changes the test so that it doesn't use that non existing image, instead of that it explicitly waits till all the hosts have upgraded to the new image.

Related: https://issues.redhat.com//browse/MGMT-14526