### PR TITLE
default_triggers skip when update_param called from tests

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/env_var.py
+++ b/src/assisted_test_infra/test_infra/utils/env_var.py
@@ -50,6 +50,10 @@ class EnvVar:
     def is_user_set(self):
         return self.__is_user_set
 
+    @is_user_set.setter
+    def user_set(self, bool_value):
+        self.__is_user_set = bool_value
+
     def copy(self, value=None) -> "EnvVar":
         """Get EnvVar copy, if value is different than None it will set the old EnvVar value"""
         env = EnvVar(self.__var_keys, loader=self.__loader, default=self.__default)

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -75,6 +75,8 @@ class BaseTest:
             with suppress(pytest.FixtureLookupError, AttributeError):
                 if hasattr(config, fixture_name):
                     value = request.getfixturevalue(fixture_name)
+                    # update params will skipp auto trigger for the variable
+                    global_variables.__dict__[fixture_name].user_set = True
                     config.set_value(fixture_name, value)
 
                     log.debug(f"{config_type}.{fixture_name} value updated from parameterized value to {value}")


### PR DESCRIPTION
Current code use default_triggers and when we set env param that appears in the triggers we skipp it in is_user_set function that check __is_user_set equal to False

Added support in update_parameterized to set __is_user_set to True. When triggered call it skip it.

The priority for params are:
global (env param from export)
update_parameterized --> called from testcases
default_triggers -> if variables not __is_user_set else skip