### PR TITLE
update user_set when calls update_parameterized

### DIFF
--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -75,7 +75,7 @@ class BaseTest:
             with suppress(pytest.FixtureLookupError, AttributeError):
                 if hasattr(config, fixture_name):
                     value = request.getfixturevalue(fixture_name)
-                    config.set_value(fixture_name, value)
+                    config.set_value(fixture_name, value, update_parameterized=True)
 
                     log.debug(f"{config_type}.{fixture_name} value updated from parameterized value to {value}")
                 else:


### PR DESCRIPTION
default_trigger checks if param already set by user in env variable.
Added support for update_parameterized from tests
The priority for params are:
global (env param from export)
update_parameterized --> called from testcases