### PR TITLE
MGMT-15018: Add option to mark variable origin

### DIFF
--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -45,7 +45,7 @@ from service_client import InventoryClient, SuppressAndLog, log
 from tests.config import ClusterConfig, InfraEnvConfig, TerraformConfig, global_variables
 from tests.config.global_configs import Day2ClusterConfig, NutanixConfig, OciConfig, VSphereConfig
 from triggers import get_default_triggers
-from triggers.env_trigger import Trigger
+from triggers.env_trigger import Trigger, VariableOrigin
 
 
 class BaseTest:
@@ -75,7 +75,7 @@ class BaseTest:
             with suppress(pytest.FixtureLookupError, AttributeError):
                 if hasattr(config, fixture_name):
                     value = request.getfixturevalue(fixture_name)
-                    config.set_value(fixture_name, value)
+                    config.set_value(fixture_name, value, origin=VariableOrigin.PARAMETERIZED)
 
                     log.debug(f"{config_type}.{fixture_name} value updated from parameterized value to {value}")
                 else:

--- a/src/tests/global_variables/default_variables.py
+++ b/src/tests/global_variables/default_variables.py
@@ -31,9 +31,6 @@ class DefaultVariables(_EnvVariables, Triggerable):
         self._set("openshift_version", utils.get_openshift_version(allow_default=True, client=client))
         Trigger.trigger_configurations([self], get_default_triggers())
 
-    def is_user_set(self, item: str) -> bool:
-        return self.get_env(item).is_user_set
-
     def _set(self, key: str, value: Any):
         if not hasattr(self, key):
             raise AttributeError(f"Invalid key {key}")


### PR DESCRIPTION
We currently can only differ if variable is set as environment variable or not.
This PR add the option to know the origin of a variable - where it was set