### PR TITLE
MGMT-14240: Plug OCI platform e2e test into CI

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -39,13 +39,13 @@ RUN dnf -y install --enablerepo=crb \
 # running with a random user.
 RUN git config --system --add safe.directory '*'
 
-RUN curl --retry 5 -Lo packer.zip https://releases.hashicorp.com/packer/1.8.0/packer_1.8.0_linux_386.zip && unzip packer.zip -d /usr/bin/ && mv /usr/bin/packer /usr/bin/packer.io && rm -rf packer.zip
-RUN curl --retry 5 -Lo terraform.zip https://releases.hashicorp.com/terraform/1.3.6/terraform_1.3.6_linux_amd64.zip && unzip terraform.zip -d /usr/bin/ && rm -rf terraform.zip
-RUN curl --retry 5 -L https://github.com/containers/podman/releases/download/v3.4.4/podman-remote-static.tar.gz -o "/tmp/podman-remote3.tar.gz" && \
+RUN curl --retry 5 --connect-timeout 30 -Lo packer.zip https://releases.hashicorp.com/packer/1.8.0/packer_1.8.0_linux_386.zip && unzip packer.zip -d /usr/bin/ && mv /usr/bin/packer /usr/bin/packer.io && rm -rf packer.zip
+RUN curl --retry 5 --connect-timeout 30 -Lo terraform.zip https://releases.hashicorp.com/terraform/1.3.6/terraform_1.3.6_linux_amd64.zip && unzip terraform.zip -d /usr/bin/ && rm -rf terraform.zip
+RUN curl --retry 5 --connect-timeout 30 -L https://github.com/containers/podman/releases/download/v3.4.4/podman-remote-static.tar.gz -o "/tmp/podman-remote3.tar.gz" && \
     tar -zxvf /tmp/podman-remote3.tar.gz && \
     mv podman-remote-static /tools/podman-remote3 && \
     rm -f /tmp/podman-remote3.tar.gz &&\
-    curl --retry 5 -L https://github.com/containers/podman/releases/download/v4.1.1/podman-remote-static.tar.gz -o "/tmp/podman-remote4.tar.gz" && \
+    curl --retry 5 --connect-timeout 30 -L https://github.com/containers/podman/releases/download/v4.1.1/podman-remote-static.tar.gz -o "/tmp/podman-remote4.tar.gz" && \
     tar -zxvf /tmp/podman-remote4.tar.gz && \
     mv podman-remote-static /tools/podman-remote4 && \
     rm -f /tmp/podman-remote4.tar.gz
@@ -60,7 +60,7 @@ RUN pip3 install --upgrade pip && \
       pip3 install --no-cache-dir -I -r ./requirements.txt -r ./requirements-dev.txt && \
       pip3 install --upgrade /build/pip/*
 
-RUN curl --retry 5 -s https://storage.googleapis.com/golang/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xz
+RUN curl --retry 5 --connect-timeout 30 -s https://storage.googleapis.com/golang/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV GOPATH=/go
 ENV GOCACHE=/go/.cache
 ENV PATH=$PATH:/usr/local/go/bin:/go/bin

--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -68,8 +68,9 @@ ENV PATH=$PATH:/usr/local/go/bin:/go/bin
 COPY . .
 
 # init terraform in order to cache the provider
-RUN terraform -chdir=/home/assisted-test-infra/terraform_files/equinix-ci-machine init && \
-    terraform -chdir=/home/assisted-test-infra/terraform_files/oci-ci-machine init && \
+RUN source scripts/utils.sh && \
+    retry -- terraform -chdir=/home/assisted-test-infra/terraform_files/equinix-ci-machine init && \
+    retry -- terraform -chdir=/home/assisted-test-infra/terraform_files/oci-ci-machine init && \
     chgrp -R 0 /home/assisted-test-infra && \
     chmod -R g=u /home/assisted-test-infra
 

--- a/ansible_files/ansible.cfg
+++ b/ansible_files/ansible.cfg
@@ -2,3 +2,6 @@
 host_key_checking = False
 remote_tmp = /tmp/ansible
 verbosity = 2
+
+[ssh_connection]
+retries = 10

--- a/ansible_files/oci_generic_destroy_ci_machine_playbook.yml
+++ b/ansible_files/oci_generic_destroy_ci_machine_playbook.yml
@@ -11,6 +11,7 @@
       delay: 30
       register: result
       until: result is succeeded
+      ignore_errors: true
 - name: Destroy OCI infrastructure provisionned for CI machine
   hosts: localhost
   vars_prompt:

--- a/ansible_files/oci_generic_destroy_ci_machine_playbook.yml
+++ b/ansible_files/oci_generic_destroy_ci_machine_playbook.yml
@@ -1,4 +1,17 @@
-- name: Destroy OCI infrastructure
+- name: Destroy OCI instrastructure provisionned by test-infra
+  hosts: primary
+  tasks:
+    - name: Destroy OCI instrastructure provisionned by test-infra
+      ansible.builtin.shell: |
+        source /root/config.sh
+        make destroy_oci
+      args:
+        chdir: /home/assisted
+      retries: 5
+      delay: 30
+      register: result
+      until: result is succeeded
+- name: Destroy OCI infrastructure provisionned for CI machine
   hosts: localhost
   vars_prompt:
     - name: oci_tf_state_file

--- a/ansible_files/roles/oci/create_infra/tasks/main.yml
+++ b/ansible_files/roles/oci/create_infra/tasks/main.yml
@@ -32,3 +32,7 @@
   ansible.builtin.setup:
   delegate_to: "{{ deployed_tf.outputs.ci_machine_inventory.value.display_name }}"
   delegate_facts: true
+  retries: 5
+  delay: 30
+  register: result
+  until: result is succeeded

--- a/ansible_files/roles/oci/export_connection_details/files/packet-conf.sh
+++ b/ansible_files/roles/oci/export_connection_details/files/packet-conf.sh
@@ -1,4 +1,4 @@
 source "${SHARED_DIR}/fix-uid.sh"
 source "${SHARED_DIR}/ci-machine-config.sh"
 
-export SSHOPTS=(-o 'ConnectTimeout=5' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -o 'ServerAliveInterval=90' -o LogLevel=ERROR -i "${SSH_KEY_FILE}")
+export SSHOPTS=(-o 'ConnectTimeout=5' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -o 'ServerAliveInterval=90' -o LogLevel=ERROR -o 'ConnectionAttempts=10' -i "${SSH_KEY_FILE}")

--- a/ansible_files/roles/oci/export_connection_details/files/packet-conf.sh
+++ b/ansible_files/roles/oci/export_connection_details/files/packet-conf.sh
@@ -1,0 +1,4 @@
+source "${SHARED_DIR}/fix-uid.sh"
+source "${SHARED_DIR}/ci-machine-config.sh"
+
+export SSHOPTS=(-o 'ConnectTimeout=5' -o 'StrictHostKeyChecking=no' -o 'UserKnownHostsFile=/dev/null' -o 'ServerAliveInterval=90' -o LogLevel=ERROR -i "${SSH_KEY_FILE}")

--- a/ansible_files/roles/oci/export_connection_details/tasks/main.yml
+++ b/ansible_files/roles/oci/export_connection_details/tasks/main.yml
@@ -15,6 +15,11 @@
       src: fix-uid.sh
       dest: "{{ shared_dir }}/fix-uid.sh"
 
+  - name: Write Packet common configuration file
+    ansible.builtin.copy:
+      src: packet-conf.sh
+      dest: "{{ shared_dir }}/packet-conf.sh"
+
   - name: Write Ansible inventory
     ansible.builtin.template:
       src: inventory.j2

--- a/ansible_files/roles/oci/setup_oci_for_test_infra/templates/assisted-additional-config.j2
+++ b/ansible_files/roles/oci/setup_oci_for_test_infra/templates/assisted-additional-config.j2
@@ -1,3 +1,5 @@
+export PLATFORM=oci
+
 export OCI_COMPARTMENT="{{ oci_compartment_id }}"
 export OCI_USER="{{ oci_user_id }}"
 export OCI_PRIVATE_KEY_PATH="{{ oci_private_key_path_ci_machine }}"
@@ -10,9 +12,9 @@ export OCI_PRIVATE_SUBNET="{{ infra.oci_private_subnet_id }}"
 
 # CI machine to access nodes (connect on them through SSH)
 # Nodes to access CI machine (assisted-service API through HTTP/HTTPS)
-export OCI_EXTRA_NODE_NSG_IDS="['{{ infra.oci_ci_machine_access_nsg_id }}', '{{ infra.oci_cluster_ci_nsg_id }}']"
+export OCI_EXTRA_NODE_NSG_IDS="{{ infra.oci_ci_machine_access_nsg_id }},{{ infra.oci_cluster_ci_nsg_id }}"
 
 # CI machine to access load balancer (cluster access through HTTP/HTTPS/MCS/API)
-export OCI_EXTRA_LOAD_BALANCER_NSG_IDS="['{{ infra.oci_load_balancer_ci_nsg_id }}']"
+export OCI_EXTRA_LOAD_BALANCER_NSG_IDS="{{ infra.oci_load_balancer_ci_nsg_id }}"
 
 export BASE_DOMAIN="{{ oci_dns_zone }}"

--- a/scripts/hub-cluster/kind/kind.sh
+++ b/scripts/hub-cluster/kind/kind.sh
@@ -23,7 +23,7 @@ function install() {
 	fi
 
 	echo "Installing kind $KIND_VERSION..."
-	sudo curl -L https://kind.sigs.k8s.io/dl/v$KIND_VERSION/kind-linux-amd64 -o /usr/local/bin/kind
+	sudo curl --retry 5 --connect-timeout 30 -L https://kind.sigs.k8s.io/dl/v$KIND_VERSION/kind-linux-amd64 -o /usr/local/bin/kind
 	sudo chmod u+x /usr/local/bin/kind
 	echo "Installed successfully!"
 }

--- a/scripts/hub-cluster/minikube.sh
+++ b/scripts/hub-cluster/minikube.sh
@@ -47,7 +47,7 @@ function _init_minikube() {
 
 function install() {
     minikube_version=v1.25.2
-    curl --retry 3 -Lo minikube https://storage.googleapis.com/minikube/releases/${minikube_version}/minikube-linux-amd64
+    curl --retry 3 --connect-timeout 30 -Lo minikube https://storage.googleapis.com/minikube/releases/${minikube_version}/minikube-linux-amd64
     ${SUDO} install minikube /usr/local/bin/
     minikube version
     rm -f minikube

--- a/scripts/install_k8s_clients.sh
+++ b/scripts/install_k8s_clients.sh
@@ -4,10 +4,10 @@ export SUDO=$(if [ -x "$(command -v sudo)" ]; then echo "sudo"; else echo ""; fi
 
 function install_kubectl() {
     kubectl_version=v1.23.0
-    curl --retry 3 -LO https://dl.k8s.io/release/${kubectl_version}/bin/linux/amd64/kubectl
+    curl --retry 3 --connect-timeout 30 -LO https://dl.k8s.io/release/${kubectl_version}/bin/linux/amd64/kubectl
     chmod +x kubectl
 
-    curl -LO https://dl.k8s.io/${kubectl_version}/bin/linux/amd64/kubectl.sha256
+    curl --retry 3 --connect-timeout 30 -LO https://dl.k8s.io/${kubectl_version}/bin/linux/amd64/kubectl.sha256
     echo "$(<kubectl.sha256)  kubectl" | sha256sum --check
     ${SUDO} install kubectl /usr/local/bin/
     rm -f kubectl.sha256 kubectl
@@ -23,7 +23,7 @@ function install_oc() {
 
     echo "Installing oc..."
     for i in {1..4}; do
-        curl --retry 3 -SL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.12/openshift-client-linux.tar.gz | sudo tar -xz -C /usr/local/bin && break
+        curl --retry 3 --connect-timeout 30 -SL https://mirror.openshift.com/pub/openshift-v4/x86_64/clients/ocp/stable-4.12/openshift-client-linux.tar.gz | sudo tar -xz -C /usr/local/bin && break
         echo "oc installation failed. Retrying again in 5 seconds..."
         sleep 5
     done

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -212,4 +212,40 @@ function select_podman_client() {
   fi
 }
 
+function retry() {
+    attempts=5
+    interval=1
+
+    local OPTIND
+    while getopts "a:i:" opt ; do
+      case "${opt}" in
+          a )
+              attempts="${OPTARG}"
+              ;;
+          i )
+              interval="${OPTARG}"
+              ;;
+          * )
+              ;;
+      esac
+    done
+    shift $((OPTIND-1))
+
+    rc=0
+    for attempt in $(seq "${attempts}")
+    do
+        echo "Attempt ${attempt}/${attempts} to execute \"$*\"..."
+
+        if "$@"; then
+            return 0
+        else
+            rc=$?
+            echo "Failed with exit code ${rc}, retrying \"$*\"..."
+            sleep "${interval}"
+        fi
+    done
+
+    return ${rc}
+}
+
 "$@"

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/oci_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/oci_controller.py
@@ -136,3 +136,6 @@ class OciController(TFController):
         ip_addresses = [self._virtual_network_client.get_vnic(vnic.vnic_id).data.private_ip for vnic in vnics]
 
         return ip_addresses, mac_addresses
+
+    def set_dns(self, api_ip: str, ingress_ip: str) -> None:
+        return

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
@@ -101,6 +101,7 @@ class TFController(NodeController, ABC):
         for node in nodes:
             self.shutdown_node(node.name)
 
+    @abstractmethod
     def set_dns(self, api_ip: str, ingress_ip: str) -> None:
         utils.add_dns_record(
             cluster_name=self.cluster_name,

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
@@ -101,7 +101,6 @@ class TFController(NodeController, ABC):
         for node in nodes:
             self.shutdown_node(node.name)
 
-    @abstractmethod
     def set_dns(self, api_ip: str, ingress_ip: str) -> None:
         utils.add_dns_record(
             cluster_name=self.cluster_name,

--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -467,6 +467,7 @@ def get_default_openshift_version(client=None) -> str:
     return versions[0] if versions else None
 
 
+@retry(exceptions=RuntimeError, tries=5, delay=10, logger=log)
 def extract_version(release_image) -> semver.VersionInfo:
     """
     Extracts the version number from the release image.

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -25,6 +25,11 @@ _default_triggers = frozendict(
             conditions=[lambda config: config.platform == consts.Platforms.NUTANIX],
             tf_platform=consts.Platforms.NUTANIX,
         ),
+        "oci_platform": Trigger(
+            conditions=[lambda config: config.platform == consts.Platforms.OCI],
+            user_managed_networking=True,
+            tf_platform=consts.Platforms.OCI,
+        ),
         "sno": Trigger(
             conditions=[lambda config: config.masters_count == 1],
             workers_count=0,

--- a/terraform_files/oci-ci-machine/03_compute.tf
+++ b/terraform_files/oci-ci-machine/03_compute.tf
@@ -40,17 +40,23 @@ resource "oci_core_instance" "ci_instance" {
   # Required
   availability_domain = data.oci_identity_availability_domains.ads.availability_domains[0].name
   compartment_id      = var.oci_compartment_id
-  shape               = "VM.Standard.E4.Flex"
+  shape               = "VM.Standard3.Flex"
 
   shape_config {
     memory_in_gbs = 16
     ocpus         = 4
   }
 
+  platform_config {
+    type                             = "INTEL_VM"
+    are_virtual_instructions_enabled = true
+  }
+
   source_details {
     source_id               = data.oci_core_images.os_images.images[0].id
     source_type             = "image"
-    boot_volume_size_in_gbs = 250
+    boot_volume_size_in_gbs = 500
+    boot_volume_vpus_per_gb = 30
   }
 
   # Optional

--- a/terraform_files/oci/01_network_security_groups.tf
+++ b/terraform_files/oci/01_network_security_groups.tf
@@ -1,8 +1,9 @@
 # Create security groups for the future cluster
 # LB should be able to reach:
 #   - cluster nodes
-# cluster should be able to reach:
-#   - LB on internal API endpoint
+# cluster nodes should be able to reach:
+#   - LB (internal and external)
+#   - Other cluster nodes
 
 # load-balancer is hold by LB
 resource "oci_core_network_security_group" "nsg_load_balancer" {

--- a/terraform_files/oci/03_compute.tf
+++ b/terraform_files/oci/03_compute.tf
@@ -44,7 +44,8 @@ resource "oci_core_instance" "master" {
     nsg_ids = concat(
       [
         oci_core_network_security_group.nsg_cluster.id,
-        oci_core_network_security_group.nsg_load_balancer_access.id # allow access to load balancer (api-int)
+        oci_core_network_security_group.nsg_cluster_access.id, # allow access from other cluster nodes
+        oci_core_network_security_group.nsg_load_balancer_access.id # allow access from load balancer
       ],
       var.oci_extra_node_nsg_oicds # e.g.: allow access to ci-machine (assisted-service)
     )
@@ -93,7 +94,8 @@ resource "oci_core_instance" "worker" {
     nsg_ids = concat(
       [
         oci_core_network_security_group.nsg_cluster.id,
-        oci_core_network_security_group.nsg_load_balancer_access.id # allow access to load balancer (api-int)
+        oci_core_network_security_group.nsg_cluster_access.id, # allow access from other cluster nodes
+        oci_core_network_security_group.nsg_load_balancer_access.id # allow access from load balancer
       ],
       var.oci_extra_node_nsg_oicds # e.g.: allow access to ci-machine (assisted-service)
     )


### PR DESCRIPTION
Fix several fixes in order to make the OCI e2e test work in Prow:
- Fix NSGs on clusters nodes
  - Allow communications between them
  - Allow communications from the nodes to the LB 
- Prevent the creation of DNS entries on the CI machine, it's not required since we setup DNS in OCI 
- Implemented various retries, I observed a lot of flakiness from OCI
- Force user managed networking to true when platform is OCI