### PR TITLE
Add support to update iso file for set_boot_order

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
@@ -136,9 +136,9 @@ class Node:
         output = self.run_command(f"sudo systemctl is-active {service}.service || true")
         return output.strip() == "active"
 
-    def set_boot_order(self, cd_first=False):
+    def set_boot_order(self, cd_first=False, cdrom_iso_path=None) -> None:
         log.info("Setting boot order with cd_first=%s on %s", cd_first, self.name)
-        self.node_controller.set_boot_order(node_name=self.name, cd_first=cd_first)
+        self.node_controller.set_boot_order(node_name=self.name, cd_first=cd_first, cdrom_iso_path=cdrom_iso_path)
 
     def set_per_device_boot_order(self, key: Callable[[Disk], int]):
         log.info("Setting boot order on %s", self.name)

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -124,7 +124,7 @@ class NodeController(ABC):
     def is_active(self, node_name) -> bool:
         pass
 
-    def set_boot_order(self, node_name, cd_first=False) -> None:
+    def set_boot_order(self, node_name: str, cd_first: bool = False, cdrom_iso_path: str = None) -> None:
         pass
 
     @abstractmethod

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/nutanix_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/nutanix_controller.py
@@ -90,12 +90,14 @@ class NutanixController(TFController):
         log.info(f"Found 2 optional VIPs: {free_ips}")
         return {"api_vip": free_ips.pop(), "ingress_vip": free_ips.pop()}
 
-    def set_boot_order(self, node_name, cd_first=False) -> None:
+    def set_boot_order(self, node_name, cd_first=False, cdrom_iso_path=None) -> None:
         vm = self._get_provider_vm(tf_vm_name=node_name)
         if cd_first:
             vm.update_boot_order(VMBootDevices.default_boot_order())
         else:
             vm.update_boot_order([VMBootDevices.DISK, VMBootDevices.CDROM, VMBootDevices.NETWORK])
+        if cdrom_iso_path:
+            raise NotImplementedError("Updating cdrom iso file path is not implemented")
 
     @property
     def terraform_vm_resource_type(self) -> str:


### PR DESCRIPTION
Added iso file path when user change the boot order. It will allow us in a cluster to boot nodes with different iso files uscases:
 - Day2 master must be in the same network as day1 masters, we can re-use one of the existing nodes to become a day2 master by overriding iso file
 - Static network changes requires to download the iso again but we dont want to override all nodes iso path
 - Validate re-download iso file when different configurations (proxy)
 - Add support for re-usable nodes plus check how we manage multiple iso in a cluster deployment

In case we want to re-use the node with same network params. node.set_boot_order(cd_first=True, cdrom_iso_path="/tmp/test.iso) node.start()