### PR TITLE
Fix paramiko incorrectly auto-detects private key method

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/ssh.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/ssh.py
@@ -47,7 +47,7 @@ class SshConnection:
             timeout=timeout,
             look_for_keys=False,
             auth_timeout=timeout,
-            key_filename=str(self._key_path),
+            pkey=paramiko.RSAKey.from_private_key_file(self._key_path),
         )
         self._ssh_client.get_transport().set_keepalive(15)
 


### PR DESCRIPTION
It seems like paramiko has a known issue where sometimes keys are not treated with the right encryption method (in our case as DSA instead of RSA):
https://github.com/paramiko/paramiko/issues/1839
[an example for such an error](https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-master-e2e-metal-assisted-ipv4v6-periodic/1677886652934000640)

Until there's a fix, this works around this issue by creating the key object with the intended encryption method RSA.