### PR TITLE
Group dependabot updates in one PR

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -18,6 +18,12 @@ updates:
       - "ok-to-test"
       - "dependencies"
       - "python"
+    groups:  # dependabot will only open one PR to update all dependencies
+      python-dependencies:
+        patterns:
+          - "*"
+        exclude-patterns:
+          - "flake8-bugbear"
 
   - package-ecosystem: "docker"
     directory: "/"


### PR DESCRIPTION
Following instructions at
https://docs.github.com/en/code-security/dependabot/dependabot-version-updates/configuration-options-for-the-dependabot.yml-file#groups, this makes dependabot to only open one PR for updating all the Python third-party dependencies, which should save some costs for us (as we don't need to run several e2e tests for each dependency being changed).

/cc @adriengentil @eliorerz 