### PR TITLE
MGMT-15312: Create  policy for OCI CCM in terraform

### DIFF
--- a/terraform_files/oci/03_compute.tf
+++ b/terraform_files/oci/03_compute.tf
@@ -7,6 +7,29 @@ locals {
   availability_domains_count = length(data.oci_identity_availability_domains.ads.availability_domains)
 }
 
+# Define tag namespace. Use to mark instance roles and configure instance policy
+resource "oci_identity_tag_namespace" "cluster_tags" {
+  compartment_id = var.oci_compartment_oicd
+  description    = "Used for track ${var.cluster_name} related resources and policies"
+  is_retired     = "false"
+  name           = var.cluster_name
+}
+
+resource "oci_identity_tag" "cluster_instance_role" {
+  description      = "Describe instance role inside OpenShift cluster"
+  is_cost_tracking = "false"
+  is_retired       = "false"
+  name             = "instance-role"
+  tag_namespace_id = oci_identity_tag_namespace.cluster_tags.id
+  validator {
+    validator_type = "ENUM"
+    values = [
+      "master",
+      "worker",
+    ]
+  }
+}
+
 # Create master instances
 resource "oci_core_instance" "master" {
   count = var.masters_count
@@ -22,8 +45,8 @@ resource "oci_core_instance" "master" {
   }
 
   platform_config {
-    type=var.instance_platform_config_type
-    are_virtual_instructions_enabled=var.instance_platform_config_virtualization_enabled
+    type                             = var.instance_platform_config_type
+    are_virtual_instructions_enabled = var.instance_platform_config_virtualization_enabled
   }
 
   source_details {
@@ -44,11 +67,15 @@ resource "oci_core_instance" "master" {
     nsg_ids = concat(
       [
         oci_core_network_security_group.nsg_cluster.id,
-        oci_core_network_security_group.nsg_cluster_access.id, # allow access from other cluster nodes
+        oci_core_network_security_group.nsg_cluster_access.id,      # allow access from other cluster nodes
         oci_core_network_security_group.nsg_load_balancer_access.id # allow access from load balancer
       ],
       var.oci_extra_node_nsg_oicds # e.g.: allow access to ci-machine (assisted-service)
     )
+  }
+
+  defined_tags = {
+    "${var.cluster_name}.instance-role" = "master"
   }
 
   preserve_boot_volume = false
@@ -72,8 +99,8 @@ resource "oci_core_instance" "worker" {
   }
 
   platform_config {
-    type=var.instance_platform_config_type
-    are_virtual_instructions_enabled=var.instance_platform_config_virtualization_enabled
+    type                             = var.instance_platform_config_type
+    are_virtual_instructions_enabled = var.instance_platform_config_virtualization_enabled
   }
 
   source_details {
@@ -94,15 +121,40 @@ resource "oci_core_instance" "worker" {
     nsg_ids = concat(
       [
         oci_core_network_security_group.nsg_cluster.id,
-        oci_core_network_security_group.nsg_cluster_access.id, # allow access from other cluster nodes
+        oci_core_network_security_group.nsg_cluster_access.id,      # allow access from other cluster nodes
         oci_core_network_security_group.nsg_load_balancer_access.id # allow access from load balancer
       ],
       var.oci_extra_node_nsg_oicds # e.g.: allow access to ci-machine (assisted-service)
     )
   }
 
+  defined_tags = {
+    "${var.cluster_name}.instance-role" = "worker"
+  }
+
   preserve_boot_volume = false
 
   # ensure the custom image was updated before creating these instances
   depends_on = [oci_core_compute_image_capability_schema.discovery_image_firmware_uefi_64]
+}
+
+resource "oci_identity_dynamic_group" "master_nodes" {
+  compartment_id = var.oci_tenancy_oicd # dynamic groups can only be created in root compartment
+  description    = "${var.cluster_name} master nodes"
+  matching_rule  = "all {instance.compartment.id='${var.oci_compartment_oicd}', tag.${var.cluster_name}.instance-role.value='master'}"
+  name           = "${var.cluster_name}-masters"
+}
+
+# The CCM will run only master nodes, no need to set a policy on worker nodes
+resource "oci_identity_policy" "master_nodes" {
+  compartment_id = var.oci_compartment_oicd
+  description    = "${var.cluster_name} master nodes instance principal"
+  name           = "${var.cluster_name}-masters"
+  statements = [
+    "Allow dynamic-group ${oci_identity_dynamic_group.master_nodes.name} to manage volume-family in compartment id ${var.oci_compartment_oicd}",
+    "Allow dynamic-group ${oci_identity_dynamic_group.master_nodes.name} to manage instance-family in compartment id ${var.oci_compartment_oicd}",
+    "Allow dynamic-group ${oci_identity_dynamic_group.master_nodes.name} to manage security-lists in compartment id ${var.oci_compartment_oicd}",
+    "Allow dynamic-group ${oci_identity_dynamic_group.master_nodes.name} to use virtual-network-family in compartment id ${var.oci_compartment_oicd}",
+    "Allow dynamic-group ${oci_identity_dynamic_group.master_nodes.name} to manage load-balancers in compartment id ${var.oci_compartment_oicd}",
+  ]
 }

--- a/terraform_files/oci/variables.tf
+++ b/terraform_files/oci/variables.tf
@@ -85,21 +85,21 @@ variable "oci_extra_lb_nsg_oicds" {
 }
 
 variable "instance_shape" {
-  type = string
+  type        = string
   description = "The shape of the instance. The shape determines the number of CPUs and the amount of memory allocated to the instance"
-  default = "VM.Standard3.Flex"
+  default     = "VM.Standard3.Flex"
 }
 
 variable "instance_platform_config_type" {
-  type = string
+  type        = string
   description = "The type of platform being configured. (Supported types=[INTEL_VM, AMD_MILAN_BM, AMD_ROME_BM, AMD_ROME_BM_GPU, INTEL_ICELAKE_BM, INTEL_SKYLAKE_BM])"
-  default = "INTEL_VM"
+  default     = "INTEL_VM"
 }
 
 variable "instance_platform_config_virtualization_enabled" {
-  type = bool
+  type        = bool
   description = "Whether virtualization instructions are available. For example, Secure Virtual Machine for AMD shapes or VT-x for Intel shapes."
-  default = "true"
+  default     = "true"
 }
 
 ///////////


### PR DESCRIPTION
- Tag cluster nodes with a specific tag
- Create a dynamic group for the master nodes based on tag
- Create a policy based on the dynamic group in order to allow the masters/CCM to be authorized to manage instances/networks/load-balancers in OCI