### PR TITLE
NO-ISSUE: Fix issue that prevent deploying nodes on platform different from cluster platform

### DIFF
--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -34,6 +34,7 @@ from assisted_test_infra.test_infra.controllers import (
     TerraformController,
     VSphereController,
 )
+from assisted_test_infra.test_infra.controllers.node_controllers.tf_controller import TFController
 from assisted_test_infra.test_infra.helper_classes import kube_helpers
 from assisted_test_infra.test_infra.helper_classes.cluster import Cluster
 from assisted_test_infra.test_infra.helper_classes.config import BaseConfig, BaseNodesConfig
@@ -383,27 +384,25 @@ class BaseTest:
     def controller(
         self, cluster_configuration: ClusterConfig, controller_configuration: BaseNodesConfig, trigger_configurations
     ) -> NodeController:
-        if cluster_configuration.platform == consts.Platforms.VSPHERE:
-            return VSphereController(controller_configuration, cluster_configuration)
+        return self.get_terraform_controller(controller_configuration, cluster_configuration)
 
-        if cluster_configuration.platform == consts.Platforms.NUTANIX:
-            return NutanixController(controller_configuration, cluster_configuration)
-
-        if cluster_configuration.platform == consts.Platforms.OCI:
-            return OciController(controller_configuration, cluster_configuration)
-
-        return TerraformController(controller_configuration, entity_config=cluster_configuration)
-
+    @classmethod
     def get_terraform_controller(
-        self, controller_configuration: BaseNodesConfig, cluster_configuration: ClusterConfig
-    ) -> TerraformController:
-        if cluster_configuration.platform == consts.Platforms.VSPHERE:
+        cls, controller_configuration: BaseNodesConfig, cluster_configuration: ClusterConfig
+    ) -> TerraformController | TFController:
+        platform = (
+            global_variables.tf_platform
+            if global_variables.tf_platform != cluster_configuration.platform
+            else cluster_configuration.platform
+        )
+
+        if platform == consts.Platforms.VSPHERE:
             return VSphereController(controller_configuration, cluster_configuration)
 
-        if cluster_configuration.platform == consts.Platforms.NUTANIX:
+        if platform == consts.Platforms.NUTANIX:
             return NutanixController(controller_configuration, cluster_configuration)
 
-        if cluster_configuration.platform == consts.Platforms.OCI:
+        if platform == consts.Platforms.OCI:
             return OciController(controller_configuration, cluster_configuration)
 
         return TerraformController(controller_configuration, entity_config=cluster_configuration)

--- a/src/tests/test_targets.py
+++ b/src/tests/test_targets.py
@@ -56,25 +56,6 @@ class TestMakefileTargets(BaseTest):
         log.info(f"Successfully deleted {len(clusters)} clusters")
 
     @JunitTestSuite()
-    def test_destroy_terraform(
-        self, api_client: InventoryClient, prepared_controller_configuration: BaseNodesConfig, cluster_configuration
-    ):
-        """Destroy cluster via terraform"""
-
-        cluster_id = cluster_configuration.cluster_id
-        clusters = api_client.clusters_list() if not cluster_id else [{"id": cluster_id}]
-
-        for cluster_info in clusters:
-            cluster = Cluster(api_client, ClusterConfig(cluster_id=cluster_info["id"]), InfraEnvConfig())
-            controller = self.get_terraform_controller(prepared_controller_configuration, cluster._config)
-            config_vars = controller.get_all_vars()
-            controller.tf.set_vars(**config_vars)
-            controller.tf.select_defined_variables()
-            controller.destroy_all_nodes()
-
-        log.info(f"Successfully destroyed {len(clusters)} clusters")
-
-    @JunitTestSuite()
     def test_destroy_available_terraform(
         self, prepared_controller_configuration: BaseNodesConfig, cluster_configuration
     ):


### PR DESCRIPTION
Sometimes for testing purposes we want to create nodes on one platform and set the cluster platform with another, e.g.
```bash
make test TF_PLATFORM=nutanix PLATFORM=baremetal
``` 

Also remove unused code that uses `get_terraform_controller` method


/cc @osherdp @adriengentil 