### PR TITLE
[WIP] MGMT-15510: Initialize terraform controller after cluster registration

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -36,6 +36,9 @@ class NodeController(ABC):
     def is_ipv6(self):
         return self._config.is_ipv6
 
+    def init_controller(self):
+        pass
+
     @abstractmethod
     def list_nodes(self) -> List[Node]:
         pass

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
@@ -30,13 +30,13 @@ class VSphereController(TFController):
         del config["iso_download_path"]
 
         self._create_folder(self._config.vsphere_parent_folder)
-        self.tf.set_and_apply(**config)
+        self._tf.set_and_apply(**config)
         return self.list_nodes()
 
     def notify_iso_ready(self) -> None:
         self.shutdown_all_nodes()
         config = self.get_all_vars()
-        self.tf.set_and_apply(**config)
+        self._tf.set_and_apply(**config)
 
     def get_cpu_cores(self, node_name: str) -> int:
         return self._get_vm(node_name)["attributes"]["num_cpus"]
@@ -56,7 +56,7 @@ class VSphereController(TFController):
         return ips, macs
 
     def destroy_all_nodes(self) -> None:
-        self.tf.destroy(force=False)
+        self._tf.destroy(force=False)
 
     def start_node(self, node_name: str, check_ips: bool) -> None:
         def start(vm) -> task:

--- a/src/assisted_test_infra/test_infra/helper_classes/entity.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/entity.py
@@ -18,6 +18,7 @@ class Entity(ABC):
         self.nodes: Nodes = nodes
         self._create() if not self.id else self.update_existing()
         self._config.iso_download_path = self.get_iso_download_path()
+        nodes.init_controller()
 
     @property
     @abstractmethod

--- a/src/assisted_test_infra/test_infra/helper_classes/nodes.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/nodes.py
@@ -70,6 +70,10 @@ class Nodes:
         for n in self.nodes:
             yield n
 
+    def init_controller(self):
+        if self.controller and hasattr(self.controller, "init_controller"):
+            self.controller.init_controller()
+
     def drop_cache(self):
         self._nodes = None
         self._nodes_as_dict = None

--- a/src/tests/test_targets.py
+++ b/src/tests/test_targets.py
@@ -94,6 +94,7 @@ class TestMakefileTargets(BaseTest):
                     dummy_iso_path.touch(exist_ok=True)
 
                     controller = self.get_terraform_controller(prepared_controller_configuration, cluster_configuration)
+                    controller.init_controller()
                     config_vars = controller.get_all_vars()
                     controller.tf.set_vars(**config_vars)
                     controller.destroy_all_nodes()


### PR DESCRIPTION
Currently the controllers are initialized before the cluster creation causing the terraform resources names to be different than the given ones (only in case where the cluster has a different name than the generated one - e.g create cluster via the UI and pass CLUSTER_ID)

Currently, the node controllers are initialized before the cluster creation, causing the Terraform resources names to be different from the ones provided (but only in cases where the cluster has a different name than the generated one). For example, if you create a cluster using the UI and pass CLUSTER_ID, this issue occurs.


/cc @talhil-rh