### PR TITLE
Change manifest parametrize - move the logic to validate_params

### DIFF
--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -7,7 +7,6 @@ from pathlib import Path
 
 import consts
 from assisted_test_infra.test_infra.utils.env_var import EnvVar
-from assisted_test_infra.test_infra.utils.manifests import Manifest
 from consts import env_defaults, resources
 from triggers.env_trigger import DataPool
 
@@ -73,7 +72,7 @@ class _EnvVariables(DataPool, ABC):
     )
     custom_manifests: EnvVar = EnvVar(
         ["CUSTOM_MANIFESTS_FILES"],
-        loader=lambda files: [m for path in re.split(r"\s|,", files) for m in Manifest.get_manifests(Path(path))],
+        loader=lambda files: [path for path in re.split(r"\s|,", files)],
         default=[],
     )
     platform: EnvVar = EnvVar(["PLATFORM"])


### PR DESCRIPTION
In tests we are going to override manifest params, to make it simple we are going to support adding list of strings and remove the logic from EnvVar.

Current change will allow us to cofigure:

@pytest.mark.parametrize("custom_manifests",
                             [["/tmp/custom1/manifests/",
                               "/tmp/custom3/manifests/",
                              "/tmp/custom2/manifests/lital2.yaml"]])

To handle multiple directories or files.