### PR TITLE
NO-ISSUE: Use a regex to select OS image in OCI

### DIFF
--- a/terraform_files/oci-ci-machine/00_main.tf
+++ b/terraform_files/oci-ci-machine/00_main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.0.0"
+      version = "5.9.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"

--- a/terraform_files/oci-ci-machine/03_compute.tf
+++ b/terraform_files/oci-ci-machine/03_compute.tf
@@ -3,14 +3,21 @@ data "oci_identity_availability_domains" "ads" {
 }
 
 data "oci_core_images" "os_images" {
-  #Required
-  compartment_id = var.oci_compartment_id
-
-  display_name = var.os_image_name
-  state        = "AVAILABLE"
-  sort_by      = "TIMECREATED"
-  sort_order   = "DESC"
+  compartment_id           = var.oci_compartment_id
+  operating_system         = "Oracle Linux"
+  operating_system_version = "8"
+  state                    = "AVAILABLE"
+  sort_by                  = "TIMECREATED"
+  sort_order               = "DESC"
+  filter {
+    # in order to filter out specialized images (e.g.: GPU) or non-x86 images,
+    # match OS names simillar to: Oracle-Linux-8.8-2023.08.16-0
+    name   = "display_name"
+    values = ["^Oracle-Linux-\\d\\.\\d-\\d{4}\\.\\d{2}\\.\\d{2}-\\d$"]
+    regex  = true
+  }
 }
+
 
 # Use cloud init to configure root user
 # and grow root filesystem

--- a/terraform_files/oci-ci-machine/variables.tf
+++ b/terraform_files/oci-ci-machine/variables.tf
@@ -46,10 +46,3 @@ variable "oci_region" {
   type        = string
   description = "OCI region"
 }
-
-# List of available OSes: https://docs.oracle.com/en-us/iaas/images/oracle-linux-8x/
-variable "os_image_name" {
-  type        = string
-  description = "Name of the OS to be provisioned on the CI machine"
-  default     = "Oracle-Linux-8.7-2023.05.24-0"
-}

--- a/terraform_files/oci/00_main.tf
+++ b/terraform_files/oci/00_main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.1.0"
+      version = "5.9.0"
     }
   }
 }


### PR DESCRIPTION
OS images are updated regulary and old ones expire. In order to avoid
spending time to update OS images when job start to fail, use a regex to
select the right OS image.

I took the opportunity of this PR to update OCI provider version.
