### PR TITLE
adds custom manifest functions(list,delete,create_single) used in kni…

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -881,9 +881,7 @@ class Cluster(BaseCluster):
             with open(local_manifest.local_path, "rb") as f:
                 encoded_content = base64.b64encode(f.read()).decode("utf-8", "ignore")
 
-            manifest = self.api_client.create_custom_manifest(
-                self.id, local_manifest.folder, local_manifest.file_name, encoded_content
-            )
+            manifest = self.create_custom_manifest(local_manifest.folder, local_manifest.file_name, encoded_content)
 
             assert manifest.file_name == local_manifest.file_name
             assert manifest.folder == local_manifest.folder
@@ -895,6 +893,15 @@ class Cluster(BaseCluster):
             assert (
                 manifest.is_folder_allowed()
             ), f"Invalid value for `folder` {manifest.folder} must be one of {manifest.get_allowed_folders()}"
+
+    def create_custom_manifest(self, folder: str = None, filename: str = None, base64_content: str = None):
+        return self.api_client.create_custom_manifest(self.id, folder, filename, base64_content)
+
+    def list_custom_manifests(self) -> models.ListManifests:
+        return self.api_client.list_custom_manifests(self.id)
+
+    def delete_custom_manifest(self, filename: str = None) -> None:
+        self.api_client.delete_custom_manifest(self.id, filename)
 
     @JunitTestCase()
     def prepare_for_installation(self, **kwargs):

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -568,3 +568,9 @@ class InventoryClient(object):
     def create_custom_manifest(self, cluster_id: str, folder: str, file_name: str, base64_content: str) -> Manifest:
         params = CreateManifestParams(file_name=file_name, folder=folder, content=base64_content)
         return self.manifest.v2_create_cluster_manifest(cluster_id=cluster_id, create_manifest_params=params)
+
+    def list_custom_manifests(self, cluster_id: str) -> models.ListManifests:
+        return self.manifest.v2_list_cluster_manifests(cluster_id=cluster_id)
+
+    def delete_custom_manifest(self, cluster_id: str, file_name: str) -> None:
+        self.manifest.v2_delete_cluster_manifest(cluster_id=cluster_id, file_name=file_name)


### PR DESCRIPTION
@eliorerz @osherdp @lalon4 
Adding few functions in assisted_service_api and in cluster.py to enable:

adding a snigle specific custom manifest (without validation of the create_custom_manifest) to catch specific api errors in negative tests
option to list custom manifest
option to delete custom manifest