### PR TITLE
MGMT-14094: Cleanup dangling resources in OCI

### DIFF
--- a/ansible_files/oci_generic_cleanup_playbook.yml
+++ b/ansible_files/oci_generic_cleanup_playbook.yml
@@ -1,0 +1,32 @@
+- name: Cleanup expired resources in OCI
+  hosts: localhost
+    vars_prompt:
+    - name: oci_compartment_id
+      prompt: parent compartment OCID where the resources will be created
+      private: false
+    - name: oci_tenancy_id
+      prompt: tenancy OCID authentication value
+      private: false
+    - name: oci_user_id
+      prompt: user OCID authentication value
+      private: false
+    - name: oci_fingerprint
+      prompt: key fingerprint authentication value
+      private: false
+    - name: oci_region
+      prompt: OCI region
+      private: false
+    - name: oci_private_key_path
+      prompt: private key path authentication value
+      private: false
+  vars:
+    oci_terraform_workdir: "{{ [playbook_dir, '..', 'terraform_files', 'oci-ci-machine'] | path_join | realpath }}"
+  environment:
+    OCI_COMPARTMENT: "{{ oci_compartment_id }}"
+    OCI_USER: "{{ oci_user_id }}"
+    OCI_PRIVATE_KEY_PATH: "{{ oci_private_key_path }}"
+    OCI_PUBLIC_KEY_FINGERPRINT: "{{ oci_fingerprint }}"
+    OCI_TENANCY: "{{ oci_tenancy_id }}"
+    OCI_REGION: "{{ oci_region }}"
+  roles:
+    - name: oci/cleanup_resources

--- a/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
+++ b/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
@@ -1,0 +1,8 @@
+# these type are cleaned up by removing their parent resource
+# we exclude them from the removal to avoid conflict type of errors
+excluded_types:
+  - oci_load_balancer_backend
+  - oci_load_balancer_listener
+  - oci_core_private_ip
+  - oci_core_public_ip
+expired_after_hours: 6

--- a/ansible_files/roles/oci/cleanup_resources/tasks/main.yml
+++ b/ansible_files/roles/oci/cleanup_resources/tasks/main.yml
@@ -1,0 +1,84 @@
+- name: Look for OCI provider binaries
+  ansible.builtin.find:
+    paths: "{{ oci_terraform_workdir }}/.terraform/providers"
+    file_type: file
+    patterns: "terraform-provider-oci_*"
+    recurse: true
+  register: found_providers
+
+- name: Select OCI provider binary
+  ansible.builtin.set_fact:
+    oci_provider_bin: "{{ (found_providers.files | first).path }}"
+
+- name: Create temporary directory where resources will be imported as terraform files
+  ansible.builtin.tempfile:
+    state: directory
+    suffix: terraform
+  register: terraform_working_tmp_dir
+  when: terraform_working_dir is not defined
+
+- name: Set terraform_working_dir
+  ansible.builtin.set_fact:
+    terraform_working_dir: "{{ terraform_working_tmp_dir.path }}"
+  when: terraform_working_dir is not defined
+
+- name: Import OCI resources
+  ansible.builtin.command:
+    cmd: >-
+      {{ oci_provider_bin }}
+        -command=export
+        -compartment_id={{ oci_compartment_id }}
+        -output_path=.
+        -services=core,load_balancer,identity,object_storage,tagging
+        -generate_state
+    creates: "terraform.tfstate"
+    chdir: "{{ terraform_working_dir }}"
+  check_mode: false
+
+- name: Load terraform state
+  ansible.builtin.command:
+    cmd: terraform show -json
+    chdir: "{{ terraform_working_dir }}"
+  register: terraform_state
+  check_mode: false
+  changed_when: false
+
+- name: Convert terraform state to dict
+  ansible.builtin.set_fact:
+    terraform_resources: "{{ (terraform_state.stdout | from_json)['values']['root_module']['resources'] | default([]) }}"
+    excluded_resources: []
+
+- name: Exclude types from terraform state
+  ansible.builtin.set_fact:
+    excluded_resources: "{{ excluded_resources + [item] }}"
+  loop: "{{ terraform_resources }}"
+  when: item.type in excluded_types
+
+- name: Exclude recently created resources from terraform state
+  ansible.builtin.set_fact:
+    excluded_resources: "{{ excluded_resources + [item] }}"
+  loop: "{{ terraform_resources }}"
+  when:
+    - item["values"]["time_created"] is defined
+    - >-
+        (
+          now(utc=true).replace(tzinfo=None)
+          -
+          (item["values"]["time_created"] | ansible.builtin.to_datetime("%Y-%m-%d %H:%M:%S.%f %z %Z")).replace(tzinfo=None)
+        ).total_seconds() / 3600 < expired_after_hours
+
+- name: Remove excluded resources from terraform state
+  ansible.builtin.command:
+    cmd: terraform state rm {{ excluded_resources | json_query('[].address') | unique | join(" ") }}
+    chdir: "{{ terraform_working_dir }}"
+  when: excluded_resources | length > 0
+  changed_when: true
+
+- name: Destroy expired resources
+  community.general.terraform:
+    project_path: "{{ terraform_working_dir }}"
+    state: absent
+  register: result
+  until: "result is not failed"
+  retries: 10
+  delay: 10


### PR DESCRIPTION
Create a new playbook that will be called periodically to cleanup
dangling resources in OCI CI compartment.

The task cleans up almost all created resources during CI test except:
- dynamic groups, created in root compartment
- DNS records, which are missing metadata and creation date to remove
  them easily

These two missing elements will be implemented later.
