### PR TITLE
Fix get_host_validation_value

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -163,12 +163,12 @@ def get_host_validation_value(cluster_info, host_id, validation_section, validat
         if host.id != host_id:
             continue
         found_status = "validation not found"
-        validations = json.loads(host.validations_info)
-        for validation in validations[validation_section]:
-            if validation["id"] == validation_id:
-                found_status = validation["status"]
-                break
-        return found_status
+        if getattr(host, "validations_info", None):
+            for validation in json.loads(host.validations_info)[validation_section]:
+                if validation["id"] == validation_id:
+                    found_status = validation["status"]
+                    break
+            return found_status
     return "host not found"
 
 


### PR DESCRIPTION
Current validation run and by some reason host.validations_info returns none Added check that host.validations_info returns object to be called by json

It appears in our runs:
"""
- ERROR - 140446193698624 - Failed to get cluster 5687b4cd-b82d-487e-afb4-354e2748442e validation info Traceback (most recent call last):
  File "/var/tmp/assisted/assisted-test-infra/src/assisted_test_infra/test_infra/helper_classes/cluster.py", line 1026, in is_host_validation_in_status utils.get_host_validation_value( File "/var/tmp/assisted/assisted-test-infra/src/assisted_test_infra/test_infra/utils/utils.py", line 166, in get_host_validation_value validations = json.loads(host.validations_info) ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ File "/root/.pyenv/versions/3.11.0/lib/python3.11/json/__init__.py", line 339, in loads raise TypeError(f'the JSON object must be str, bytes or bytearray, ' TypeError: the JSON object must be str, bytes or bytearray, not NoneType

"""