### PR TITLE
Add support for cpu fallback model when set customize

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
@@ -169,6 +169,9 @@ class Node:
     def set_ram_kib(self, ram_kib):
         self.node_controller.set_ram_kib(self.name, ram_kib)
 
+    def set_cpu_fallback_model(self, fallback_model: str) -> None:
+        self.node_controller.set_cpu_fallback_model(self.name, fallback_model)
+
     def reset_ram_kib(self):
         self.set_ram_kib(self.original_ram_kib)
 

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -165,6 +165,10 @@ class NodeController(ABC):
     def set_ram_kib(self, node_name: str, ram_kib: int) -> None:
         pass
 
+    @abstractmethod
+    def set_cpu_fallback_model(self, node_name: str, fallback_model: str) -> None:
+        pass
+
     def get_primary_machine_cidr(self) -> Optional[str]:
         # Default to auto resolve by the cluster. see cluster.get_primary_machine_cidr
         return None

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
@@ -174,3 +174,6 @@ class TFController(NodeController, ABC):
 
     def set_single_node_ip(self, ip):
         pass
+
+    def set_cpu_fallback_model(self, node_name: str, fallback_model: str) -> None:
+        pass


### PR DESCRIPTION
Due to bug in RHEL9, vm unable to boot with qemu64 cpu model. BZ-2188896[RHEL9] when libvirt cpu mode=custom hit on kernel panic when trying to load the virtual machine