### PR TITLE
MGMT-14094: Fix oci cleanup

### DIFF
--- a/ansible_files/ansible.cfg
+++ b/ansible_files/ansible.cfg
@@ -2,6 +2,7 @@
 host_key_checking = False
 remote_tmp = /tmp/ansible
 verbosity = 2
+stdout_callback = yaml
 
 [ssh_connection]
 retries = 10

--- a/ansible_files/oci_generic_cleanup_playbook.yml
+++ b/ansible_files/oci_generic_cleanup_playbook.yml
@@ -1,6 +1,6 @@
 - name: Cleanup expired resources in OCI
   hosts: localhost
-    vars_prompt:
+  vars_prompt:
     - name: oci_compartment_id
       prompt: parent compartment OCID where the resources will be created
       private: false
@@ -22,11 +22,11 @@
   vars:
     oci_terraform_workdir: "{{ [playbook_dir, '..', 'terraform_files', 'oci-ci-machine'] | path_join | realpath }}"
   environment:
-    OCI_COMPARTMENT: "{{ oci_compartment_id }}"
-    OCI_USER: "{{ oci_user_id }}"
-    OCI_PRIVATE_KEY_PATH: "{{ oci_private_key_path }}"
-    OCI_PUBLIC_KEY_FINGERPRINT: "{{ oci_fingerprint }}"
-    OCI_TENANCY: "{{ oci_tenancy_id }}"
-    OCI_REGION: "{{ oci_region }}"
+    TF_VAR_compartment_ocid: "{{ oci_compartment_id }}"
+    TF_VAR_user_ocid: "{{ oci_user_id }}"
+    TF_VAR_private_key_path: "{{ oci_private_key_path }}"
+    TF_VAR_fingerprint: "{{ oci_fingerprint }}"
+    TF_VAR_tenancy_ocid: "{{ oci_tenancy_id }}"
+    TF_VAR_region: "{{ oci_region }}"
   roles:
     - name: oci/cleanup_resources

--- a/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
+++ b/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
@@ -1,8 +1,9 @@
 # these type are cleaned up by removing their parent resource
 # we exclude them from the removal to avoid conflict type of errors
 excluded_types:
-  - oci_load_balancer_backend
-  - oci_load_balancer_listener
   - oci_core_private_ip
   - oci_core_public_ip
+  - oci_load_balancer_backend
+  - oci_load_balancer_backend_set
+  - oci_load_balancer_listener
 expired_after_hours: 6


### PR DESCRIPTION
Few changes:
- Fix how credentials are passed
- Exclude `oci_load_balancer_backend_set`, it will be deleted along the
  LB it belongs to
- Improve ansible output
