### PR TITLE
Reduce stress when running start/stop in parallel runs

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
@@ -5,6 +5,7 @@ from paramiko import SSHException
 from scp import SCPException
 
 import consts
+from assisted_test_infra.test_infra import utils
 from assisted_test_infra.test_infra.controllers.node_controllers import ssh
 from assisted_test_infra.test_infra.controllers.node_controllers.disk import Disk
 from service_client import log
@@ -92,9 +93,11 @@ class Node:
                 output = _ssh.script(bash_command, verbose=False)
         return output
 
+    @utils.lock_function_call
     def shutdown(self):
         return self.node_controller.shutdown_node(self.name)
 
+    @utils.lock_function_call
     def start(self, check_ips=True):
         return self.node_controller.start_node(self.name, check_ips)
 

--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -306,6 +306,15 @@ def file_lock_context(filepath="/tmp/src.lock", timeout=300):
         lock.release()
 
 
+def lock_function_call(func):
+    @wraps(func)
+    def inner_func(*args, **kwargs):
+        with file_lock_context():
+            log.info(f"Lock function {func} during call")
+            return func(*args, **kwargs)
+    return inner_func
+
+
 def create_ip_address_list(node_count, starting_ip_addr):
     return [str(ipaddress.ip_address(starting_ip_addr) + i) for i in range(node_count)]
 


### PR DESCRIPTION
We have issues related to nodes installation post node reboot or timeout for operators CVO , CNV and more.

When runnin the same test without parallel we have less issues and its hard to reproduce.

Adding support for serial node actions , means all actions related to node start, node shutdown, clean_virsh_resources and assetes actions will share the same lock.

The purpose is to reduce stress from libvirt when having parallel jobs. The node start/stop will be delayed to lock, we will try to see if the CI results changed or node.

The current code missing external param to controll the nodes actions , parallel support or not ... will do it later after POC .

Current code wont impact on installation process only on node creation and shutdown triggered by controllers.