### PR TITLE
MGMT-15598: Bugfix - list all cluster manifests irrespective of type

### DIFF
--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -260,7 +260,9 @@ class InventoryClient(object):
 
     def download_manifests(self, cluster_id: str, dir_path: str) -> None:
         log.info(f"Downloading manifests for cluster {cluster_id} into {dir_path}")
-        response = self.manifest.v2_list_cluster_manifests(cluster_id=cluster_id, _preload_content=False)
+        response = self.manifest.v2_list_cluster_manifests(
+            cluster_id=cluster_id, include_system_generated=True, _preload_content=False
+        )
         for record in json.loads(response.data):
             response = self.manifest.v2_download_cluster_manifest(
                 cluster_id=cluster_id, file_name=record["file_name"], folder=record["folder"], _preload_content=False


### PR DESCRIPTION
A recent change to Assisted Service changed the default behaviour of the manifest list functionality. By default, the manifest list will only return manifests that were supplied by the user and will exclude system generated manifests.

This PR works in conjunction with a PR to the service https://github.com/openshift/assisted-service/pull/5498/files  (and corresponding Python client) to supply an additional parameter
"include_system_generated" and set this to "true" so that assisted-test-infra will fetch all manifests irrespective of type.