### PR TITLE
MGMT-14094: Install jmespath

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -35,4 +35,5 @@ prompt_toolkit==3.0.39
 nutanix-api==0.0.20
 pytest-error-for-skips==2.0.2
 ansible==8.3.0
+jmespath==1.0.1
 oci==2.112.0


### PR DESCRIPTION
jmespath is a required dependency to use `json_query` filter in ansible.

fixes oci cleanup ansible role.