### PR TITLE
MGMT-15707: Add s390x trigger

### DIFF
--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -330,3 +330,10 @@ class DeployTargets:
     ONPREM = "onprem"
     MINIKUBE = "minikube"
     ASSISTED_OPERATOR = "operator"
+
+
+class CPUArchitecture:
+    X86 = "x86_64"
+    ARM = "arm64"
+    S390X = "s390x"
+    PPC64 = "ppc64le"

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -83,6 +83,11 @@ _default_triggers = frozendict(
             master_boot_devices=["hd", "network"],
             worker_boot_devices=["hd", "network"],
         ),
+        "cpu_s390x": Trigger(
+            conditions=[lambda config: config.cpu_architecture == consts.CPUArchitecture.S390X],
+            user_managed_networking=True,
+            iso_image_type=consts.ImageType.FULL_ISO,
+        ),
     }
 )
 


### PR DESCRIPTION
To enable s390x architecture a trigger is necessary to set the required values for user_managed_networking (true) and iso_image_type (full_iso).