### PR TITLE
MGMT-14094: Manage case when no resources are found in OCI

### DIFF
--- a/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
+++ b/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
@@ -6,4 +6,7 @@ excluded_types:
   - oci_load_balancer_backend
   - oci_load_balancer_backend_set
   - oci_load_balancer_listener
+  - oci_network_load_balancer_backend
+  - oci_network_load_balancer_backend_set
+  - oci_network_load_balancer_listener
 expired_after_hours: 6

--- a/ansible_files/roles/oci/cleanup_resources/tasks/cleanup_resources.yml
+++ b/ansible_files/roles/oci/cleanup_resources/tasks/cleanup_resources.yml
@@ -1,0 +1,47 @@
+- name: Load terraform state
+  ansible.builtin.command:
+    cmd: terraform show -json
+    chdir: "{{ terraform_working_dir }}"
+  register: terraform_state
+  check_mode: false
+  changed_when: false
+
+- name: Convert terraform state to dict
+  ansible.builtin.set_fact:
+    terraform_resources: "{{ (terraform_state.stdout | from_json)['values']['root_module']['resources'] | default([]) }}"
+    excluded_resources: []
+
+- name: Exclude types from terraform state
+  ansible.builtin.set_fact:
+    excluded_resources: "{{ excluded_resources + [item] }}"
+  loop: "{{ terraform_resources }}"
+  when: item.type in excluded_types
+
+- name: Exclude recently created resources from terraform state
+  ansible.builtin.set_fact:
+    excluded_resources: "{{ excluded_resources + [item] }}"
+  loop: "{{ terraform_resources }}"
+  when:
+    - item["values"]["defined_tags"]["Oracle-Tags.CreatedOn"] is defined
+    - >-
+        (
+          now(utc=true).replace(tzinfo=None)
+          -
+          (item["values"]["defined_tags"]["Oracle-Tags.CreatedOn"] | ansible.builtin.to_datetime("%Y-%m-%dT%H:%M:%S.%fZ")).replace(tzinfo=None)
+        ).total_seconds() / 3600 < expired_after_hours
+
+- name: Remove excluded resources from terraform state
+  ansible.builtin.command:
+    cmd: terraform state rm {{ excluded_resources | json_query('[].address') | unique | join(" ") }}
+    chdir: "{{ terraform_working_dir }}"
+  when: excluded_resources | length > 0
+  changed_when: true
+
+- name: Destroy expired resources
+  community.general.terraform:
+    project_path: "{{ terraform_working_dir }}"
+    state: absent
+  register: result
+  until: "result is not failed"
+  retries: 10
+  delay: 10

--- a/ansible_files/roles/oci/cleanup_resources/tasks/main.yml
+++ b/ansible_files/roles/oci/cleanup_resources/tasks/main.yml
@@ -35,50 +35,12 @@
     chdir: "{{ terraform_working_dir }}"
   check_mode: false
 
-- name: Load terraform state
-  ansible.builtin.command:
-    cmd: terraform show -json
-    chdir: "{{ terraform_working_dir }}"
-  register: terraform_state
-  check_mode: false
-  changed_when: false
+- name: Check terraform state file
+  ansible.builtin.stat:
+    path: "{{ [terraform_working_dir, 'terraform.tfstate'] | path_join }}"
+  register: terraform_state_file_result
 
-- name: Convert terraform state to dict
-  ansible.builtin.set_fact:
-    terraform_resources: "{{ (terraform_state.stdout | from_json)['values']['root_module']['resources'] | default([]) }}"
-    excluded_resources: []
-
-- name: Exclude types from terraform state
-  ansible.builtin.set_fact:
-    excluded_resources: "{{ excluded_resources + [item] }}"
-  loop: "{{ terraform_resources }}"
-  when: item.type in excluded_types
-
-- name: Exclude recently created resources from terraform state
-  ansible.builtin.set_fact:
-    excluded_resources: "{{ excluded_resources + [item] }}"
-  loop: "{{ terraform_resources }}"
-  when:
-    - item["values"]["defined_tags"]["Oracle-Tags.CreatedOn"] is defined
-    - >-
-        (
-          now(utc=true).replace(tzinfo=None)
-          -
-          (item["values"]["defined_tags"]["Oracle-Tags.CreatedOn"] | ansible.builtin.to_datetime("%Y-%m-%dT%H:%M:%S.%fZ")).replace(tzinfo=None)
-        ).total_seconds() / 3600 < expired_after_hours
-
-- name: Remove excluded resources from terraform state
-  ansible.builtin.command:
-    cmd: terraform state rm {{ excluded_resources | json_query('[].address') | unique | join(" ") }}
-    chdir: "{{ terraform_working_dir }}"
-  when: excluded_resources | length > 0
-  changed_when: true
-
-- name: Destroy expired resources
-  community.general.terraform:
-    project_path: "{{ terraform_working_dir }}"
-    state: absent
-  register: result
-  until: "result is not failed"
-  retries: 10
-  delay: 10
+- name: Cleanup resources when a terraform state file exists
+  ansible.builtin.include_tasks:
+    file: cleanup_resources.yml
+  when: terraform_state_file_result.stat.exists


### PR DESCRIPTION
Check that a state file was generated by the import process. When no
state file is present, it means no resources were found in the
compartment.

Exclude network load blancer backend, backend_set and listener resources
from deletion as they will be deleted when the parent LB is deleted.
