### PR TITLE
NO-ISSUE: use urlib3 < 2.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -28,7 +28,7 @@ scp==0.14.5
 semver==3.0.1
 tabulate==0.9.0
 tqdm==4.66.1
-urllib3==2.0.4
+urllib3<2.0
 pyvmomi>=7.0.2
 waiting>=1.4.1
 prompt_toolkit==3.0.39


### PR DESCRIPTION
Dependabot updates are failing because Kubernetes library requires urlib3 < 2.0.
x-ref: https://github.com/openshift/assisted-test-infra/pull/2280