### PR TITLE
NO-ISSUE: fix oci cleanup

### DIFF
--- a/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
+++ b/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
@@ -1,6 +1,7 @@
 # these type are cleaned up by removing their parent resource
 # we exclude them from the removal to avoid conflict type of errors
 excluded_types:
+  - oci_core_network_security_group_security_rule
   - oci_core_private_ip
   - oci_core_public_ip
   - oci_load_balancer_backend

--- a/ansible_files/roles/oci/cleanup_resources/tasks/cleanup_resources.yml
+++ b/ansible_files/roles/oci/cleanup_resources/tasks/cleanup_resources.yml
@@ -30,6 +30,18 @@
           (item["values"]["defined_tags"]["Oracle-Tags.CreatedOn"] | ansible.builtin.to_datetime("%Y-%m-%dT%H:%M:%S.%fZ")).replace(tzinfo=None)
         ).total_seconds() / 3600 < expired_after_hours
 
+- name: List excluded bucket names
+  ansible.builtin.set_fact:
+    excluded_buckets: "{{ excluded_resources | json_query('[?type==`oci_objectstorage_bucket`].values.name') }}"
+
+- name: Exclude objects belonging to excluded buckets
+  ansible.builtin.set_fact:
+    excluded_resources: "{{ excluded_resources + [item] }}"
+  loop: "{{ terraform_resources }}"
+  when:
+    - item["type"] == "oci_objectstorage_object"
+    - item["values"]["bucket"] in excluded_buckets
+
 - name: Remove excluded resources from terraform state
   ansible.builtin.command:
     cmd: terraform state rm {{ excluded_resources | json_query('[].address') | unique | join(" ") }}


### PR DESCRIPTION
2 resources were deleted too early because we don't know when they were
created.

- `oci_core_network_security_group_security_rule`: exclude it from
  deletion, the parent network security group will delete it
- `oci_objectstorage_object`: exclude it from deletion if its parent
  bucket is already excluded
