### PR TITLE
MGMT-15945: Pull service and index images from ocm-2.9 tag

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,9 +35,9 @@ CONTAINER_RUNTIME_COMMAND := $(or ${CONTAINER_COMMAND}, ${CONTAINER_RUNTIME_COMM
 LINT_CODE_STYLING_DIRS := src/tests src/triggers src/assisted_test_infra/test_infra src/assisted_test_infra/download_logs src/service_client src/consts src/virsh_cleanup src/cli
 
 # assisted-service
-SERVICE := $(or $(SERVICE), quay.io/edge-infrastructure/assisted-service:latest)
+SERVICE := $(or $(SERVICE), quay.io/edge-infrastructure/assisted-service:ocm-2.9)
 SERVICE_NAME := $(or $(SERVICE_NAME),assisted-service)
-INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/edge-infrastructure/assisted-service-index:latest)
+INDEX_IMAGE := $(or ${INDEX_IMAGE},quay.io/edge-infrastructure/assisted-service-index:ocm-2.9)
 REMOTE_SERVICE_URL := $(or $(REMOTE_SERVICE_URL), "")
 
 # terraform


### PR DESCRIPTION
By default in release-ocm-2.9 branch, pull ocm-2.9 tag for service and index images.