### PR TITLE
MGMT-15695: check tf_platform to know if LB is required

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -36,6 +36,10 @@ class NodeController(ABC):
     def is_ipv6(self):
         return self._config.is_ipv6
 
+    @property
+    def tf_platform(self):
+        return self._config.tf_platform
+
     @abstractmethod
     def list_nodes(self) -> List[Node]:
         pass

--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -947,8 +947,8 @@ class Cluster(BaseCluster):
         self.nodes.wait_for_networking()
         self.set_network_params(controller=self.nodes.controller)
 
-        # in case of None platform we need to specify dns records before hosts are ready
-        if self._config.platform in [consts.Platforms.NONE, consts.Platforms.EXTERNAL]:
+        # in case of None or External platform we need to specify dns records before hosts are ready
+        if self.nodes.controller.tf_platform in [consts.Platforms.NONE, consts.Platforms.EXTERNAL]:
             self._configure_load_balancer()
             self.nodes.controller.set_dns_for_user_managed_network()
         elif self._high_availability_mode == consts.HighAvailabilityMode.NONE:


### PR DESCRIPTION
tf_platform represents the instrastructure that test-infra is
provisionning. We don't want to provision a LB when we deploy an
external platform cluster on top of OCI.
