### PR TITLE
Add function name caller to test-infra logs

### DIFF
--- a/src/service_client/logger.py
+++ b/src/service_client/logger.py
@@ -93,7 +93,7 @@ def add_log_file_handler(logger: logging.Logger, filename: str) -> logging.FileH
 
 def add_stream_handler(logger: logging.Logger):
     fmt = SensitiveFormatter(
-        "%(asctime)s  %(name)s %(levelname)-10s - %(thread)d - %(message)s \t" "(%(pathname)s:%(lineno)d)"
+        "%(asctime)s  %(name)s %(levelname)-10s - %(thread)d - %(message)s \t" "(%(pathname)s:%(lineno)d)->%(funcName)s"
     )
     ch = ColorizingStreamHandler(sys.stderr)
     ch.setFormatter(fmt)


### PR DESCRIPTION
With this change we will print to log the function called by the line. example:
Adding rule - [path]/nat_controller.py:98)->_insert_rule (/home/benny/assisted-test-infra/src/tests/base_test.py:82)->update_parameterize
