### PR TITLE
Fix thread id in test-infra.log file

### DIFF
--- a/src/service_client/logger.py
+++ b/src/service_client/logger.py
@@ -84,7 +84,7 @@ logging.getLogger("asyncio").setLevel(logging.ERROR)
 
 
 def add_log_file_handler(logger: logging.Logger, filename: str) -> logging.FileHandler:
-    fmt = SensitiveFormatter("%(asctime)s - %(name)s - %(levelname)s - %(thread)d - %(message)s")
+    fmt = SensitiveFormatter("%(asctime)s - %(name)s - %(levelname)s - %(thread)d:%(process)d - %(message)s")
     fh = logging.FileHandler(filename)
     fh.setFormatter(fmt)
     logger.addHandler(fh)


### PR DESCRIPTION
Current code shows thread id in log file, the problem in parallel run that we create multiple proccesses and each one create threads. Due to that we may see same thread_id when calling threading.get_ident() under different services.

solution is to add the process id to the thread and create combination thread_id:proccess_id . i think under the same proccess we may not see duplicate thread id.

by default python store the thread_id and proccess_id unless user disable it. logging.logThreads = True
logging.logProcesses = True