### PR TITLE
MGMT-16399: Use plural vips in test environment variables

### DIFF
--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -130,8 +130,8 @@ class _EnvVariables(DataPool, ABC):
     )
     reclaim_hosts: EnvVar = EnvVar(["RECLAIM_HOSTS"], loader=lambda x: bool(strtobool(x)), default=False)
 
-    api_vip: EnvVar = EnvVar(["API_VIP"])
-    ingress_vip: EnvVar = EnvVar(["INGRESS_VIP"])
+    api_vips: EnvVar = EnvVar(["API_VIPS"], loader=json.loads)
+    ingress_vips: EnvVar = EnvVar(["INGRESS_VIPS"], loader=json.loads)
 
     metallb_api_ip: EnvVar = EnvVar(["METALLB_API_IP"])
     metallb_ingress_ip: EnvVar = EnvVar(["METALLB_INGRESS_IP"])


### PR DESCRIPTION
The singular versions were removed from the BaseClusterConfig which gets values from these default environment variables.

Without access to these variables vmware jobs were failing with errors like:

```
            # patch the aci with the vips. The cidr will be derived from the range
            access_vips = nodes.controller.get_ingress_and_api_vips()
>           api_vip = access_vips["api_vips"][0].get("ip", "") if len(access_vips["api_vips"]) > 0 else ""
E           TypeError: 'NoneType' object is not subscriptable

src/tests/test_kube_api.py:163: TypeError
```

An example of a failing job is https://prow.ci.openshift.org/view/gs/origin-ci-test/logs/periodic-ci-openshift-assisted-test-infra-master-e2e-vsphere-assisted-kube-api-periodic/1736174421904723968

https://issues.redhat.com/browse/MGMT-16399

cc @adriengentil 