### PR TITLE
MGMT-15772: Moving Equinix to use Metros

### DIFF
--- a/terraform_files/equinix-ci-machine/main.tf
+++ b/terraform_files/equinix-ci-machine/main.tf
@@ -11,7 +11,7 @@ resource "equinix_metal_device" "ci_devices" {
 
   hostname         = each.value["hostname"]
   plan             = each.value["plan"]
-  facilities       = each.value["facilities"]
+  metro            = each.value["metros"]
   operating_system = each.value["operating_system"]
   project_id       = each.value["project_id"]
   tags             = each.value["tags"]

--- a/terraform_files/equinix-ci-machine/variables_equinix.tf
+++ b/terraform_files/equinix-ci-machine/variables_equinix.tf
@@ -2,7 +2,7 @@ variable "devices" {
   description = "Settings for desired devices"
   type = list(
     object({
-      facilities           = optional(list(string), ["any"])
+      metros               = optional(list(string), ["any"])
       hostname             = string
       operating_system     = optional(string, "rocky_8")
       plan                 = string


### PR DESCRIPTION
Due to deprecation of `facilities`  we are moving to use `metro` instead 

1. This change won't effect CI, the CI configured to use `any` which is default
2. after merge, we will hard coded which metros to use.


```yaml
# https://github.com/openshift/release/blob/master/ci-operator/step-registry/baremetalds/packet/setup/baremetalds-packet-setup-ref.yaml#L16-L17


  env:
   ...
  - name: PACKET_FACILITY
    default: any
    ....
```