### PR TITLE
Add new log record for testcase id

### DIFF
--- a/src/service_client/__init__.py
+++ b/src/service_client/__init__.py
@@ -1,5 +1,5 @@
 from .assisted_service_api import InventoryClient
 from .client_factory import ClientFactory
-from .logger import SuppressAndLog, log
+from .logger import SuppressAndLog, add_log_record, log
 
-__all__ = ["InventoryClient", "ClientFactory", "log", "SuppressAndLog"]
+__all__ = ["InventoryClient", "ClientFactory", "log", "add_log_record", "SuppressAndLog"]

--- a/src/service_client/logger.py
+++ b/src/service_client/logger.py
@@ -73,6 +73,22 @@ class ColorizingStreamHandler(logging.StreamHandler):
             self.handleError(record)
 
 
+def add_log_record(test_id):
+    # Adding log record for testcase id
+    _former_log_record_factory = logging.getLogRecordFactory()
+
+    def log_record_uuid_injector(*args, **kwargs):
+        record = _former_log_record_factory(*args, **kwargs)
+        record.test_id = test_id
+        return record
+
+    logging.setLogRecordFactory(log_record_uuid_injector)
+
+
+# set test_id record to "" empty by default
+add_log_record("")
+
+
 def get_logging_level():
     level = os.environ.get("LOGGING_LEVEL", "")
     return logging.getLevelName(level.upper()) if level else logging.DEBUG
@@ -84,7 +100,9 @@ logging.getLogger("asyncio").setLevel(logging.ERROR)
 
 
 def add_log_file_handler(logger: logging.Logger, filename: str) -> logging.FileHandler:
-    fmt = SensitiveFormatter("%(asctime)s - %(name)s - %(levelname)s - %(thread)d:%(process)d - %(message)s")
+    fmt = SensitiveFormatter(
+        "%(asctime)s - %(name)s - %(levelname)s - %(test_id)s:%(thread)d:%(process)d - %(message)s"
+    )
     fh = logging.FileHandler(filename)
     fh.setFormatter(fmt)
     logger.addHandler(fh)

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -43,7 +43,7 @@ from assisted_test_infra.test_infra.helper_classes.day2_cluster import Day2Clust
 from assisted_test_infra.test_infra.helper_classes.events_handler import EventsHandler
 from assisted_test_infra.test_infra.helper_classes.infra_env import InfraEnv
 from assisted_test_infra.test_infra.tools import LibvirtNetworkAssets
-from service_client import InventoryClient, SuppressAndLog, log
+from service_client import InventoryClient, SuppressAndLog, add_log_record, log
 from tests.config import ClusterConfig, InfraEnvConfig, TerraformConfig, global_variables
 from tests.config.global_configs import Day2ClusterConfig, NutanixConfig, OciConfig, VSphereConfig
 from triggers import get_default_triggers
@@ -351,6 +351,8 @@ class BaseTest:
         def test_something(cluster):
             pass
         """
+        # Add log record when starting cluster test
+        add_log_record(request.node.name)
         yield utils.run_marked_fixture(new_infra_env_configuration, "override_infra_env_configuration", request)
 
     @pytest.fixture


### PR DESCRIPTION
Current code in parallel may have duplicate threads id , when run in parallel multiple proccesses created and threads per proccess with duplicate id.

Current patch adding new record to logger names test_id set to "" In case we want to update the param we can set it in the begining of test.

When request fixture exists per cluster creation we take the request.node.name (testcase name) as test_id.

I tested it in parallel run and it works but i think we need more tests.