### PR TITLE
Revert "MGMT-15772: Moving Equinix to use Metros"

### DIFF
--- a/terraform_files/equinix-ci-machine/main.tf
+++ b/terraform_files/equinix-ci-machine/main.tf
@@ -11,7 +11,7 @@ resource "equinix_metal_device" "ci_devices" {
 
   hostname         = each.value["hostname"]
   plan             = each.value["plan"]
-  metro            = each.value["metros"]
+  facilities       = each.value["facilities"]
   operating_system = each.value["operating_system"]
   project_id       = each.value["project_id"]
   tags             = each.value["tags"]

--- a/terraform_files/equinix-ci-machine/variables_equinix.tf
+++ b/terraform_files/equinix-ci-machine/variables_equinix.tf
@@ -2,7 +2,7 @@ variable "devices" {
   description = "Settings for desired devices"
   type = list(
     object({
-      metros               = optional(list(string), ["any"])
+      facilities           = optional(list(string), ["any"])
       hostname             = string
       operating_system     = optional(string, "rocky_8")
       plan                 = string


### PR DESCRIPTION
Reverts openshift/assisted-test-infra#2347

* cannot use metro as `any` `null` or a list 