### PR TITLE
MGMT-16499: Allow using custom OCP release when we create cluster

### DIFF
--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -41,6 +41,7 @@ export REGISTRY_SERVICE_NAMESPACE=kube-system
 export REGISTRY_SERVICE_PORT=80
 export REGISTRY_SERVICE_HOST_PORT=5000
 export ENABLE_HOST_RECLAIM=${RECLAIM_HOSTS:-false}
+export OPENSHIFT_CI=${OPENSHIFT_CI:-false}
 
 
 if [[ "${ENABLE_KUBE_API}" == "true" || "${DEPLOY_TARGET}" == "operator" ]]; then
@@ -67,8 +68,10 @@ if [ "${OPENSHIFT_INSTALL_RELEASE_IMAGE}" != "" ]; then
     fi
 fi
 
-OS_IMAGES=$(skipper run ./scripts/override_os_images.py --src ./assisted-service/data/default_os_images.json)
-export OS_IMAGES
+if [ "${OPENSHIFT_CI}" == "true" ]; then
+    OS_IMAGES=$(skipper run ./scripts/override_os_images.py --src ./assisted-service/data/default_os_images.json)
+    export OS_IMAGES
+fi
 
 if [ "${DEPLOY_TARGET}" == "onprem" ]; then
     if [ -n "${INSTALLER_IMAGE:-}" ]; then

--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -612,3 +612,8 @@ def get_iso_download_path(entity_name: str):
             f"{entity_name}-{consts.env_defaults.DEFAULT_IMAGE_FILENAME}"
         )
     ).strip()
+
+
+def get_major_minor_version(openshift_full_version: str) -> str:
+    semantic_version = semver.VersionInfo.parse(openshift_full_version, optional_minor_and_patch=True)
+    return f"{semantic_version.major}.{semantic_version.minor}"

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -33,17 +33,17 @@ def get_available_openshift_versions() -> List[str]:
     except RuntimeError:
         return [global_variables.openshift_version]  # if no service found return hard-coded version number
 
-    available_versions = list(openshift_versions.keys())
+    available_versions = set(utils.get_major_minor_version(version) for version in openshift_versions.keys())
     override_version = utils.get_openshift_version(allow_default=False)
 
     if override_version:
         if override_version == consts.OpenshiftVersion.MULTI_VERSION.value:
-            return sorted(available_versions, key=lambda s: list(map(int, s.split("."))))
+            return sorted(list(available_versions), key=lambda s: list(map(int, s.split("."))))
         if override_version in available_versions:
             return [override_version]
         raise ValueError(
             f"Invalid version {override_version}, can't find among versions: "
-            f"{available_versions + [consts.OpenshiftVersion.MULTI_VERSION.value]}"
+            f"{list(available_versions) + [consts.OpenshiftVersion.MULTI_VERSION.value]}"
         )
 
     return [k for k, v in openshift_versions.items() if "default" in v and v["default"]]


### PR DESCRIPTION
Allow using custom `OCP` release when we create cluster - Within the CI environment, our aim is to load the fewest possible number of ISO images because the image-service takes a significant amount of time to load each one. Conversely, for scenarios outside of CI, we aim to facilitate the installation of each `OCP` release using test-infra, necessitating the loading of all ISO images.