### PR TITLE
Add informative info from assisted-installer-controller log when time…

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -830,6 +830,7 @@ class Cluster(BaseCluster):
             client=self.api_client, cluster_id=self.id, statuses=[consts.ClusterStatus.INSUFFICIENT]
         )
 
+    @utils.waiter_decorator
     def wait_for_hosts_to_install(
         self,
         timeout=consts.CLUSTER_INSTALLATION_TIMEOUT,
@@ -847,6 +848,7 @@ class Cluster(BaseCluster):
             fall_on_pending_status=fall_on_pending_status,
         )
 
+    @utils.waiter_decorator
     def wait_for_operators_to_finish(self, timeout=consts.CLUSTER_INSTALLATION_TIMEOUT, fall_on_error_status=True):
         operators = self.get_operators()
 
@@ -881,6 +883,7 @@ class Cluster(BaseCluster):
             operators=self.get_operators(), operator_name=operator_name, status=status
         )
 
+    @utils.waiter_decorator
     def wait_for_install(self, timeout=consts.CLUSTER_INSTALLATION_TIMEOUT):
         utils.waiting.wait_till_cluster_is_in_status(
             client=self.api_client,

--- a/src/assisted_test_infra/test_infra/utils/__init__.py
+++ b/src/assisted_test_infra/test_infra/utils/__init__.py
@@ -10,6 +10,7 @@ from .utils import (
     get_openshift_release_image,
     recreate_folder,
     run_command,
+    waiter_decorator,
 )
 
 __all__ = [


### PR DESCRIPTION
Add controller later error when timeout during installation

During installation when waiter hit on timeout , raise timeout exception without information about the root cause and the installer timers wait longer time till it change state to fail / success.

Added support for last error in assisted-installer-controller logs when timeout exception raised by the waiter.
Added the info from controller logs to raises exception.

Created decorator for waiter functions, in case waiter func wrapped:
- No exception from waiter return func to caller as is
- Waiter bubble-up TimeoutExpired
	- veify the waiter called from cluster waiter
	- Try to download kubeconfig , success return true
	- Try to get assisted-installer-controller logs filtered by level=error
	- Add the last error to the exception , if no error nothing to append. Sometime logs call may return empty or fail due to vip network so retry
	- raise updated new TimeoutExpired exception to the caller