### PR TITLE
MGMT-16330: disallow SDN network type testing for 4.15 and above

### DIFF
--- a/src/tests/test_e2e_install.py
+++ b/src/tests/test_e2e_install.py
@@ -1,8 +1,10 @@
 import pytest
+import semver
 from junit_report import JunitTestSuite
 
 import consts
 from tests.base_test import BaseTest
+from tests.config import global_variables
 from tests.conftest import get_available_openshift_versions, get_supported_operators
 
 
@@ -21,6 +23,11 @@ class TestInstall(BaseTest):
     @JunitTestSuite()
     @pytest.mark.parametrize("network_type", [consts.NetworkType.OpenShiftSDN, consts.NetworkType.OVNKubernetes])
     def test_networking(self, cluster, network_type):
+        if semver.Compare(global_variables.openshift_version, "4.15.0") >= 0:
+            raise ValueError(
+                "parametrization of network type not necessary from 4.15.0 and above,"
+                " as the only supported network type is OVN"
+            )
         cluster.prepare_for_installation()
         cluster.start_install_and_wait_for_installed(fall_on_pending_status=True)
 


### PR DESCRIPTION
We have removed support for SDN from OCP 4.15 onward. This will throw explicit error early in case of misusage of assisted-test-infra
/cc @eifrach @adriengentil 