### PR TITLE
NO-ISSUE: Set version 1.24.0 for equinix provider

### DIFF
--- a/terraform_files/equinix-ci-machine/main.tf
+++ b/terraform_files/equinix-ci-machine/main.tf
@@ -2,6 +2,7 @@ terraform {
   required_providers {
     equinix = {
       source = "equinix/equinix"
+      version = "1.24.0"
     }
   }
 }


### PR DESCRIPTION
At the moment, 1.25.0 fails to be downloaded. Use 1.24.0 to unblock the
CI.

https://prow.ci.openshift.org/view/gs/test-platform-results/pr-logs/pull/openshift_assisted-service/5892/pull-ci-openshift-assisted-service-master-edge-e2e-metal-assisted/1747851387535888384