### PR TITLE
Add support for disk tunning - rate and iops

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -592,6 +592,42 @@ class LibvirtController(NodeController, ABC):
         dom.setVcpusFlags(core_count)
         log.info(f"Successfully set vcpus to {core_count} for node: {node_name}")
 
+    def set_disk_tune(self, node_name: str, disk_name: str, **kwargs: dict) -> None:
+        """Set disk speed rate bytes per second and iops per second. by default all zero
+        xml additional xml:
+        <iotune>
+        <total_bytes_sec>1500</total_bytes_sec>
+        <total_iops_sec>1500</total_iops_sec>
+        </iotune>
+
+        list of supported kwargs:
+        {'read_bytes_sec': 0,
+        'read_bytes_sec_max': 0,
+        'read_bytes_sec_max_length': 0,
+        'read_iops_sec': 0,
+        'read_iops_sec_max': 0,
+        'read_iops_sec_max_length': 0,
+        'size_iops_sec': 0,
+        'total_bytes_sec': 0,
+        'total_bytes_sec_max': 0,
+        'total_bytes_sec_max_length': 0,
+        'total_iops_sec': 0,
+        'total_iops_sec_max': 0,
+        'total_iops_sec_max_length': 0,
+        'write_bytes_sec': 0,
+        'write_bytes_sec_max': 0,
+        'write_bytes_sec_max_length': 0,
+        'write_iops_sec': 0,
+        'write_iops_sec_max': 0,
+        'write_iops_sec_max_length': 0}
+        :param node_name:
+        :param disk_name: disk name as sda ,vdb
+        :param kwargs: {"total_bytes_sec": 0, total_iops_sec:0}
+        :return:
+        """
+        domain = self.libvirt_connection.lookupByName(node_name)
+        domain.setBlockIoTune(disk_name, kwargs)
+
     def get_ram_kib(self, node_name):
         xml = self._get_xml(node_name)
         memory_element = xml.getElementsByTagName("currentMemory")[0]

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node.py
@@ -160,6 +160,9 @@ class Node:
     def set_cpu_cores(self, core_count):
         self.node_controller.set_cpu_cores(self.name, core_count)
 
+    def set_disk_tune(self, disk_name: str, **kwargs: dict) -> None:
+        self.node_controller.set_disk_tune(self.name, disk_name, **kwargs)
+
     def reset_cpu_cores(self):
         self.set_cpu_cores(self.original_vcpu_count)
 

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -165,6 +165,10 @@ class NodeController(ABC):
         pass
 
     @abstractmethod
+    def set_disk_tune(self, node_name: str, disk_name: str, **kwargs: dict) -> None:
+        pass
+
+    @abstractmethod
     def get_ram_kib(self, node_name: str) -> int:
         pass
 

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
@@ -163,6 +163,9 @@ class TFController(NodeController, ABC):
     def set_cpu_cores(self, node_name: str, core_count: int) -> None:
         pass
 
+    def set_disk_tune(self, node_name: str, disk_name: str, **kwargs: dict) -> None:
+        pass
+
     def set_ram_kib(self, node_name: str, ram_kib: int) -> None:
         pass
 

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/zvm_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/zvm_controller.py
@@ -161,6 +161,9 @@ class ZVMController(NodeController, ABC):
     def set_cpu_cores(self, node_name: str, core_count: int) -> None:
         pass
 
+    def set_disk_tune(self, node_name: str, disk_name: str, **kwargs: dict) -> None:
+        pass
+
     def get_ram_kib(self, node_name: str) -> int:
         return -1
 


### PR DESCRIPTION
Libvirt allow to limit disks io and rates per disk name Added support to controller node ,it will allow us to slow down installation by limit disks speed or io.
On every installation phase we may limit disk and undo.