### PR TITLE
NO-ISSUE: Update OCI check to test against stage/prod

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -898,10 +898,10 @@ class Cluster(BaseCluster):
     def prepare_nodes(self, is_static_ip: bool = False, **kwargs):
         super(Cluster, self).prepare_nodes(is_static_ip=self._infra_env_config.is_static_ip, **kwargs)
         platform = self.get_details().platform
-        assert (
-            platform.type in self.api_client.get_cluster_supported_platforms(self.id)
-            or (platform.type == consts.Platforms.EXTERNAL and platform.external.platform_name == consts.ExternalPlatformNames.OCI) # required to test against stage/production
-        )  # Patch for SNO OCI - currently not supported in the service
+        assert platform.type in self.api_client.get_cluster_supported_platforms(self.id) or (
+            platform.type == consts.Platforms.EXTERNAL
+            and platform.external.platform_name == consts.ExternalPlatformNames.OCI
+        )  # required to test against stage/production  # Patch for SNO OCI - currently not supported in the service
         self.set_hostnames_and_roles()
         if self._high_availability_mode != consts.HighAvailabilityMode.NONE:
             self.set_host_roles(len(self.nodes.get_masters()), len(self.nodes.get_workers()))

--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -897,10 +897,10 @@ class Cluster(BaseCluster):
 
     def prepare_nodes(self, is_static_ip: bool = False, **kwargs):
         super(Cluster, self).prepare_nodes(is_static_ip=self._infra_env_config.is_static_ip, **kwargs)
-        platform_type = self.get_details().platform.type
+        platform = self.get_details().platform
         assert (
-            platform_type in self.api_client.get_cluster_supported_platforms(self.id)
-            or platform_type == consts.Platforms.OCI
+            platform.type in self.api_client.get_cluster_supported_platforms(self.id)
+            or (platform.type == consts.Platforms.EXTERNAL and platform.external.platform_name == consts.ExternalPlatformNames.OCI) # required to test against stage/production
         )  # Patch for SNO OCI - currently not supported in the service
         self.set_hostnames_and_roles()
         if self._high_availability_mode != consts.HighAvailabilityMode.NONE:

--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -304,6 +304,8 @@ class Platforms:
     OCI = "oci"
     EXTERNAL = "external"
 
+class ExternalPlatformNames:
+    OCI = "oci"
 
 class KubeAPIPlatforms:
     """

--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -304,8 +304,10 @@ class Platforms:
     OCI = "oci"
     EXTERNAL = "external"
 
+
 class ExternalPlatformNames:
     OCI = "oci"
+
 
 class KubeAPIPlatforms:
     """

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -31,11 +31,6 @@ _default_triggers = frozendict(
             conditions=[lambda config: config.platform == consts.Platforms.NUTANIX],
             tf_platform=consts.Platforms.NUTANIX,
         ),
-        "oci_platform": Trigger(
-            conditions=[lambda config: config.platform == consts.Platforms.OCI],
-            user_managed_networking=True,
-            tf_platform=consts.Platforms.OCI,
-        ),
         "sno": Trigger(
             conditions=[lambda config: config.masters_count == 1],
             workers_count=0,


### PR DESCRIPTION
Update assert against `get_cluster_supported_platforms` in order to pass if platform name is `oci`, in order to be able to to provision a cluster using SaaS in production. It is required because the external platform is not fully enabled yet in production.