### PR TITLE
Add status_info for waiting for specific host

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -589,6 +589,7 @@ class Cluster(BaseCluster):
         self,
         host,
         statuses,
+        status_info="",
         nodes_count: int = MINIMUM_NODES_TO_WAIT,
         timeout: int = consts.NODES_REGISTERED_TIMEOUT,
     ):
@@ -597,6 +598,7 @@ class Cluster(BaseCluster):
             cluster_id=self.id,
             host_name=host.get("requested_hostname"),
             statuses=statuses,
+            status_info=status_info,
             nodes_count=nodes_count,
             timeout=timeout,
         )

--- a/src/assisted_test_infra/test_infra/utils/waiting.py
+++ b/src/assisted_test_infra/test_infra/utils/waiting.py
@@ -40,8 +40,9 @@ def _are_hosts_in_status(
         raise InstallationPendingActionError()
 
     log.info(
-        "Asked hosts to be in one of the statuses from %s and currently hosts statuses are %s",
+        "Asked hosts to be in one of the statuses from %s %s and currently hosts statuses are %s",
         statuses,
+        status_info,
         host_statuses(hosts),
     )
     return False
@@ -191,17 +192,19 @@ def wait_till_specific_host_is_in_status(
     host_name,
     nodes_count,
     statuses,
+    status_info="",
     timeout=consts.NODES_REGISTERED_TIMEOUT,
     fall_on_error_status=True,
     interval=consts.DEFAULT_CHECK_STATUSES_INTERVAL,
 ):
-    log.info(f"Wait till {nodes_count} host is in one of the statuses: {statuses}")
+    log.info(f"Wait till {nodes_count} host is in one of the statuses: {statuses} {status_info}")
 
     waiting.wait(
         lambda: _are_hosts_in_status(
             hosts=[client.get_host_by_name(cluster_id, host_name)],
             nodes_count=nodes_count,
             statuses=statuses,
+            status_info=status_info,
             fall_on_error_status=fall_on_error_status,
         ),
         timeout_seconds=timeout,


### PR DESCRIPTION
Getting host status is not enough , we would like to catch a host in detailed status info.
Example:
installing-in-progress Waiting for bootkube and others