### PR TITLE
MGMT-16493: Open KAS port when installing OCI cluster

### DIFF
--- a/terraform_files/oci-ci-machine/00_main.tf
+++ b/terraform_files/oci-ci-machine/00_main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.9.0"
+      version = "5.29.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"

--- a/terraform_files/oci/00_main.tf
+++ b/terraform_files/oci/00_main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.9.0"
+      version = "5.29.0"
     }
   }
 }

--- a/terraform_files/oci/01_network_security_groups.tf
+++ b/terraform_files/oci/01_network_security_groups.tf
@@ -34,6 +34,23 @@ resource "oci_core_network_security_group_security_rule" "rule_allow_from_nsg_lo
   protocol                  = "all"
 }
 
+# allow connection to Kube API Server from the internet.
+# required to run conformance and OCPT tests from Prow.
+resource "oci_core_network_security_group_security_rule" "rule_allow_from_public_nat_gateway" {
+  network_security_group_id = oci_core_network_security_group.nsg_load_balancer.id
+  description               = "Allow traffic from internet to KAS"
+  direction                 = "INGRESS"
+  source_type               = "CIDR_BLOCK"
+  source                    = "0.0.0.0/0"
+  protocol                  = "6" # TCP
+  tcp_options {
+    destination_port_range {
+      min = 6443
+      max = 6443
+    }
+  }
+}
+
 # cluster NSG is hold by all clusters nodes
 resource "oci_core_network_security_group" "nsg_cluster" {
   #Required


### PR DESCRIPTION
Open port 6443 when installing a cluster on OCI so we can run the OPCT
test suite directly from Prow.

Since the access is authenticated, and the cluster is ephemeral, it
should not be security issue to open this port to the world.
