### PR TITLE
NO-ISSUE: Adjust cleanup in OCI

### DIFF
--- a/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
+++ b/ansible_files/roles/oci/cleanup_resources/defaults/main.yml
@@ -10,4 +10,4 @@ excluded_types:
   - oci_network_load_balancer_backend
   - oci_network_load_balancer_backend_set
   - oci_network_load_balancer_listener
-expired_after_hours: 6
+expired_after_hours: 7


### PR DESCRIPTION
The OPCT test job can run for up to 7 hours, this change adjust the OCI
cleanup process accordingly.
