### PR TITLE
NO-ISSUE: netaddr package rollback do to breaking changes

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -24,6 +24,7 @@ updates:
           - "*"
         exclude-patterns:
           - "flake8-bugbear"
+          - "netaddr"
 
   - package-ecosystem: "docker"
     directory: "/"

--- a/requirements.txt
+++ b/requirements.txt
@@ -10,7 +10,7 @@ junit-report==0.2.7
 kubernetes==29.0.0
 libvirt-python==10.1.0
 munch==4.0.0
-netaddr==1.2.1
+netaddr==0.10.0
 netifaces==0.11.0
 openshift-client==2.0.1
 paramiko==3.4.0


### PR DESCRIPTION
netaddr remove support for `is_private` function.
reveting version and blocking packge update.

will revert after fix in ansible utils
https://github.com/ansible-collections/ansible.utils/issues/331
