### PR TITLE
fixing disk size in kickstart

### DIFF
--- a/packer_files/nutanix_centos_template/centos-config/ks.cfg
+++ b/packer_files/nutanix_centos_template/centos-config/ks.cfg
@@ -2,7 +2,7 @@
 text
 
 %packages
-@^server-product-environment
+@^Minimal install
 kexec-tools
 openssh-server
 perl
@@ -30,10 +30,10 @@ ignoredisk --only-use=sda
 bootloader --append="crashkernel=auto" --location=mbr --boot-drive=sda
 
 part /boot --fstype=ext4 --size=512
-part pv.1 --size=10000 --grow
+part pv.1 --size 99999 --grow --ondisk=sda
 volgroup vg00 pv.1
-logvol swap --vgname=vg00 --recommended --name=swap --fstype=swap
-logvol / --vgname=vg00 --percent=100 --grow --name=root --fstype=ext4
+logvol swap --vgname=vg00 --recommended  --name=swap --fstype=swap
+logvol / --vgname=vg00 --percent=100 --name=root --fstype=ext4
 
 # Partition clearing information
 clearpart --none --initlabel

--- a/packer_files/nutanix_centos_template/cloud-config.yaml
+++ b/packer_files/nutanix_centos_template/cloud-config.yaml
@@ -1,3 +1,5 @@
+ssh_pwauth: True
+disable_root: false
 chpasswd:
   list: |
     root:packer

--- a/packer_files/nutanix_centos_template/cloud-config.yaml
+++ b/packer_files/nutanix_centos_template/cloud-config.yaml
@@ -1,0 +1,10 @@
+chpasswd:
+  list: |
+    root:packer
+  expire: False
+ssh_pwauth: True
+users:
+  - name: root
+    lock_passwd: false
+    ssh_authorized_keys:
+      - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIwXUKAPxJm/1Rf500vh9TUusq7DPxrGdK+/DhsfCJEN vsphere@redhat.com"

--- a/packer_files/nutanix_centos_template/cloud-config.yaml
+++ b/packer_files/nutanix_centos_template/cloud-config.yaml
@@ -8,3 +8,5 @@ users:
     lock_passwd: false
     ssh_authorized_keys:
       - "ssh-ed25519 AAAAC3NzaC1lZDI1NTE5AAAAIIwXUKAPxJm/1Rf500vh9TUusq7DPxrGdK+/DhsfCJEN vsphere@redhat.com"
+runcmd:
+  - systemctl enable --now sshd

--- a/packer_files/nutanix_centos_template/sources.pkr.hcl
+++ b/packer_files/nutanix_centos_template/sources.pkr.hcl
@@ -17,7 +17,7 @@ source "nutanix" "test-infra" {
 
   vm_disks {
     image_type = "DISK"
-    disk_size_gb = var.disk_size / 1024
+    disk_size_gb = var.disk_size
   }
 
   vm_nics {

--- a/packer_files/nutanix_centos_template/sources.pkr.hcl
+++ b/packer_files/nutanix_centos_template/sources.pkr.hcl
@@ -6,17 +6,19 @@ source "nutanix" "test-infra" {
   nutanix_insecure = var.nutanix_insecure
   cluster_name     = var.nutanix_cluster
   os_type          = "Linux"
+  user_data = base64encode(file("cloud-config.yaml"))
+
+  # vm_disks {
+  #  image_type = "ISO_IMAGE"
+  #  source_image_name = var.centos_iso_image_name
+  # }
+
+  # cd_files = ["centos-config/ks.cfg"]
+  # cd_label = "OEMDRV"
 
   vm_disks {
-    image_type = "ISO_IMAGE"
-    source_image_name = var.centos_iso_image_name
-  }
-
-  cd_files = ["centos-config/ks.cfg"]
-  cd_label = "OEMDRV"
-
-  vm_disks {
-    image_type = "DISK"
+    image_type = "DISK_IMAGE"
+    source_image_uri = "https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud-Base.latest.x86_64.qcow2"
     disk_size_gb = var.disk_size
   }
 

--- a/packer_files/nutanix_centos_template/sources.pkr.hcl
+++ b/packer_files/nutanix_centos_template/sources.pkr.hcl
@@ -18,7 +18,7 @@ source "nutanix" "test-infra" {
 
   vm_disks {
     image_type = "DISK_IMAGE"
-    source_image_uri = "https://dl.rockylinux.org/pub/rocky/8/images/x86_64/Rocky-8-GenericCloud-Base.latest.x86_64.qcow2"
+    source_image_uri = "https://cloud.centos.org/centos/8-stream/x86_64/images/CentOS-Stream-GenericCloud-8-20230501.0.x86_64.qcow2"
     disk_size_gb = var.disk_size
   }
 

--- a/packer_files/nutanix_centos_template/variables.pkr.hcl
+++ b/packer_files/nutanix_centos_template/variables.pkr.hcl
@@ -44,7 +44,7 @@ variable "image_name" {
 variable "disk_size" {
   type = number
   default = 100
-  description = "The VM disk size in MB. default 100G"
+  description = "The VM disk size in GB. default 100GB"
 }
 
 variable "memory_size" {

--- a/packer_files/nutanix_centos_template/variables.pkr.hcl
+++ b/packer_files/nutanix_centos_template/variables.pkr.hcl
@@ -43,7 +43,7 @@ variable "image_name" {
 
 variable "disk_size" {
   type = number
-  default = 102400 
+  default = 100
   description = "The VM disk size in MB. default 100G"
 }
 

--- a/packer_files/vsphere_centos_template/centos-config/centos8-ks.cfg
+++ b/packer_files/vsphere_centos_template/centos-config/centos8-ks.cfg
@@ -31,10 +31,10 @@ ignoredisk --only-use=sda
 bootloader --append="crashkernel=auto" --location=mbr --boot-drive=sda
 
 part /boot --fstype=ext4 --size=512
-part pv.1 --size=10000 --grow
+part pv.1 --size 99999 --grow --ondisk=sda
 volgroup vg00 pv.1
-logvol swap --vgname=vg00 --recommended --name=swap --fstype=swap
-logvol / --vgname=vg00 --size=5000 --grow --name=root --fstype=ext4
+logvol swap --vgname=vg00 --recommended  --name=swap --fstype=swap
+logvol / --vgname=vg00 --percent=100 --name=root --fstype=ext4
 
 # Partition clearing information
 clearpart --none --initlabel


### PR DESCRIPTION
- fix kickstart file to auto adjust to whatever disk size is given.
- remove calculation from MB to GB as it is not needed
- change installation type to "Minimal" faster installation and smaller footprint 

TODO: 
- align configuration to vSphere setup
- combine kickstart files to one shared file
- change OS type to Rocky 9
