### PR TITLE
MGMT-15772: change facilities to metro

### DIFF
--- a/terraform_files/equinix-ci-machine/main.tf
+++ b/terraform_files/equinix-ci-machine/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     equinix = {
       source = "equinix/equinix"
-      version = "1.24.0"
+      version = "1.32.0"
     }
   }
 }
@@ -12,7 +12,7 @@ resource "equinix_metal_device" "ci_devices" {
 
   hostname         = each.value["hostname"]
   plan             = each.value["plan"]
-  facilities       = each.value["facilities"]
+  metro            = each.value["metro"]
   operating_system = each.value["operating_system"]
   project_id       = each.value["project_id"]
   tags             = each.value["tags"]

--- a/terraform_files/equinix-ci-machine/variables_equinix.tf
+++ b/terraform_files/equinix-ci-machine/variables_equinix.tf
@@ -2,7 +2,7 @@ variable "devices" {
   description = "Settings for desired devices"
   type = list(
     object({
-      facilities           = optional(list(string), ["any"])
+      metro                = optional(string, "da")
       hostname             = string
       operating_system     = optional(string, "rocky_8")
       plan                 = string


### PR DESCRIPTION
Move Equinx to use metro

1. updating provider version to 1.32
2. setting metro instead of facilities
3. default `metro` is DA ( dallas )


metro DA has all need metal servers including ARM based

* note: there is one more metro with ARM images which is DC