### PR TITLE
NO-ISSUE: Use legit python image for failing ipxe CI test

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/ipxe_controller/server/Dockerfile
+++ b/src/assisted_test_infra/test_infra/controllers/ipxe_controller/server/Dockerfile
@@ -1,4 +1,4 @@
-FROM quay.io/cchun/python:3.9.12-alpine3.15
+FROM quay.io/assisted-installer-ops/base-python:3.12
 
 ARG SERVER_IP
 ARG SERVER_PORT


### PR DESCRIPTION
Change to use a base python image to run the iPXE server as the other one was from a private repository.