### PR TITLE
WIP MGMT-17250 Replace xinetd with firewallcmd port forwards

### DIFF
--- a/scripts/deploy_prometheus_ui.sh
+++ b/scripts/deploy_prometheus_ui.sh
@@ -19,10 +19,8 @@ mkdir -p build
 print_log "Wait till ui Prometheus Port is ready"
 wait_for_url_and_run "$(minikube service ${PROMETHEUS_SERVICE_NAME} -n ${NAMESPACE} --url)" "echo \"waiting for ${PROMETHEUS_SERVICE_NAME}\""
 
-add_firewalld_port $PROMETHEUS_UI_PORT
-
 print_log "Starting port forwarding for deployment/${PROMETHEUS_SERVICE_NAME} on port $PROMETHEUS_UI_PORT"
-wait_for_url_and_run "http://${NODE_IP}:${PROMETHEUS_UI_PORT}" "spawn_port_forwarding_command $PROMETHEUS_SERVICE_NAME $PROMETHEUS_UI_PORT $NAMESPACE $NAMESPACE_INDEX $KUBECONFIG minikube"
+wait_for_url_and_run "http://${NODE_IP}:${PROMETHEUS_UI_PORT}" "spawn_port_forwarding_command $PROMETHEUS_SERVICE_NAME $PROMETHEUS_UI_PORT $NAMESPACE $NAMESPACE_INDEX $KUBECONFIG"
 print_log "Prometheus UI can be reached at http://${NODE_IP}:${PROMETHEUS_UI_PORT}"
 
 print_log "Done"

--- a/scripts/deploy_ui.sh
+++ b/scripts/deploy_ui.sh
@@ -43,7 +43,7 @@ add_firewalld_port $ui_port
 
 if [[ "${DEPLOY_TARGET}" == "minikube" ]]; then
     print_log "Starting port forwarding for deployment/${UI_SERVICE_NAME} on port $ui_port"
-    wait_for_url_and_run "http://${node_ip}:${ui_port}" "spawn_port_forwarding_command $UI_SERVICE_NAME $ui_port $NAMESPACE $NAMESPACE_INDEX $KUBECONFIG minikube"
+    wait_for_url_and_run "http://${node_ip}:${ui_port}" "spawn_port_forwarding_command $UI_SERVICE_NAME $ui_port $NAMESPACE $NAMESPACE_INDEX $KUBECONFIG"
 fi
 
 print_log "Done. Assisted-installer UI can be reached at http://${node_ip}:${ui_port}"

--- a/scripts/hub-cluster/minikube.sh
+++ b/scripts/hub-cluster/minikube.sh
@@ -60,7 +60,7 @@ function create() {
     # Change the registry service type to LoadBalancer to be able to access it from outside the cluster
     kubectl patch service registry -n kube-system --type json -p='[{"op": "replace", "path": "/spec/type", "value":"LoadBalancer"}]'
     # Forward the minikube registry addon k8s service to the host to push the debug image using localhost:5000
-    spawn_port_forwarding_command registry 5000 kube-system 999 $KUBECONFIG minikube undeclaredip 80 registry
+    spawn_port_forwarding_command registry 5000 kube-system 999 $KUBECONFIG minikube undeclaredip 80
 
     eval $(minikube docker-env)
 }

--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -171,8 +171,7 @@ function install_runtime_container() {
 
 function install_packages() {
     echo "Installing dnf packages"
-    sudo dnf install -y make python3 python3-pip git jq bash-completion xinetd
-    sudo systemctl enable --now xinetd
+    sudo dnf install -y make python3 python3-pip git jq bash-completion
 
     echo "Installing python packages"
     sudo pip3 install aicli


### PR DESCRIPTION
xinetd is not available on RHEL9, so services need to be port-forwarded with firewallcmd.

TODO:
* [ ] Fix `kill_port_forwardings`
* [ ] Test ipv6