### PR TITLE
MGMT-17250: Support RHEL9

### DIFF
--- a/scripts/create_full_environment.sh
+++ b/scripts/create_full_environment.sh
@@ -19,13 +19,13 @@ fi
 
 #Check CentOS version
 VER=$(awk -F= '/^VERSION_ID=/ { print $2 }' /etc/os-release | tr -d '"' | cut -f1 -d'.')
-VER_SUPPORTED=8
-
-if [[ ${OS} =~ ^(centos)$ && ${VER} -ne ${VER_SUPPORTED} ]]; then
-    error "CentOS version ${VER_SUPPORTED} is required."
-    exit 1
-elif [[ ${OS} =~ ^(rhel)$ && ${VER} -ne ${VER_SUPPORTED} ]]; then
-    error "RHEL version ${VER_SUPPORTED} is required."
+SUPPORTED_VERSIONS=( 8 9 )
+if [[ ! " ${SUPPORTED_VERSIONS[@]} " =~ " ${VER} " ]]; then
+    if [[ ${OS} =~ ^(centos)$ ]]; then
+        error "CentOS version 8 or 9 is required."
+    elif [[ ${OS} =~ ^(rhel)$ ]]; then
+        error "RHEL version 8 or 9 is required."
+    fi
     exit 1
 fi
 

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -38,37 +38,45 @@ function spawn_port_forwarding_command() {
     target=$6
     ip=${7:-""}
     port=${8:-""}
-    xinet_service_name="${9:-${service_name}}"
+    socket_name="forward-${service_name}-${external_port}"
+    service_file="/etc/systemd/system/${socket_name}@.service"
+    socket_file="/etc/systemd/system/${socket_name}.socket"
 
-    filename=${xinet_service_name}__${namespace}__${namespace_index}__${external_port}__assisted_installer
     if [ "$target" = "minikube" ]; then
-        ip=$(kubectl --kubeconfig=$kubeconfig get nodes -o=jsonpath={.items[0].status.addresses[0].address})
-        if [ -z "$port" ]
-        then
-          port=$(kubectl --kubeconfig=$kubeconfig get svc/${service_name} -n ${namespace} -o=jsonpath='{.spec.ports[0].nodePort}')
+        ip=$(kubectl --kubeconfig="$kubeconfig" get nodes -o=jsonpath='{.items[0].status.addresses[0].address}')
+        if [ -z "$port" ]; then
+            port=$(kubectl --kubeconfig="$kubeconfig" get svc/"${service_name}" -n "${namespace}" -o=jsonpath='{.spec.ports[0].nodePort}')
         else
-          # resolve the service node port form the service internal port (Support multiple ports per service).
-          port=$(kubectl --kubeconfig=$kubeconfig get svc/${service_name} -n ${namespace} -o=jsonpath="{.spec.ports[?(@.port==$port)].nodePort}")
+            port=$(kubectl --kubeconfig="$kubeconfig" get svc/"${service_name}" -n "${namespace}" -o=jsonpath="{.spec.ports[?(@.port==$port)].nodePort}")
         fi
     fi
-    mkdir -p ./build
-    cat <<EOF >build/xinetd-$filename
-service ${xinet_service_name}
-{
-  type		= UNLISTED
-  socket_type	= stream
-  protocol	= tcp
-  user		= root
-  wait		= no
-  redirect	= $ip $port
-  port		= ${external_port}
-  per_source	= UNLIMITED
-  instances	= UNLIMITED
-}
+
+    cat <<EOF | sudo tee "${socket_file}"
+[Unit]
+Description=Socket for forwarding to Minikube ${service_name}
+
+[Socket]
+ListenStream=${external_port}
+Accept=yes
+
+[Install]
+WantedBy=sockets.target
 EOF
-    sudo mv build/xinetd-$filename /etc/xinetd.d/$filename --force
-    sudo systemctl restart xinetd
+
+    cat <<EOF | sudo tee "${service_file}"
+[Unit]
+Description=Forwarding instance to Minikube ${service_name}
+
+[Service]
+ExecStart=/usr/bin/socat STDIO TCP:${ip}:${port}
+StandardInput=socket
+EOF
+
+    sudo systemctl daemon-reload
+    sudo systemctl enable "${socket_name}.socket"
+    sudo systemctl start "${socket_name}.socket"
 }
+
 
 function run_in_background() {
     bash -c "nohup $1  >/dev/null 2>&1 &"
@@ -76,12 +84,18 @@ function run_in_background() {
 
 function kill_port_forwardings() {
     services=$1
-    sudo systemctl stop xinetd
-    for s in $services; do
-        for f in $(sudo ls /etc/xinetd.d/ | grep $s); do
-            sudo rm -f /etc/xinetd.d/$f
+
+    for service_name in $services; do
+        for socket_file in $(ls /etc/systemd/system/forward-${service_name}-*.socket 2>/dev/null); do
+            socket_base=$(basename "$socket_file" .socket)
+            sudo systemctl stop "$socket_base.socket"
+            sudo systemctl disable "$socket_base.socket"
+            sudo rm -f "/etc/systemd/system/${socket_base}.socket"
+            sudo rm -f "/etc/systemd/system/${socket_base}@.service"
         done
     done
+
+    sudo systemctl daemon-reload
 }
 
 function get_main_ip() {

--- a/terraform_files/baremetal_host/main.tf
+++ b/terraform_files/baremetal_host/main.tf
@@ -62,6 +62,13 @@ resource "libvirt_domain" "host" {
     dev = var.boot_devices
   }
 
+  graphics {
+    type           = "vnc"
+    listen_type    = "address"
+    listen_address = "127.0.0.1"
+    autoport       = true
+  }
+
   dynamic "tpm" {
     for_each = var.vtpm2 ? [1] : []
 


### PR DESCRIPTION
Currently, `assisted-test-infra` is only compatible with `Rocky8`, `RHEL8`, and `CentOS8`. As `RHEL8` approaches end-of-life (`EOL`) at the end of this month, we aim to also support `Rocky9`, `RHEL9`, and `CentOS9`. A primary challenge with `stream9` is the absence of `xinetd` in these releases. To address this, I have replaced the port forwarding mechanism with `systemd` socket to listen (with `socat`) and service to forward. This solution should work on all versions.

- [x] Test on RHEL8
- [x] Test on RHEL9
- [x]  Test on Rocky8 (in the CI)
- [x] Test on Rocky9 (in the CI) 