### PR TITLE
NO-ISSUE: Update `requirements.txt` to match the package naming conventions of the interpreter.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -15,13 +15,13 @@ netifaces==0.11.0
 openshift-client==2.0.4
 paramiko==3.4.0
 pre-commit==3.7.0
-pycharm_remote_debugger==0.1.16
+pycharm-remote-debugger==0.1.18
 pytest-xdist==3.6.1
 pytest==8.2.0
 python-dateutil==2.9.0.post0
 python-hcl2==4.3.3
 python-terraform==0.10.1
-pyyaml==6.0.1
+PyYAML==6.0.1
 requests==2.31.0
 retry==0.9.2
 scp==0.14.5
@@ -31,7 +31,7 @@ tqdm==4.66.4
 urllib3<3.0
 pyvmomi>=7.0.2
 waiting>=1.4.1
-prompt_toolkit==3.0.43
+prompt-toolkit==3.0.43
 nutanix-api==0.0.20
 pytest-error-for-skips==2.0.2
 ansible==9.5.1


### PR DESCRIPTION
Some package names were incorrectly written with erroneous characters, causing certain IDEs to mistakenly believe that the packages were not present.
Also update `pycharm-remote-debugger` to latest

/cc @danmanor @adriengentil 