### PR TITLE
NO-ISSUE: Add generic CI SSH key for nutanix packer

### DIFF
--- a/packer_files/nutanix_centos_template/centos-config/ks.cfg
+++ b/packer_files/nutanix_centos_template/centos-config/ks.cfg
@@ -42,8 +42,8 @@ clearpart --none --initlabel
 timezone America/New_York --isUtc
 
 # Root password
-sshkey --username=root "ssh-rsa AAAAB3NzaC1yc2EAAAADAQABAAABgQCWY2zGVj0ZqSHHve7aEfj4un7dGQdOE6qPf4cNlBLLgfp7ig13oT78FiRRvke2E10dNzz63BT0tgQSm6yN+zb1P3OChB8Wtt+enfmfZhJ11NXoKUwBdqOHmdQRGx6qsA1GjGU2Qb4an7ojwP+PBBhS4fNPTsVp8ggYxv5exSh9JiGhqyBY7sfMAQqAttDv31OwmON7mFmOO4Npc0UW0GaVUkcvMY4AR4lPArQYkrXZvAqEtGYoc6JnLVCtr1QSdNsQxft0FLsUkjCiOhPR281lhrVPfprOfz0yMQBoJsOMO0Io/DHYzVBv8+zPCHdPVjpR8f0I3Hb33W1CJ7ingkp9Ds5+Qi6EL3GZ4v/VmR4WD+aXSiuMabPeIzjUukJk7DqzUa3ziBWAkS1dQosCsDoKy4Gm/jH1B70Lzbq+aiPY79ilTBajP9rA2GhgVuuJ1uBtKyObjouiBTvzeBrSZcTCjuxfOfmu++5/UKiTzlIma6Igvrbjv6Sc/piOdpIr3vM= assisted_nutanix_ci@redhat.com"
-rootpw packer
+sshkey --username=root "${ssh_public_key_content}"
+rootpw ${root_password}
 
 %addon com_redhat_kdump --enable --reserve-mb='auto'
 selinux --permissive

--- a/packer_files/nutanix_centos_template/variables.pkr.hcl
+++ b/packer_files/nutanix_centos_template/variables.pkr.hcl
@@ -43,7 +43,7 @@ variable "image_name" {
 
 variable "disk_size" {
   type = number
-  default = 102400 
+  default = 102400
   description = "The VM disk size in MB. default 100G"
 }
 
@@ -61,7 +61,7 @@ variable "vcpus" {
 
 variable "root_password" {
   type = string
-  default = "test"
+  default = "packer"
   description = "The os root password"
 }
 


### PR DESCRIPTION
Use the public ssh key that is CI vault instead of the one hard-coded in nutanix packer configuration files