### PR TITLE
NO-ISSUE: Update vsphere packer plugin and packer base ISO

### DIFF
--- a/packer_files/vsphere_centos_template/build.pkr.hcl
+++ b/packer_files/vsphere_centos_template/build.pkr.hcl
@@ -2,7 +2,7 @@ packer {
   required_plugins {
     vsphere = {
       source  = "github.com/hashicorp/vsphere"
-      version = "= 1.0.8"
+      version = "= 1.3.0"
     }
   }
 }

--- a/packer_files/vsphere_centos_template/variables.pkr.hcl
+++ b/packer_files/vsphere_centos_template/variables.pkr.hcl
@@ -70,14 +70,13 @@ variable "vcpus" {
 
 variable "iso_url" {
   type = string
-  default = "http://rep-centos-il.upress.io/8-stream/isos/x86_64/CentOS-Stream-8-20230904.0-x86_64-boot.iso"
+  default = "http://rep-centos-il.upress.io/8-stream/isos/x86_64/CentOS-Stream-8-x86_64-latest-boot.iso"
   description = "The Centos8 ISO download URL"
 }
 
 variable "iso_checksum" {
   type = string
-  default = "9602c69c52d93f51295c0199af395ca0edbe35e36506e32b8e749ce6c8f5b60a"
-  description = "The Centos8 ISO checksum"
+  description = "The Centos8 ISO checksum. See checksum at http://rep-centos-il.upress.io/8-stream/isos/x86_64/CHECKSUM"
 }
 
 variable "root_password" {

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -40,9 +40,6 @@ class NodeController(ABC):
     def tf_platform(self):
         return self._config.tf_platform
 
-    def init_controller(self):
-        pass
-
     @abstractmethod
     def list_nodes(self) -> List[Node]:
         pass

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
@@ -14,27 +14,18 @@ class TFController(NodeController, ABC):
 
     def __init__(self, config: BaseNodesConfig, cluster_config: BaseClusterConfig):
         super().__init__(config, cluster_config)
-        self._tf = None
+        self.cluster_name = cluster_config.cluster_name.get()
+        folder = TerraformControllerUtil.create_folder(self.cluster_name, platform=config.tf_platform)
+        self.tf = terraform_utils.TerraformUtils(working_dir=folder, terraform_init=False)
         self._provider_client = None
 
     @property
-    def tf(self):
-        return self._tf
-
-    def init_controller(self):
-        folder = TerraformControllerUtil.create_folder(self.cluster_name, platform=self._config.tf_platform)
-        self._tf = terraform_utils.TerraformUtils(working_dir=folder, terraform_init=False)
-
-    @property
-    def cluster_name(self):
-        return self._entity_config.cluster_name.get()
-
     @abstractmethod
     def terraform_vm_resource_type(self) -> str:
         pass
 
     def _get_tf_resource(self, resource_type: str) -> List[Dict[str, Any]]:
-        resource_object_type = self._tf.get_resources(resource_type=resource_type)
+        resource_object_type = self.tf.get_resources(resource_type=resource_type)
 
         if not resource_object_type:
             return list()
@@ -54,7 +45,7 @@ class TFController(NodeController, ABC):
     def prepare_nodes(self):
         config = self.get_all_vars()
         self._provider_client = self._get_provider_client()
-        self._tf.set_and_apply(**config)
+        self.tf.set_and_apply(**config)
         nodes = self.list_nodes()
         for node in nodes:
             self.set_boot_order(node.name)
@@ -94,7 +85,7 @@ class TFController(NodeController, ABC):
         pass
 
     def destroy_all_nodes(self) -> None:
-        self._tf.destroy(force=False)
+        self.tf.destroy(force=False)
 
     def start_all_nodes(self) -> List[Node]:
         nodes = self.list_nodes()

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/vsphere_controller.py
@@ -30,13 +30,13 @@ class VSphereController(TFController):
         del config["iso_download_path"]
 
         self._create_folder(self._config.vsphere_parent_folder)
-        self._tf.set_and_apply(**config)
+        self.tf.set_and_apply(**config)
         return self.list_nodes()
 
     def notify_iso_ready(self) -> None:
         self.shutdown_all_nodes()
         config = self.get_all_vars()
-        self._tf.set_and_apply(**config)
+        self.tf.set_and_apply(**config)
 
     def get_cpu_cores(self, node_name: str) -> int:
         return self._get_vm(node_name)["attributes"]["num_cpus"]
@@ -56,7 +56,7 @@ class VSphereController(TFController):
         return ips, macs
 
     def destroy_all_nodes(self) -> None:
-        self._tf.destroy(force=False)
+        self.tf.destroy(force=False)
 
     def start_node(self, node_name: str, check_ips: bool) -> None:
         def start(vm) -> task:

--- a/src/assisted_test_infra/test_infra/helper_classes/entity.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/entity.py
@@ -18,11 +18,6 @@ class Entity(ABC):
         self.nodes: Nodes = nodes
         self._create() if not self.id else self.update_existing()
         self._config.iso_download_path = self.get_iso_download_path()
-        self.__init_controller()
-
-    def __init_controller(self):
-        if self.nodes:
-            self.nodes.init_controller()
 
     @property
     @abstractmethod

--- a/src/assisted_test_infra/test_infra/helper_classes/nodes.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/nodes.py
@@ -70,10 +70,6 @@ class Nodes:
         for n in self.nodes:
             yield n
 
-    def init_controller(self):
-        if self.controller and hasattr(self.controller, "init_controller"):
-            self.controller.init_controller()
-
     def drop_cache(self):
         self._nodes = None
         self._nodes_as_dict = None

--- a/src/tests/test_targets.py
+++ b/src/tests/test_targets.py
@@ -94,7 +94,6 @@ class TestMakefileTargets(BaseTest):
                     dummy_iso_path.touch(exist_ok=True)
 
                     controller = self.get_terraform_controller(prepared_controller_configuration, cluster_configuration)
-                    controller.init_controller()
                     config_vars = controller.get_all_vars()
                     controller.tf.set_vars(**config_vars)
                     controller.destroy_all_nodes()


### PR DESCRIPTION
- Update vsphere packer plugin. 
- Update default iso_url image ISO
- Remove image ISO default checksum 

This PR completes the work done on https://github.com/openshift/release/pull/52387

Also this PR reverts https://github.com/openshift/assisted-test-infra/pull/2353 due to error in vsphere and nutanix jobs 

```
'NoneType' object has no attribute 'get_resources' AttributeError Traceback (most recent call last):
  File "/root/.pyenv/versions/3.12.0/lib/python3.12/site-packages/junit_report/decorators/_junit_decorator.py", line 51, in _wrapper
    value = self._execute_wrapped_function(*args, **kwargs)
            ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/root/.pyenv/versions/3.12.0/lib/python3.12/site-packages/junit_report/decorators/_junit_fixture_test_case.py", line 80, in _execute_wrapped_function
    return next(generator)
           ^^^^^^^^^^^^^^^
  File "/home/assisted/src/tests/base_test.py", line 523, in cluster
    cluster = Cluster(
              ^^^^^^^^
  File "/home/assisted/src/assisted_test_infra/test_infra/helper_classes/cluster.py", line 45, in __init__
    super().__init__(api_client, config, infra_env_config, nodes)
  File "/home/assisted/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py", line 32, in __init__
    super().__init__(api_client, config, nodes)
  File "/home/assisted/src/assisted_test_infra/test_infra/helper_classes/entity.py", line 21, in __init__
    self.__init_controller()
  File "/home/assisted/src/assisted_test_infra/test_infra/helper_classes/entity.py", line 24, in __init_controller
    if self.nodes:
       ^^^^^^^^^^
  File "/home/assisted/src/assisted_test_infra/test_infra/helper_classes/nodes.py", line 67, in __len__
    return len(self.nodes)
               ^^^^^^^^^^
  File "/home/assisted/src/assisted_test_infra/test_infra/helper_classes/nodes.py", line 52, in nodes
    self._nodes = self.controller.list_nodes()
                  ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/assisted/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py", line 76, in list_nodes
    tf_vms = self._get_tf_vms()
             ^^^^^^^^^^^^^^^^^^
  File "/home/assisted/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py", line 45, in _get_tf_vms
    return self._get_tf_resource(self.terraform_vm_resource_type)
           ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/home/assisted/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py", line 37, in _get_tf_resource
    resource_object_type = self._tf.get_resources(resource_type=resource_type)
                           ^^^^^^^^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get_resources'
```



/cc @eliorerz 