### PR TITLE
Add support for libvirt removable disks and bus types

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/node_controller.py
@@ -88,12 +88,14 @@ class NodeController(ABC):
         pass
 
     @abstractmethod
-    def attach_test_disk(self, node_name: str, disk_size: int, bootable=False, persistent=False, with_wwn=False):
+    def attach_test_disk(self, node_name: str, disk_size: int, bus="scsi", bootable=False, persistent=False,
+                         with_wwn=False):
         """
         Attaches a test disk. That disk can later be detached with `detach_all_test_disks`
         :param with_wwn: Weather the disk should have a WWN(World Wide Name), Having a WWN creates a disk by-id link
         :param node_name: Node to attach disk to
         :param disk_size: Size of disk to attach
+        :param bus: supported disk bus scsi, usb, virtio or sata
         :param bootable: Whether to format an MBR sector at the beginning of the disk
         :param persistent: Whether the disk should survive shutdowns
         """

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/tf_controller.py
@@ -142,7 +142,7 @@ class TFController(NodeController, ABC):
     def list_leases(self, network_name: str) -> List[Any]:
         pass
 
-    def attach_test_disk(self, node_name: str, disk_size: int, bootable=False, persistent=False, with_wwn=False):
+    def attach_test_disk(self, node_name: str, disk_size: int, bus="scsi", bootable=False, persistent=False, with_wwn=False):
         pass
 
     def detach_all_test_disks(self, node_name: str):

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/zvm_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/zvm_controller.py
@@ -110,7 +110,7 @@ class ZVMController(NodeController, ABC):
         return None
 
     # attach for zVM might be tricky or not possible due to missing cli support for zVM commands
-    def attach_test_disk(self, node_name: str, disk_size: int, bootable=False, persistent=False, with_wwn=False):
+    def attach_test_disk(self, node_name: str, disk_size: int, bus="scsi", bootable=False, persistent=False, with_wwn=False):
         pass
 
     # as attach the detach of disks might be tricky (missing cli support for zVM commands)

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -860,9 +860,9 @@ class BaseTest:
     def attach_disk_flags(persistent):
         modified_nodes = set()
 
-        def attach(node, disk_size, bootable=False, with_wwn=False):
+        def attach(node, disk_size, bus="scsi", bootable=False, with_wwn=False):
             nonlocal modified_nodes
-            node.attach_test_disk(disk_size, bootable=bootable, persistent=persistent, with_wwn=with_wwn)
+            node.attach_test_disk(disk_size, bus=bus, bootable=bootable, persistent=persistent, with_wwn=with_wwn)
             modified_nodes.add(node)
 
         yield attach


### PR DESCRIPTION
Added support for test disks  different bus types: usb, virtio, sata, scsi In case usb we set the disk to removable