### PR TITLE
NO-ISSUE: Fix cluster configuration name is not properly set on update cluster

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -74,7 +74,7 @@ class Cluster(BaseCluster):
         self.update_config(
             **dict(
                 openshift_version=existing_cluster.openshift_version,
-                cluster_name=ClusterName(existing_cluster.name),
+                entity_name=ClusterName(existing_cluster.name),
                 additional_ntp_source=existing_cluster.additional_ntp_source,
                 user_managed_networking=existing_cluster.user_managed_networking,
                 high_availability_mode=existing_cluster.high_availability_mode,

--- a/src/assisted_test_infra/test_infra/helper_classes/infra_env.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/infra_env.py
@@ -26,6 +26,8 @@ class InfraEnv(Entity):
         return self._config.infra_env_id
 
     def update_existing(self) -> str:
+        # Might cause issues with defaults
+        self.api_client.update_infra_env(self.id, models.InfraEnvUpdateParams(image_type=self._config.iso_image_type))
         return self.id
 
     def _create(self):

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -16,7 +16,7 @@ from paramiko import SSHException
 
 import consts
 from assisted_test_infra.download_logs.download_logs import download_logs
-from assisted_test_infra.test_infra import Nodes, utils
+from assisted_test_infra.test_infra import Nodes, utils, ClusterName
 from assisted_test_infra.test_infra.controllers import (
     AssistedInstallerInfraController,
     IptableRule,
@@ -240,7 +240,7 @@ class BaseTest:
         )
 
     @pytest.fixture
-    def new_cluster_configuration(self, request: FixtureRequest) -> ClusterConfig:
+    def new_cluster_configuration(self, request: FixtureRequest, api_client) -> ClusterConfig:
         """
         Creates new cluster configuration object.
         Override this fixture in your test class to provide a custom cluster configuration. (See TestInstall)
@@ -248,6 +248,11 @@ class BaseTest:
         """
         config = ClusterConfig()
         self.update_parameterized(request, config)
+
+        # Update cluster name before creating the controller if cluster id was provided
+        if api_client and config.cluster_id is not None:
+            c = api_client.cluster_get(config.cluster_id)
+            config.cluster_name = ClusterName(c.name)
 
         return config
 

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -16,7 +16,7 @@ from paramiko import SSHException
 
 import consts
 from assisted_test_infra.download_logs.download_logs import download_logs
-from assisted_test_infra.test_infra import Nodes, utils, ClusterName
+from assisted_test_infra.test_infra import ClusterName, Nodes, utils
 from assisted_test_infra.test_infra.controllers import (
     AssistedInstallerInfraController,
     IptableRule,

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -2,6 +2,7 @@ from typing import List
 
 import pytest
 from _pytest.nodes import Item
+from assisted_service_client.rest import ApiException
 
 import consts
 from assisted_test_infra.test_infra import utils
@@ -20,8 +21,11 @@ def api_client():
     # prevent from kubeapi tests from failing if the fixture is dependant on api_client fixture
     if not global_variables.is_kube_api:
         log.debug("Getting new inventory client")
-        verify_client_version()
-        client = global_variables.get_api_client()
+        try:
+            verify_client_version()
+            client = global_variables.get_api_client()
+        except (RuntimeError, ApiException) as e:
+            log.warning(f"Failed to access api client, {e}")
 
     yield client
 

--- a/src/tests/conftest.py
+++ b/src/tests/conftest.py
@@ -15,9 +15,15 @@ assert global_variables.pull_secret is not None, "Missing pull secret"
 @pytest.fixture(scope="session")
 def api_client():
     log.info("--- SETUP --- api_client\n")
-    verify_client_version()
+    client = None
 
-    yield global_variables.get_api_client()
+    # prevent from kubeapi tests from failing if the fixture is dependant on api_client fixture
+    if not global_variables.is_kube_api:
+        log.debug("Getting new inventory client")
+        verify_client_version()
+        client = global_variables.get_api_client()
+
+    yield client
 
 
 def get_supported_operators() -> List[str]:


### PR DESCRIPTION
This PR fixes multiple bugs related to cluster configuration:

- Fix cluster configuration name is not properly set on update cluster
- Update cluster configurations when `cluster_id` is provided.
- Allow getting `api_client` fixture without failing on kube api.
- Update infra-env iso-image-type when infra-env is exists
