### PR TITLE
MGMT-17246: add support for ignoring clusters that already exist on jira

### DIFF
--- a/src/assisted_test_infra/download_logs/__main__.py
+++ b/src/assisted_test_infra/download_logs/__main__.py
@@ -64,6 +64,11 @@ def main():
             log.info("No clusters were found")
             return
 
+        if args.clusters_to_filter_out_file:
+            with open(args.clusters_to_filter_out_file, "r") as file:
+                clusters_to_filter_out = set(line.strip() for line in file)
+            clusters = [cluster for cluster in clusters if cluster["id"] not in clusters_to_filter_out]
+
         for cluster in clusters:
             if args.download_all or should_download_logs(cluster):
                 download_cluster_logs(client, cluster, args.dest, args.must_gather, args.update_by_events)
@@ -76,6 +81,11 @@ def handle_arguments():
 
     parser.add_argument("inventory_url", help="URL of remote inventory", type=str)
     parser.add_argument("dest", help="Destination to download logs", type=str)
+    parser.add_argument(
+        "clusters_to_filter_out_file",
+        help="A file containing a list of clusters to ignore, delimeted by a new line",
+        type=str,
+    )
     parser.add_argument("--cluster-id", help="Cluster id to download its logs", type=str, default=None, nargs="?")
     parser.add_argument("--download-all", help="Download logs from all clusters", action="store_true")
     parser.add_argument("--must-gather", help="must-gather logs", action="store_true")

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_nodes_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_nodes_config.py
@@ -42,7 +42,9 @@ class BaseNodesConfig(BaseConfig, ABC):
     base_cluster_domain: Optional[str] = None
 
     network_mtu: int = None
-    tf_platform: str = None  # todo - make all tf dependent platforms (e.g. vsphere, nutanix) inherit from BaseTerraformConfig  # noqa E501
+    tf_platform: str = (
+        None  # todo - make all tf dependent platforms (e.g. vsphere, nutanix) inherit from BaseTerraformConfig  # noqa E501
+    )
 
     @property
     def nodes_count(self):

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -76,7 +76,14 @@ class InventoryClient(object):
             }
 
             log.info("Refreshing API key")
-            response = requests.post(os.environ.get("SSO_URL"), data=params)
+            try:
+                sso_url = os.environ["SSO_URL"]
+            except KeyError:
+                log.error("The environment variable SSO_URL is mandatory but was not supplied")
+                raise
+            else:
+                response = requests.post(sso_url, data=params)
+
             response.raise_for_status()
 
             config.api_key["Authorization"] = response.json()["access_token"]


### PR DESCRIPTION
As part of the triage process, we download logs for all the failed cluster installations and create jira tickets for each failed installation.
Currently, we download all the logs time and time again, and this PR adds additional optional argument, a file containing a list of cluster ids, which we can exclude from downloading.

Also, since SSO_URL is a required env var, I added an exception in case it is not set.