### PR TITLE
MGMT-18118: Use Rocky Linux 9 on OCI

### DIFF
--- a/terraform_files/oci-ci-machine/00_main.tf
+++ b/terraform_files/oci-ci-machine/00_main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     oci = {
       source  = "oracle/oci"
-      version = "5.29.0"
+      version = "5.45.0"
     }
     cloudinit = {
       source  = "hashicorp/cloudinit"


### PR DESCRIPTION
Use Rocky Linux instead of Oracle Linux in order to be consistent with our other workload, and avoid issues like 'crb' repo being unavailable.

Since Rocky is provided by the OCI marketplace, we need to fetch the image from there, and create the necessary resources to accept the agreement to use that OS.

See https://blogs.oracle.com/cloud-infrastructure/post/using-terraform-for-marketplace-images