### PR TITLE
NO-ISSUE: Remove docker as container runtime command option

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -3,7 +3,7 @@
 #############
 
 SHELL=/bin/sh
-CONTAINER_COMMAND := $(shell scripts/utils.sh get_container_runtime_command)
+CONTAINER_COMMAND := podman
 
 # Selecting the right podman-remote version since podman-remote4 cannot work against podman-server3 and vice versa.
 # It must be occurred before any other container related task.

--- a/scripts/install_environment.sh
+++ b/scripts/install_environment.sh
@@ -166,10 +166,6 @@ function install_podman(){
 
 function install_runtime_container() {
     echo "Container runtime package"
-    if [ -x "$(command -v docker)" ]; then
-        echo "docker is already installed"
-        return
-    fi
 
     # getting podman version and allowing it to fail if podman is not installed
     current_podman_version="$(podman info --format={{.Version.Version}} || true)"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -183,30 +183,6 @@ function running_from_skipper() {
    [ -n "${SKIPPER_UID+x}" ]
 }
 
-function get_container_runtime_command() {
-  # if CONTAINER_TOOL is defined skipping
-  if [ -z "${CONTAINER_TOOL+x}" ]; then
-    if running_from_skipper; then
-      if [ -z ${CONTAINER_RUNTIME_COMMAND+x} ]; then
-        echo "CONTAINER_RUNTIME_COMMAND doesn't set on old skipper version -> default to podman. Upgrade your skipper to the latest version" 1>&2;
-      fi
-
-      if [ "${CONTAINER_RUNTIME_COMMAND:-podman}" = "docker" ]; then
-        CONTAINER_TOOL="docker"
-      else
-        CONTAINER_TOOL=$( command -v podman &> /dev/null && echo "podman" || echo "podman-remote")
-      fi
-    else
-      # The Docker command could be an alias for podman, so check first for podman
-      # Fallback to Docker if podman is not available
-      # In the absence of a container tool installed on the system, default to podman as we will install it during setup.
-      CONTAINER_TOOL=$( command -v podman &> /dev/null && echo "podman" || (command -v docker &> /dev/null && echo "docker" || echo "podman"))
-    fi
-  fi
-
-  echo $CONTAINER_TOOL
-}
-
 # podman-remote4 cannot run against podman server 3 so the skipper image contains them both
 # here we select the right podman-remote version
 function select_podman_client() {


### PR DESCRIPTION
Due to the lack of docker support in newer skipper versions

/cc @danmanor 