### PR TITLE
NO-ISSUE: Set pyvmomi version to 8.0.2.0.1 

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -29,7 +29,7 @@ semver==3.0.2
 tabulate==0.9.0
 tqdm==4.66.4
 urllib3<3.0
-pyvmomi>=7.0.2
+pyvmomi==8.0.2.0.1  # Fixed due to a dependancy issue
 waiting>=1.4.1
 prompt-toolkit==3.0.47
 nutanix-api==0.0.20


### PR DESCRIPTION
NO-ISSUE: Fix pyvmomi version to 8.0.2.0.1 due to an issue with 8.0.3.0.0 
Issue opened half hour ago: https://github.com/vmware/pyvmomi/issues/1079

```
      Traceback (most recent call last):
        File "/root/.pyenv/versions/3.12.0/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 353, in <module>
          main()
        File "/root/.pyenv/versions/3.12.0/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 335, in main
          json_out['return_val'] = hook(**hook_input['kwargs'])
                                   ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/root/.pyenv/versions/3.12.0/lib/python3.12/site-packages/pip/_vendor/pyproject_hooks/_in_process/_in_process.py", line 118, in get_requires_for_build_wheel
          return hook(config_settings)
                 ^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-va_iwwvx/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 327, in get_requires_for_build_wheel
          return self._get_build_requires(config_settings, requirements=[])
                 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-build-env-va_iwwvx/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 297, in _get_build_requires
          self.run_setup()
        File "/tmp/pip-build-env-va_iwwvx/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 497, in run_setup
          super().run_setup(setup_script=setup_script)
        File "/tmp/pip-build-env-va_iwwvx/overlay/lib/python3.12/site-packages/setuptools/build_meta.py", line 313, in run_setup
          exec(code, locals())
        File "<string>", line 21, in <module>
        File "/tmp/pip-install-8anpl7l3/pyvmomi_f10ffc1c0ebd48718e49fe38bacb5775/pyVmomi/__init__.py", line 49, in <module>
          from . import VmomiSupport  # noqa: E402
          ^^^^^^^^^^^^^^^^^^^^^^^^^^
        File "/tmp/pip-install-8anpl7l3/pyvmomi_f10ffc1c0ebd48718e49fe38bacb5775/pyVmomi/VmomiSupport.py", line 12, in <module>
          import six
      ModuleNotFoundError: No module named 'six'
```

/cc @eifrach
FYI @danmanor @adriengentil 