### PR TITLE
MGMT-18077: Set OCP 4.16 as default, add OCP 4.17 option

### DIFF
--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -15,7 +15,8 @@ class OpenshiftVersion(Enum):
     VERSION_4_14 = "4.14"
     VERSION_4_15 = "4.15"
     VERSION_4_16 = "4.16"
-    DEFAULT = VERSION_4_15
+    VERSION_4_17 = "4.17"
+    DEFAULT = VERSION_4_16
     MULTI_VERSION = "all"
 
 


### PR DESCRIPTION
- Set OCP 4.16 as default OCP version
- Enable OCP 4.17 installation