### PR TITLE
MGMT-18333: Generate python client instead of using the one from assisted-service image

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -11,6 +11,7 @@ minikube
 .env
 capi
 sno-bootstrap-manifests
+.pip/
 
 # terraform
 .terraform.lock.hcl

--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -1,5 +1,3 @@
-FROM quay.io/edge-infrastructure/assisted-service:latest AS service
-
 FROM quay.io/assisted-installer-ops/base-python:3.12
 
 # A directory in the path with write permission even for non-root users
@@ -56,10 +54,8 @@ COPY --from=quay.io/ocp-splat/govc:v0.29.0 /govc /usr/local/bin
 WORKDIR /home/assisted-test-infra
 
 COPY requirements.txt requirements-dev.txt ./
-COPY --from=service /clients/assisted_service_client-*.whl /build/pip/
 RUN pip3 install --upgrade pip && \
-      pip3 install --no-cache-dir -I -r ./requirements.txt -r ./requirements-dev.txt && \
-      pip3 install --upgrade /build/pip/*
+      pip3 install --no-cache-dir -I -r ./requirements.txt -r ./requirements-dev.txt
 
 RUN curl --retry 5 --connect-timeout 30 -s https://storage.googleapis.com/golang/go1.18.1.linux-amd64.tar.gz | tar -C /usr/local -xz
 ENV GOPATH=/go
@@ -77,3 +73,8 @@ RUN source scripts/utils.sh && \
 
 # setting pre-commit env
 ENV PRE_COMMIT_HOME build
+
+# Install the assisted-service Python client if it exists locally. 
+# In the CI, it will be missing during the first build in "images" in prow,
+# but should be present after running "make image_build" during setup.
+RUN pip3 install --no-index ./.pip/* || true

--- a/Makefile
+++ b/Makefile
@@ -142,10 +142,8 @@ setup:
 
 create_environment: image_build bring_assisted_service create_hub_cluster
 
-image_build:
-	scripts/pull_dockerfile_images.sh
-	sed 's/^FROM .*assisted-service.*:latest/FROM $(subst /,\/,${SERVICE})/' Dockerfile.assisted-test-infra | \
-		$(CONTAINER_COMMAND) build --network=host -t $(IMAGE_NAME) -f- .
+image_build: bring_assisted_service generate_python_client
+	$(CONTAINER_COMMAND) build --network=host -t $(IMAGE_NAME) -f Dockerfile.assisted-test-infra .
 	$(CONTAINER_COMMAND) tag $(IMAGE_NAME) test-infra:latest  # For backwards computability
 
 create_hub_cluster:
@@ -410,3 +408,7 @@ cli:
 
 validate_client:
 	skipper run "python3 ${DEBUG_FLAGS} src/service_client/client_validator.py"
+
+generate_python_client: bring_assisted_service
+	cd assisted-service && skipper make generate-python-client
+	mkdir -p ./.pip && mv assisted-service/build/assisted-installer/assisted-service-client/dist/*.whl ./.pip/

--- a/README.md
+++ b/README.md
@@ -380,7 +380,7 @@ make image_build
 ## In case you would like to build the image with a different `assisted-service` client
 
 ```bash
-make image_build SERVICE=<assisted service image URL>
+make image_build SERVICE_REPO=<assisted-service repository to use> SERVICE_BASE_REF=<assisted-service branch to use>
 ```
 
 ## Test with RHSSO Authentication

--- a/scripts/create_full_environment.sh
+++ b/scripts/create_full_environment.sh
@@ -33,11 +33,6 @@ echo "Installing environment"
 scripts/install_environment.sh
 echo "Done installing"
 
-echo "Creating image"
-make bring_assisted_service
-make image_build
-echo "Done creating image"
-
 echo "Installing kind"
 scripts/hub-cluster/kind/kind.sh install
 echo "Done installing kind"
@@ -49,6 +44,10 @@ echo "Done installing minikube"
 echo "Installing oc and kubectl"
 scripts/install_k8s_clients.sh
 echo "Done installing oc and kubectl"
+
+echo "Creating image"
+make image_build
+echo "Done creating image"
 
 if [ "${DEPLOY_TARGET}" == "minikube" ] && [ -z "${NO_MINIKUBE}" ]; then
     echo "Start minikube"


### PR DESCRIPTION
Currently, we generate python client for assisted-service inside its primary Dockerfile. In order to generate the python client, we need the repository git tags. This behavior collisions with Konflux behavior because Konflux builds the image, searching for the tags in the fork instead of the upstream repository. As a result developers currently need to periodically push git tags to their fork for konflux to build successfully. 

This PR generates generated assisted-service client during assisted-test-infra image build, so later we could follow with a PR to remove assisted-service's generation


reference - https://redhat-internal.slack.com/archives/C035X734RQB/p1719496182644409

