### PR TITLE
NO-ISSUE: better clean up when using destory

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -132,7 +132,7 @@ endif
 
 all: setup run deploy_nodes_with_install
 
-destroy: destroy_nodes delete_minikube delete_kind kill_port_forwardings delete_onprem stop_load_balancer
+destroy: destroy_nodes delete_minikube delete_kind destroy_host_port_forwarding_and_firewall delete_onprem stop_load_balancer
 
 ###############
 # Environment #
@@ -260,6 +260,11 @@ kill_port_forwardings:
 kill_all_port_forwardings:
 	scripts/utils.sh kill_port_forwardings '$(SERVICE_NAME) $(UI_SERVICE_NAME)'
 	scripts/utils.sh kill_port_forwardings '$(SERVICE_NAME) $(PROMETHEUS_SERVICE_NAME)'
+
+destroy_host_port_forwarding_and_firewall:
+	scripts/utils.sh delete_all_port_forwarding
+	firewall-cmd --reload
+
 
 #########
 # Nodes #

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -89,6 +89,18 @@ function kill_port_forwardings() {
     sudo systemctl daemon-reload
 }
 
+function delete_all_port_forwarding() {
+    for service_file in $(ls /etc/systemd/system/forward-*.service 2>/dev/null); do
+            service_base_name=$(basename "$service_file" | cut -d"." -f1)
+            echo "deleting service $service_base_name"
+            sudo systemctl disable --now "service_base_name" 2>/dev/null
+            sudo rm -f "$service_file"
+    done
+
+    sudo systemctl daemon-reload
+}
+
+
 function get_main_ip() {
     echo "$(ip route get 1 | sed 's/^.*src \([^ ]*\).*$/\1/;q')"
 }


### PR DESCRIPTION
When using `make destroy` the host networking doesn't clean up properly 

- stoping all forwarding service
- deleting all forwarding service
- reloading firewall 
 