### PR TITLE
iPXE assets download to container and modify iPxe script

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/ipxe_controller/ipxe_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/ipxe_controller/ipxe_controller.py
@@ -1,3 +1,4 @@
+import copy
 import os
 import shutil
 
@@ -14,10 +15,12 @@ class IPXEController(ContainerizedController):
         name: str = None,
         port: int = consts.DEFAULT_IPXE_SERVER_PORT,
         ip: str = consts.DEFAULT_IPXE_SERVER_IP,
+        local_pxe_assets: bool = False,
     ):
         super().__init__(name, port, name)
         self._ip = ip
         self._api_client = api_client
+        self._local_pxe_assets = local_pxe_assets
         self._dir = os.path.dirname(os.path.realpath(__file__))
         self._ipxe_scripts_folder = f"{self._dir}/server/ipxe_scripts"
 
@@ -37,9 +40,44 @@ class IPXEController(ContainerizedController):
     def _download_ipxe_script(self, infra_env_id: str, cluster_name: str):
         log.info(f"Downloading iPXE script to {self._ipxe_scripts_folder}")
         utils.recreate_folder(self._ipxe_scripts_folder, force_recreate=False)
-        self._api_client.download_and_save_infra_env_file(
-            infra_env_id=infra_env_id, file_name="ipxe-script", file_path=f"{self._ipxe_scripts_folder}/{cluster_name}"
-        )
+        pxe_content = self._api_client.client.v2_download_infra_env_files(
+            infra_env_id=infra_env_id, file_name="ipxe-script", _preload_content=False
+        ).data.decode("utf-8")
+
+        # PXE can not boot from http redirected to https, update the assets images to local http server
+        if self._local_pxe_assets:
+            pxe_content = self._download_ipxe_assets(pxe_content)
+
+        with open(f"{self._ipxe_scripts_folder}/{cluster_name}", "w") as _file:
+            _file.writelines(pxe_content)
+
+    @staticmethod
+    def _replace_assets_pxe(pxe_content: str, old_asset: str, new_asset: str):
+        log.info(f"Replace pxe assets {old_asset} to {new_asset}")
+        return pxe_content.replace(old_asset, new_asset)
+
+    def _download_ipxe_assets(self, pxe_content: str) -> str:
+        """Download the ipxe assets to the container http server
+        Update the ipxe-script assets download from the container.
+        The new asset will be downloaded from http://{self._ip}:{self._port}
+        return new updated pxe content.
+        """
+
+        # New pxe content replace http links to local http server
+        new_pxe_content = copy.deepcopy(pxe_content)
+        new_asset = f"http://{self._ip}:{self._port}/"
+        http_to_download = [res for res in pxe_content.split() if "http:" in res]
+        for http in http_to_download:
+            http = http[http.index("http") :]  # in case http not at the beginning
+            for img in ["pxe-initrd", "kernel", "rootfs"]:
+                if img in http:
+                    utils.download_file(
+                        url=http,
+                        local_filename=f"{self._ipxe_scripts_folder}/{img}",
+                        verify_ssl=False,
+                    )
+                    new_pxe_content = self._replace_assets_pxe(new_pxe_content, http, new_asset + img)
+        return new_pxe_content
 
     def _remove_ipxe_scripts_folder(self):
         log.info(f"Removing iPXE scripts folder {self._ipxe_scripts_folder}")

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -392,6 +392,13 @@ class LibvirtController(NodeController, ABC):
         log.info(f"Destroy network: {network.name()}")
         network.destroy()
 
+    def undefine_network(self, network):
+        """
+        Undefine network of a given libvirt.virNetwork object
+        """
+        log.info(f"Undefine network: {network.name()}")
+        network.undefine()
+
     def add_interface(self, node_name, network_name, target_interface, model="virtio"):
         """
         Create an interface using given network name, return created interface's mac address.
@@ -624,6 +631,7 @@ class LibvirtController(NodeController, ABC):
         bootp.setAttribute("file", ipxe_url)
         dhcp_element.appendChild(bootp)
         self.destroy_network(network)
+        self.undefine_network(network)
         self.create_network(xml.toprettyxml())
 
     def _create_dns_host_xml(self, api_vip: str, cluster_name: str):


### PR DESCRIPTION
Curren iPXE script contains links redirected to https, PXE can not run the downloaded script directly from node.

Steps: (as descibied in UI)
Download the example iPXE script file
Download the assets in the script file to your iPXE server Inside the example script file, customize the asset URLs to your local server address

- Added support for libvirt undefine network
- Added new flag local_pxe_assets to keep support "other" without modifying the pxe content
- Download the ipxe , decode to utf-8 and download http links to the container directoy
- Modify the iPXE scrips link to download from container.

iPXE script should contain local address  http://192.168.XXX.1:8500/ for each image type  pxe-initrd, kernel, rootfs