### PR TITLE
MGMT-18852: disable DHCP for static networking

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,7 +12,7 @@ minikube
 capi
 sno-bootstrap-manifests
 .pip/
-
+**/UNKNOWN.egg-info
 # terraform
 .terraform.lock.hcl
 terraform.tfstate

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -98,6 +98,7 @@ class TerraformController(LibvirtController):
             "libvirt_storage_pool_path": kwargs.get("storage_pool_path", os.path.join(os.getcwd(), "storage_pool")),
             # TODO change to namespace index
             "libvirt_secondary_network_if": self._config.net_asset.libvirt_secondary_network_if,
+            "enable_dhcp": (False if kwargs.get("is_static_ip") else True),
             "provisioning_cidr": self._config.net_asset.provisioning_cidr,
             "running": self._config.running,
             "single_node_ip": kwargs.get("single_node_ip", ""),

--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -25,6 +25,9 @@ resource "libvirt_network" "net" {
   domain    = "${var.cluster_name}.${var.cluster_domain}"
   addresses = var.machine_cidr_addresses
   autostart = true
+  dhcp {
+    enabled = var.enable_dhcp
+  }
 
   dns {
     local_only = true

--- a/terraform_files/baremetal/variables-libvirt.tf
+++ b/terraform_files/baremetal/variables-libvirt.tf
@@ -273,3 +273,9 @@ variable "slave_interfaces" {
   description = "create interfaces as slaves.  do not assign to them mac and IP addresses"
   default     = false
 }
+
+variable "enable_dhcp" {
+  type        = bool
+  description = "Disabling DHCP for static IP"
+  default = true
+}


### PR DESCRIPTION
When deploying static networking the network has DHCP.
In some cases where the IP config is invalid the installation continues using DHCP
