### PR TITLE
Add enable redirect to console for classes inherit from BaseTest

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/__init__.py
+++ b/src/assisted_test_infra/test_infra/utils/__init__.py
@@ -11,6 +11,7 @@ from .utils import (
     get_openshift_release_image,
     recreate_folder,
     run_command,
+    console_redirect_decorator,
 )
 
 __all__ = [
@@ -25,4 +26,5 @@ __all__ = [
     "config_etc_hosts",
     "run_command",
     "wait_for_pod_ready",
+    "console_redirect_decorator",
 ]

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -501,6 +501,19 @@ class BaseTest:
         yield EventsHandler(api_client)
 
     @pytest.fixture
+    def kernel_arguments(self):
+        """Hook to enable console redirect
+        The kernel_arguments should be enabled on a function with pytest.mark.parametrize decorator, but we can not
+        modify function signature on runtime.
+        We create a dummy fixture with same name.
+
+        In order to enable console redirection:
+        @console_redirect_decorator
+        class TestIPv6(BaseTest):
+        """
+        pass
+
+    @pytest.fixture
     @JunitFixtureTestCase()
     def cluster(
         self,
@@ -512,6 +525,7 @@ class BaseTest:
         cluster_configuration: ClusterConfig,
         ipxe_server: Callable,
         tang_server: Callable,
+        kernel_arguments
     ) -> Cluster:
         log.debug(f"--- SETUP --- Creating cluster for test: {request.node.name}\n")
         if cluster_configuration.disk_encryption_mode == consts.DiskEncryptionMode.TANG:

--- a/src/tests/test_e2e_install.py
+++ b/src/tests/test_e2e_install.py
@@ -4,12 +4,15 @@ from junit_report import JunitTestSuite
 from kubernetes import client, config
 
 import consts
-from assisted_test_infra.test_infra.utils import wait_for_pod_ready
+
+from assisted_test_infra.test_infra.utils import console_redirect_decorator, wait_for_pod_ready
+
 from tests.base_test import BaseTest
 from tests.config import global_variables
 from tests.conftest import get_available_openshift_versions, get_supported_operators
 
 
+@console_redirect_decorator
 class TestInstall(BaseTest):
     @JunitTestSuite()
     @pytest.mark.parametrize("openshift_version", get_available_openshift_versions())


### PR DESCRIPTION
Current code does not support kernel_arguments cosole for node when running virsh console.

Added support for class decorator enabled by request on BaseTest childs The decorator check all test_ function and add parametrize kernel_arguments without change the functions signature.
Added hook to cluster fixture to enable kernel_arguments params.