### PR TITLE
MGMT-19039: Prioritize OPENSHIFT_VERSION over OPENSHIFT_INSTALL_RELEASE_IMAGE when overriding images

### DIFF
--- a/scripts/override_images/override_release_images.py
+++ b/scripts/override_images/override_release_images.py
@@ -34,20 +34,7 @@ def main():
     with open(release_images_path, "r") as f:
         release_images = [ReleaseImage(**release_image_dict) for release_image_dict in json.load(f)]
 
-    if (release_image_ref := os.getenv("OPENSHIFT_INSTALL_RELEASE_IMAGE", "")) != "":
-        ocp_semantic_version = utils.extract_version(release_image=release_image_ref)
-        ocp_xyz_version = f"{ocp_semantic_version.major}.{ocp_semantic_version.minor}.{ocp_semantic_version.patch}"
-        ocp_xy_version = f"{ocp_semantic_version.major}.{ocp_semantic_version.minor}"
-
-        if (release_image := get_release_image(release_images=release_images, ocp_xy_version=ocp_xy_version)) is None:
-            release_image = ReleaseImage(
-                openshift_version=ocp_xy_version,
-                version=ocp_xyz_version,
-                cpu_architecture=DEFAULT_CPU_ARCHITECTURE,
-                url=release_image_ref,
-            )
-
-    elif (version := os.getenv("OPENSHIFT_VERSION", "")) != "":
+    if (version := os.getenv("OPENSHIFT_VERSION", "")) != "":
         try:
             sem_version = semver.VersionInfo.parse(version, optional_minor_and_patch=True)
             ocp_xy_version = f"{sem_version.major}.{sem_version.minor}"
@@ -60,6 +47,19 @@ def main():
                 No release image found with 'openshift_version':
                 {ocp_xy_version} and cpu_architecture: {DEFAULT_CPU_ARCHITECTURE}"
             """
+            )
+
+    elif (release_image_ref := os.getenv("OPENSHIFT_INSTALL_RELEASE_IMAGE", "")) != "":
+        ocp_semantic_version = utils.extract_version(release_image=release_image_ref)
+        ocp_xyz_version = f"{ocp_semantic_version.major}.{ocp_semantic_version.minor}.{ocp_semantic_version.patch}"
+        ocp_xy_version = f"{ocp_semantic_version.major}.{ocp_semantic_version.minor}"
+
+        if (release_image := get_release_image(release_images=release_images, ocp_xy_version=ocp_xy_version)) is None:
+            release_image = ReleaseImage(
+                openshift_version=ocp_xy_version,
+                version=ocp_xyz_version,
+                cpu_architecture=DEFAULT_CPU_ARCHITECTURE,
+                url=release_image_ref,
             )
 
     else:


### PR DESCRIPTION
To avoid having to set `OPENSHIFT_INSTALL_RELEASE_IMAGE = ""` in the CI jobs 