### PR TITLE
MGMT-19278: Use multi-arch OCP release images with OPENSHIFT_VERSION configuration

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,6 +180,7 @@ before you run start the deployment.
 | `PLATFORM`                   | The openshift platform to integrate with, one of: `baremetal`, `none`,`vsphere`, `external`, default: `baremetal`                                          |
 | `KERNEL_ARGUMENTS`           | Update live ISO kernel arguments. JSON formatted string containing array of dictionaries each having 2 attributes: `operation` and `value`. Currently, only `append` operation is supported. |
 | `CPU_ARCHITECTURE`           | CPU architecture of the nodes that will be part of the cluster, one of: `x86_64`, `arm64`, `s390x`, `ppc64le`, default: `x86_64`                           |
+| `DAY2_CPU_ARCHITECTURE`      | CPU architecture of the nodes that will be part of the cluster in day2, one of: `x86_64`, `arm64`, `s390x`, `ppc64le` default:`x86_64`                     |
 | `CUSTOM_MANIFESTS_FILES`     | List of local manifest files separated by commas or path to directory containing multiple manifests                                                        |
 | `DISCONNECTED`               | Set to "true" if local mirror needs to be used                                                            |
 | `REGISTRY_CA_PATH`           | Path to mirror registry CA bundle                                                            |

--- a/scripts/deploy_assisted_service.sh
+++ b/scripts/deploy_assisted_service.sh
@@ -52,6 +52,7 @@ export ASSISTED_SERVICE_DATA_BASE_PATH="./assisted-service/data"
 export RELEASE_IMAGES_PATH="${ASSISTED_SERVICE_DATA_BASE_PATH}/default_release_images.json"
 export OS_IMAGES_PATH="${ASSISTED_SERVICE_DATA_BASE_PATH}/default_os_images.json"
 
+
 if [ -n "${IMAGES_FLAVOR}" ]; then
     RELEASE_IMAGES_PATH="${ASSISTED_SERVICE_DATA_BASE_PATH}/default_${IMAGES_FLAVOR}_release_images.json"
     OS_IMAGES_PATH="${ASSISTED_SERVICE_DATA_BASE_PATH}/default_${IMAGES_FLAVOR}_os_images.json"
@@ -81,10 +82,14 @@ if [ "${RELEASE_IMAGES}" = "" ] && { [ "${OPENSHIFT_INSTALL_RELEASE_IMAGE}" != "
     fi
 fi
 
-if [ "${OS_IMAGES}" = "" ] && [ "${ENABLE_KUBE_API}" != "true" ] && [ "${DEPLOY_TARGET}" != "operator" ] && { [ "${OPENSHIFT_CI}" = "true" ] || [ "${OPENSHIFT_INSTALL_RELEASE_IMAGE}" != "" ] || [ "${OPENSHIFT_VERSION}" != "" ]; }; then
+if [ "${OS_IMAGES}" = "" ] && [ "${ENABLE_KUBE_API}" != "true" ] && [ "${DEPLOY_TARGET}" != "operator" ] && { [ "${OPENSHIFT_INSTALL_RELEASE_IMAGE}" != "" ] || [ "${OPENSHIFT_VERSION}" != "" ]; }; then
     OS_IMAGES=$(skipper run ./scripts/override_images/override_os_images.py)
     export OS_IMAGES
 fi
+
+# assisted-service has a mechanism for filtering images which filters out multi-arch images.
+# This way we disable it as we already filtered here
+unset OPENSHIFT_VERSION
 
 if [ "${DEPLOY_TARGET}" == "onprem" ]; then
     # Override assisted-service and assisted-image-service

--- a/scripts/override_images/override_os_images.py
+++ b/scripts/override_images/override_os_images.py
@@ -8,10 +8,9 @@ import json
 import os
 import sys
 
-import semver
 from assisted_service_client.models import OsImage, ReleaseImage
 
-from consts import DEFAULT_CPU_ARCHITECTURE
+from consts import DEFAULT_CPU_ARCHITECTURE, CPUArchitecture
 
 
 def get_os_image(
@@ -37,40 +36,49 @@ def main():
         raise ValueError("RELEASE_IMAGES environment variable must be provided")
 
     try:
-        release_images = json.loads(release_images)
+        release_images = [ReleaseImage(**release_image_dict) for release_image_dict in json.loads(release_images)]
     except json.JSONDecodeError as e:
         raise ValueError("RELEASE_IMAGES enironment variable content is invalid JSON") from e
 
-    if len(release_images) == 0:
-        raise ValueError("RELEASE_IMAGES enironment variable content must contain at least one release")
-
-    # get latest default CPU architecture release image
-    release_image_objects = [
-        ReleaseImage(**release_image)
-        for release_image in release_images
-        if release_image["cpu_architecture"] == DEFAULT_CPU_ARCHITECTURE
-    ]
-    release_images_map = {
-        semver.VersionInfo.parse(
-            release_image.version.removesuffix("-multi"), optional_minor_and_patch=True
-        ): release_image
-        for release_image in release_image_objects
-    }
-    latest_release_image_version = sorted(release_images_map.keys(), key=lambda version: version)[-1]
-    latest_release_image = release_images_map[latest_release_image_version]
-
-    if (
-        os_image := get_os_image(os_images=os_images, openshift_version=str(latest_release_image.openshift_version))
-    ) is None:
+    if len(release_images) != 1:
         raise ValueError(
-            f"""no OS image found with openshift_version:
-            {latest_release_image.openshift_version} for the latest release image
-            """
+            "RELEASE_IMAGES enironment variable content must contain exactly one release image after its override"
         )
 
-    os_images_dict = [os_image.to_dict()]
+    release_image = release_images[0]
+    filtered_os_images: list[OsImage] = []
 
-    json.dump(os_images_dict, sys.stdout, separators=(",", ":"))
+    # Get all matching OS images
+    if release_image.cpu_architecture == CPUArchitecture.MULTI:
+        for arch in {CPUArchitecture.X86, CPUArchitecture.ARM, CPUArchitecture.S390X, CPUArchitecture.PPC64}:
+            if (
+                os_image := get_os_image(
+                    os_images=os_images,
+                    openshift_version=str(release_image.openshift_version).removesuffix(f"-{CPUArchitecture.MULTI}"),
+                    cpu_architecture=arch,
+                )
+            ) is not None:
+                filtered_os_images.append(os_image)
+
+    else:
+        if (
+            os_image := get_os_image(
+                os_images=os_images,
+                openshift_version=str(release_image.openshift_version),
+                cpu_architecture=str(release_image.cpu_architecture),
+            )
+        ) is None:
+            raise ValueError(
+                "Failed find get OS image matching openshift_version:"
+                f"{release_image.openshift_version} and CPU architecture: {release_image.cpu_architecture}"
+            )
+        filtered_os_images.append(os_image)
+
+    if filtered_os_images == 0:
+        raise ValueError("No OS Images found")
+
+    os_images = [os_image.to_dict() for os_image in filtered_os_images]
+    json.dump(os_images, sys.stdout, separators=(",", ":"))
 
 
 if __name__ == "__main__":

--- a/scripts/override_images/override_release_images.py
+++ b/scripts/override_images/override_release_images.py
@@ -2,7 +2,8 @@
 # -*- coding: utf-8 -*-
 """
 Overrides the list of release images according to
-OPENSHIFT_VERSION or OPENSHIFT_INSTALL_RELEASE_IMAGE environment variables
+OPENSHIFT_VERSION or OPENSHIFT_INSTALL_RELEASE_IMAGE environment variables.
+Should result in single release image.
 """
 import json
 import os
@@ -12,7 +13,7 @@ import semver
 from assisted_service_client.models import ReleaseImage
 
 from assisted_test_infra.test_infra import utils
-from consts import DEFAULT_CPU_ARCHITECTURE
+from consts import DEFAULT_CPU_ARCHITECTURE, CPUArchitecture
 
 
 def get_release_image(
@@ -37,39 +38,51 @@ def main():
     if (version := os.getenv("OPENSHIFT_VERSION", "")) != "":
         try:
             sem_version = semver.VersionInfo.parse(version, optional_minor_and_patch=True)
-            ocp_xy_version = f"{sem_version.major}.{sem_version.minor}"
+            ocp_xy_version = f"{sem_version.major}.{sem_version.minor}-{CPUArchitecture.MULTI}"
         except ValueError as e:
             raise ValueError("provided OPENSHIFT_VERSION is not a valid semantic version") from e
 
-        if (release_image := get_release_image(release_images=release_images, ocp_xy_version=ocp_xy_version)) is None:
+        if (
+            release_image := get_release_image(
+                release_images=release_images, ocp_xy_version=ocp_xy_version, cpu_architecture=CPUArchitecture.MULTI
+            )
+        ) is None:
             raise ValueError(
                 f"""
                 No release image found with 'openshift_version':
-                {ocp_xy_version} and cpu_architecture: {DEFAULT_CPU_ARCHITECTURE}"
+                {ocp_xy_version} and cpu_architecture: {CPUArchitecture.MULTI}"
             """
             )
 
+        release_image.default = True
+
     elif (release_image_ref := os.getenv("OPENSHIFT_INSTALL_RELEASE_IMAGE", "")) != "":
         ocp_semantic_version = utils.extract_version(release_image=release_image_ref)
-        ocp_xyz_version = f"{ocp_semantic_version.major}.{ocp_semantic_version.minor}.{ocp_semantic_version.patch}"
-        ocp_xy_version = f"{ocp_semantic_version.major}.{ocp_semantic_version.minor}"
+        cpu_architecture = utils.extract_architecture(release_image=release_image_ref)
+        cpu_architectures = (
+            [CPUArchitecture.X86, CPUArchitecture.ARM, CPUArchitecture.S390X, CPUArchitecture.PPC64]
+            if cpu_architecture == CPUArchitecture.MULTI
+            else [cpu_architecture]
+        )
+        suffix = CPUArchitecture.MULTI if cpu_architecture == CPUArchitecture.MULTI else ""
+        ocp_xy_version = f"{ocp_semantic_version.major}.{ocp_semantic_version.minor}{suffix}"
 
-        if (release_image := get_release_image(release_images=release_images, ocp_xy_version=ocp_xy_version)) is None:
-            release_image = ReleaseImage(
-                openshift_version=ocp_xy_version,
-                version=ocp_xyz_version,
-                cpu_architecture=DEFAULT_CPU_ARCHITECTURE,
-                url=release_image_ref,
-            )
+        release_image = ReleaseImage(
+            openshift_version=ocp_xy_version,
+            version=str(ocp_semantic_version),
+            cpu_architecture=cpu_architecture,
+            cpu_architectures=cpu_architectures,
+            default=True,
+            url=release_image_ref,
+        )
 
     else:
         raise ValueError(
             "OPENSHIFT_INSTALL_RELEASE_IMAGE or OPENSHIFT_VERSION must be specified in order to override RELEASE_IMAGES"
         )
 
-    release_images_dict = [release_image.to_dict()]
-
-    json.dump(release_images_dict, sys.stdout, separators=(",", ":"))
+    release_images = [release_image.to_dict()]
+    json.dump(release_images, sys.stdout, separators=(",", ":"))
 
 
 if __name__ == "__main__":

--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -125,9 +125,6 @@ class Cluster(BaseCluster):
         if self._config.network_type is not None:
             extra_vars["network_type"] = self._config.network_type
 
-        if self._config.cpu_architecture:
-            extra_vars["cpu_architecture"] = self._config.cpu_architecture
-
         if self._config.is_disconnected:
             extra_vars["is_disconnected"] = self._config.is_disconnected
 
@@ -153,6 +150,12 @@ class Cluster(BaseCluster):
             high_availability_mode=self._config.high_availability_mode,
             disk_encryption=disk_encryption,
             tags=self._config.cluster_tags or None,
+            control_plane_count=self.nodes.masters_count,
+            cpu_architecture=(
+                consts.CPUArchitecture.MULTI
+                if self._config.openshift_version.endswith(f"{consts.CPUArchitecture.MULTI}")
+                else self._config.cpu_architecture
+            ),
             **extra_vars,
         )
 

--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -348,3 +348,4 @@ class CPUArchitecture:
     ARM = "arm64"
     S390X = "s390x"
     PPC64 = "ppc64le"
+    MULTI = "multi"

--- a/src/tests/global_variables/default_variables.py
+++ b/src/tests/global_variables/default_variables.py
@@ -28,7 +28,12 @@ class DefaultVariables(_EnvVariables, Triggerable):
         if not self.is_kube_api:
             with suppress(RuntimeError, TimeoutError):
                 client = self.get_api_client()
-        self._set("openshift_version", utils.get_openshift_version(allow_default=True, client=client))
+
+        openshift_version = utils.get_openshift_version(allow_default=True, client=client)
+        if openshift_version is None:
+            raise ValueError("openshift_Version is None")
+
+        self._set("openshift_version", openshift_version)
         Trigger.trigger_configurations([self], get_default_triggers())
 
     def _set(self, key: str, value: Any):

--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -112,8 +112,8 @@ class _EnvVariables(DataPool, ABC):
     bootstrap_in_place: EnvVar = EnvVar(
         ["BOOTSTRAP_IN_PLACE"], loader=lambda x: bool(strtobool(x)), default=env_defaults.DEFAULT_BOOTSTRAP_IN_PLACE
     )
-    cpu_architecture: EnvVar = EnvVar(["CPU_ARCHITECTURE"])
-    day2_cpu_architecture: EnvVar = EnvVar(["DAY2_CPU_ARCHITECTURE"])
+    cpu_architecture: EnvVar = EnvVar(["CPU_ARCHITECTURE"], default=consts.DEFAULT_CPU_ARCHITECTURE)
+    day2_cpu_architecture: EnvVar = EnvVar(["DAY2_CPU_ARCHITECTURE"], default=consts.DEFAULT_CPU_ARCHITECTURE)
 
     single_node_ip: EnvVar = EnvVar(["SINGLE_NODE_IP"], default=env_defaults.DEFAULT_SINGLE_NODE_IP)
     worker_cpu_mode: EnvVar = EnvVar(["WORKER_CPU_MODE"], default=env_defaults.DEFAULT_TF_CPU_MODE)


### PR DESCRIPTION
Adjust the correct `cpu_architecture` which should be used for cluster, infraenv creation