### PR TITLE
OCI: Add default tag_namespace_name for terraform variables.

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/oci_api_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/oci_api_controller.py
@@ -220,6 +220,7 @@ class OciApiController(NodeController):
             "compute_shape": compute_shape,
             "compute_count": compute_count,
             "zone_dns": base_dns,
+            "tag_namespace_name": f"openshift-{str(cluster_name)}",
             **kwargs,
         }
         log.info(f"Terraform variables before apply setting  {variables}")


### PR DESCRIPTION
Sometimes during stack apply we hit on:
Error: 400-InvalidParameter, Failed to validate tags: TagNamespace openshift-test-infra-cluster-b1c19bff does not exists Suggestion: Please update the parameter(s) in the Terraform config as per error message Failed to validate tags: TagNamespace openshift-test-infra-cluster-b1c19bff does not exists

Set the param in terraform.

description = "Name of tag namespace to create or use for tagging OCI resources". Defaults to "openshift-{cluster_name}"