### PR TITLE
Increasing Terraform's timeout.

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -66,6 +66,7 @@ COPY . .
 
 # init terraform in order to cache the provider
 RUN source scripts/utils.sh && \
+    export TF_REGISTRY_CLIENT_TIMEOUT=60 && \
     retry -- terraform -chdir=/home/assisted-test-infra/terraform_files/equinix-ci-machine init && \
     retry -- terraform -chdir=/home/assisted-test-infra/terraform_files/oci-ci-machine init && \
     chgrp -R 0 /home/assisted-test-infra && \


### PR DESCRIPTION
When running `make setup` on a clean Centos stream 9 machine, we get a timeout when running `terraform ... init` for the equinix plugin.

Increasing the time solved the issue.

---

/cc @eliorerz 