### PR TITLE
MGMT-17556: Add network to clean os boot data

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -522,12 +522,12 @@ class LibvirtController(NodeController, ABC):
 
         for el in os_element.getElementsByTagName("boot"):
             dev = el.getAttribute("dev")
-            if dev in ["cdrom", "hd"]:
+            if dev in ["cdrom", "hd", "network"]:
                 os_element.removeChild(el)
             else:
                 raise ValueError(f"Found unexpected boot device: '{dev}'")
 
-        for disk in node_xml.getElementsByTagName("disk"):
+        for disk in [*node_xml.getElementsByTagName("disk"), *node_xml.getElementsByTagName("network")]:
             for boot in disk.getElementsByTagName("boot"):
                 disk.removeChild(boot)
 


### PR DESCRIPTION
Libvirt allows to boot from network and set order per interface with <boot order= /> When try to add support for boot order when disk exists it rejected by libvirt: unsupported configuration: per-device boot elements cannot be used together with os/boot elements

Adding support to clean network from os boot and from interfaces.

In case of boot from iSCSI we must add the provision interface as primary interface to boot from.