### PR TITLE
Revert "MGMT-19080: Setup test infra for testing new control_plane_count field in https://github.com/openshift/assisted-service/pull/6917"

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -150,7 +150,6 @@ class Cluster(BaseCluster):
             high_availability_mode=self._config.high_availability_mode,
             disk_encryption=disk_encryption,
             tags=self._config.cluster_tags or None,
-            control_plane_count=self.nodes.masters_count,
             **extra_vars,
         )
 

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -2,7 +2,6 @@
 import base64
 import contextlib
 import enum
-import inspect
 import ipaddress
 import json
 import os
@@ -175,13 +174,9 @@ class InventoryClient(object):
     def create_cluster(
         self, name: str, ssh_public_key: Optional[str] = None, **cluster_params
     ) -> models.cluster.Cluster:
-        init_signature = inspect.signature(models.ClusterCreateParams.__init__)
-        if "control_plane_count" not in init_signature.parameters:
-            del cluster_params["control_plane_count"]
-
-        params = models.ClusterCreateParams(name=name, ssh_public_key=ssh_public_key, **cluster_params)
-        log.info("Creating cluster with params %s", params.__dict__)
-        result = self.client.v2_register_cluster(new_cluster_params=params)
+        cluster = models.ClusterCreateParams(name=name, ssh_public_key=ssh_public_key, **cluster_params)
+        log.info("Creating cluster with params %s", cluster.__dict__)
+        result = self.client.v2_register_cluster(new_cluster_params=cluster)
         return result
 
     def create_infra_env(


### PR DESCRIPTION
Reverts openshift/assisted-test-infra#2562

breaking CI and QE testing - this field is not in the SaaS releases yet