### PR TITLE
NO-ISSUE: Enable sourcing utils.sh in function calls

### DIFF
--- a/scripts/download_logs.sh
+++ b/scripts/download_logs.sh
@@ -59,7 +59,7 @@ function download_cluster_logs() {
       elif [ "${DEPLOY_TARGET:-}" = "minikube" ]; then
         SERVICE_URL=$(KUBECONFIG=${HOME}/.kube/config minikube service assisted-service -n ${NAMESPACE} --url)
       else
-        SERVICE_URL="${SERVICE_URL:-$(get_main_ip)}:8090"
+        SERVICE_URL="http://${SERVICE_URL:-$(get_main_ip)}:8090"
       fi
     fi
     skipper run -e JUNIT_REPORT_DIR "python3 ${DEBUG_FLAGS} -m src.assisted_test_infra.download_logs ${SERVICE_URL} ${LOGS_DEST} --cluster-id ${CLUSTER_ID} ${ADDITIONAL_PARAMS}"

--- a/scripts/utils.sh
+++ b/scripts/utils.sh
@@ -284,4 +284,6 @@ function get_pods_with_label() {
     kubectl get pods -n $namespace -l $pod_label -o name
 }
 
-"$@"
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    "$@"
+fi


### PR DESCRIPTION
- enable sourcing utils.sh in function calls
- Fix download_logs url

The logs are collected now -  https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/openshift_assisted-test-infra/2576/pull-ci-openshift-assisted-test-infra-master-e2e-metal-assisted/1861049718910488576/artifacts/e2e-metal-assisted/assisted-common-gather/artifacts/2024-11-25_15-05-40_85b00325-b4ac-4ec9-bd07-00c1292f2162/