### PR TITLE
MGMT-19236: Add Openshift sandboxed containers operator(OSC) support

### DIFF
--- a/src/consts/olm_operators.py
+++ b/src/consts/olm_operators.py
@@ -76,15 +76,15 @@ class OperatorResource:
     def get_osc_resource_dict(cls, is_sno: bool) -> dict:
         if not is_sno:
             return cls.get_resource_dict(
-                master_memory=1024,
-                worker_memory=1024,
-                master_vcpu=1,
-                worker_vcpu=1,
+                master_memory=16384,
+                worker_memory=8192,
+                master_vcpu=4,
+                worker_vcpu=2,
             )
         else:
             return cls.get_resource_dict(
-                master_memory=1024,
-                master_vcpu=1,
+                master_memory=16384,
+                master_vcpu=8,
             )
 
     @classmethod

--- a/src/consts/olm_operators.py
+++ b/src/consts/olm_operators.py
@@ -10,6 +10,7 @@ class OperatorType:
     MCE = "mce"
     METALLB = "metallb"
     OPENSHIFT_AI = "openshift-ai"
+    OSC = "osc"
 
 
 class OperatorStatus:
@@ -72,6 +73,21 @@ class OperatorResource:
             )
 
     @classmethod
+    def get_osc_resource_dict(cls, is_sno: bool) -> dict:
+        if not is_sno:
+            return cls.get_resource_dict(
+                master_memory=1024,
+                worker_memory=1024,
+                master_vcpu=1,
+                worker_vcpu=1,
+            )
+        else:
+            return cls.get_resource_dict(
+                master_memory=1024,
+                master_vcpu=1,
+            )
+
+    @classmethod
     def values(cls, is_sno: bool = False) -> dict:
         return {
             OperatorType.CNV: cls.get_resource_dict(master_memory=150, worker_memory=360, master_vcpu=4, worker_vcpu=2),
@@ -110,6 +126,7 @@ class OperatorResource:
                 worker_disk_count=2,
                 worker_count=3,
             ),
+            OperatorType.OSC: cls.get_osc_resource_dict(is_sno),
         }
 
 
@@ -149,6 +166,10 @@ class OpenShiftAIOperatorFailedError(OperatorFailedError):
     pass
 
 
+class OSCOperatorFailedError(OperatorFailedError):
+    pass
+
+
 def get_exception_factory(operator: str):
 
     if operator == OperatorType.CNV:
@@ -174,6 +195,9 @@ def get_exception_factory(operator: str):
 
     if operator == OperatorType.OPENSHIFT_AI:
         return OpenShiftAIOperatorFailedError
+
+    if operator == OperatorType.OSC:
+        return OSCOperatorFailedError
 
     return OperatorFailedError
 

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -74,6 +74,7 @@ _default_triggers = frozendict(
             conditions=[lambda config: "openshift-ai" in config.olm_operators],
             operator="openshift-ai",
         ),
+        "osc_operator": OlmOperatorsTrigger(conditions=[lambda config: "osc" in config.olm_operators], operator="osc"),
         "sno_mce_operator": OlmOperatorsTrigger(
             conditions=[lambda config: "mce" in config.olm_operators, lambda config2: config2.masters_count == 1],
             operator="mce",

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -74,7 +74,6 @@ _default_triggers = frozendict(
             conditions=[lambda config: "openshift-ai" in config.olm_operators],
             operator="openshift-ai",
         ),
-        "osc_operator": OlmOperatorsTrigger(conditions=[lambda config: "osc" in config.olm_operators], operator="osc"),
         "sno_mce_operator": OlmOperatorsTrigger(
             conditions=[lambda config: "mce" in config.olm_operators, lambda config2: config2.masters_count == 1],
             operator="mce",
@@ -83,6 +82,15 @@ _default_triggers = frozendict(
         "mce_operator": OlmOperatorsTrigger(
             conditions=[lambda config: "mce" in config.olm_operators, lambda config2: config2.masters_count > 1],
             operator="mce",
+        ),
+        "sno_osc_operator": OlmOperatorsTrigger(
+            conditions=[lambda config: "osc" in config.olm_operators, lambda config2: config2.masters_count == 1],
+            operator="osc",
+            is_sno=True,
+        ),
+        "osc_operator": OlmOperatorsTrigger(
+            conditions=[lambda config: "osc" in config.olm_operators, lambda config2: config2.masters_count > 1],
+            operator="osc",
         ),
         "ipxe_boot": Trigger(
             conditions=[lambda config: config.ipxe_boot is True],


### PR DESCRIPTION
- Testing with 3 masters and 3 workers, the osc operator can be installed. 
![Screenshot from 2024-12-02 23-32-30](https://github.com/user-attachments/assets/5544b92e-39d4-4931-9280-9ac00c6ad666)

- Testing with SNO, the osc operator can be installed. 
![Screenshot from 2024-12-03 10-27-37](https://github.com/user-attachments/assets/0d6d0c51-c0a9-4ea8-8a3e-26850f26856a)
