### PR TITLE
NO-ISSUE: Use `max` to calculate operator resources

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/operators_utils.py
+++ b/src/assisted_test_infra/test_infra/utils/operators_utils.py
@@ -94,10 +94,7 @@ def filter_operators_by_type(operators: List[MonitoredOperator], operator_types:
 
 def resource_param(base_value: int, resource_name: str, operator: str, is_sno: bool = False):
     try:
-        value = base_value
         resource = consts.OperatorResource.values(is_sno)[operator][resource_name]
-        if value <= resource:
-            value = value + resource
-        return value
+        return max(base_value, resource)
     except KeyError as e:
         raise ValueError(f"Unknown operator name {e.args[0]}") from e


### PR DESCRIPTION
Currently the logic used to calculate resources for operators is like this:

```python
def resource_param(base_value: int, resource_name: str, operator: str, is_sno: bool = False):
    try:
        value = base_value
        resource = consts.OperatorResource.values(is_sno)[operator][resource_name]
        if value <= resource:
            value = value + resource
        return value
     except KeyError as e:
         raise ValueError(f"Unknown operator name {e.args[0]}") from e
```

For example, the default for resource `worker_count` is 2, and with this logic there is no way to specify that 3 workers are required:

| Default | Operator | Result |
| ------- | --------- | ------|
| 2       | 0         | 2     |
| 2       | 1         | 2     |
| 2       | 2         | 4     |
| 2       | 3         | 5     |
| 2       | 4         | 6     |

As you can see the actual value jumps from 2 to 4, and there is no way to get 3 as the result, no mather what is the requirement of the operator.

The same happens for other resources, like memory or CPU.

It would be more useful to calculate the actual value as the maximum of the default and the value required by the operator. This is what this patch does.