### PR TITLE
NO-ISSUE: Remove deletion of `control_plane_count` field during cluster creation

### DIFF
--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -2,7 +2,6 @@
 import base64
 import contextlib
 import enum
-import inspect
 import ipaddress
 import json
 import os
@@ -175,10 +174,6 @@ class InventoryClient(object):
     def create_cluster(
         self, name: str, ssh_public_key: Optional[str] = None, **cluster_params
     ) -> models.cluster.Cluster:
-        init_signature = inspect.signature(models.ClusterCreateParams.__init__)
-        if "control_plane_count" not in init_signature.parameters:
-            del cluster_params["control_plane_count"]
-
         params = models.ClusterCreateParams(name=name, ssh_public_key=ssh_public_key, **cluster_params)
         log.info("Creating cluster with params %s", params.__dict__)
         result = self.client.v2_register_cluster(new_cluster_params=params)


### PR DESCRIPTION
Remove deletion of `control_plane_count` field during cluster creation as it was replaced in https://github.com/openshift/assisted-test-infra/pull/2569 to conditionally adding this field