### PR TITLE
NO-ISSUE: Fix networking test OCP version handling

### DIFF
--- a/src/tests/test_e2e_install.py
+++ b/src/tests/test_e2e_install.py
@@ -25,7 +25,7 @@ class TestInstall(BaseTest):
     @JunitTestSuite()
     @pytest.mark.parametrize("network_type", [consts.NetworkType.OpenShiftSDN, consts.NetworkType.OVNKubernetes])
     def test_networking(self, cluster, network_type):
-        if semver.compare(_get_semver(global_variables.openshift_version), "4.15.0") >= 0:
+        if semver.VersionInfo.parse(str(global_variables.openshift_version), optional_minor_and_patch=True) >= "4.15.0":
             raise ValueError(
                 "parametrization of network type not necessary from 4.15.0 and above,"
                 " as the only supported network type is OVN"
@@ -83,12 +83,3 @@ class TestInstall(BaseTest):
                 assert status.ready, "Expected pod to be ready"
                 assert status.started, "Expected pod to be started"
                 assert status.state.running is not None, "Expected pod to be running"
-
-
-def _get_semver(version: str) -> str:
-    """
-    Ensure version to be semver compatible
-    """
-    if version.count(".") > 1:
-        return version
-    return _get_semver(f"{version}.0")


### PR DESCRIPTION
```
  File "/root/.pyenv/versions/3.12.0/lib/python3.12/site-packages/semver/version.py", line 646, in parse
    raise ValueError(f"{version} is not valid SemVer string")
ValueError: 4.14-multi.0 is not valid SemVer string
```