### PR TITLE
NO-ISSUE: Enable single arch OCP released image installation

### DIFF
--- a/scripts/override_images/override_release_images.py
+++ b/scripts/override_images/override_release_images.py
@@ -48,19 +48,22 @@ def main():
     if (version := os.getenv("OPENSHIFT_VERSION", "")) != "":
         try:
             sem_version = semver.VersionInfo.parse(version, optional_minor_and_patch=True)
-            ocp_xy_version = f"{sem_version.major}.{sem_version.minor}-{CPUArchitecture.MULTI}"
         except ValueError as e:
             raise ValueError("provided OPENSHIFT_VERSION is not a valid semantic version") from e
 
+        suffix = f"-{CPUArchitecture.MULTI}" if version.endswith(f"-{CPUArchitecture.MULTI}") else ""
+        ocp_xy_version = f"{sem_version.major}.{sem_version.minor}{suffix}"
+        cpu_architecture = CPUArchitecture.MULTI if suffix == CPUArchitecture.MULTI else DEFAULT_CPU_ARCHITECTURE
+
         if (
             release_image := get_release_image(
-                release_images=release_images, ocp_xy_version=ocp_xy_version, cpu_architecture=CPUArchitecture.MULTI
+                release_images=release_images, ocp_xy_version=ocp_xy_version, cpu_architecture=cpu_architecture
             )
         ) is None:
             raise ValueError(
                 f"""
                 No release image found with 'openshift_version':
-                {ocp_xy_version} and cpu_architecture: {CPUArchitecture.MULTI}"
+                {ocp_xy_version} and cpu_architecture: {cpu_architecture}"
             """
             )
 

--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -527,8 +527,7 @@ def get_openshift_version(allow_default=True, client=None) -> str | None:
 
     version = get_env("OPENSHIFT_VERSION")
     if version:
-        # Make sure the suffix exists once
-        return f"{version.removesuffix(f'-{consts.CPUArchitecture.MULTI}')}-{consts.CPUArchitecture.MULTI}"
+        return version
 
     release_image = os.getenv("OPENSHIFT_INSTALL_RELEASE_IMAGE")
 


### PR DESCRIPTION
Lately assisted-test-infra was changed to use multi-arch release images when `OPENSHIFT_VERSION` is set (which should be the case for CI jobs). The problem is that some assisted-service features are forbidden from being active in a `mult` cluster, therefore this PR changes the behaviour to use `x86_64` arch by default, unless   `OPENSHIFT_VERSION` with `multi` suffix is set.