### PR TITLE
MGMT-18852: Static IP validation

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -23,6 +23,12 @@ max-complexity = 18
 ; Exclude consts and utils __init__ files due to violation of F401 - imported but unused
 ; TODO - After removing import * from those init files delete this excluded files
 exclude =
+    venv/
+    .venv/
+    build/
+    .github/
+    .idea/
+    .code/
     src/consts/__init__.py
     src/assisted_test_infra/test_infra/utils/__init__.py
     .git

--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -662,3 +662,16 @@ def get_release_images_path() -> str:
         return f"{consts.ASSISTED_SERVICE_DATA_BASE_PATH}/default_{flavor}_release_images.json"
 
     return f"{consts.ASSISTED_SERVICE_DATA_BASE_PATH}/default_release_images.json"
+
+
+def unescape_string(raw_string: str) -> str:
+    """
+    input example: 'dns-resolver:\n  config:\n    server:\n    - 192.168.127.1`
+    output example: '
+        dns-resolver:
+          config:
+            server:
+            - 192.168.127.1
+    '
+    """
+    return raw_string.encode("raw_unicode_escape").decode("unicode_escape")

--- a/src/consts/__init__.py
+++ b/src/consts/__init__.py
@@ -1,5 +1,5 @@
 from .consts import *  # TODO - temporary import all old consts
-from .consts import NUMBER_OF_MASTERS, ClusterStatus, HostsProgressStages, NetworkType, OpenshiftVersion
+from .consts import IP_VERSIONS, NUMBER_OF_MASTERS, ClusterStatus, HostsProgressStages, NetworkType, OpenshiftVersion
 from .env_defaults import DEFAULT_SSH_PRIVATE_KEY_PATH, DEFAULT_SSH_PUBLIC_KEY_PATH
 from .kube_api import (
     CRD_API_GROUP,
@@ -37,4 +37,5 @@ __all__ = [
     "DEFAULT_WAIT_FOR_ISO_URL_TIMEOUT",
     "NUMBER_OF_MASTERS",
     "get_operator_properties",
+    "IP_VERSIONS",
 ]

--- a/src/consts/consts.py
+++ b/src/consts/consts.py
@@ -154,6 +154,11 @@ REQUIRED_ASSET_FIELDS = (
     *IP_NETWORK_ASSET_FIELDS,
 )
 
+IP_VERSIONS = {
+    "ipv4": "ipv4_addresses",
+    "ipv6": "ipv6_addresses",
+}
+
 GB = 10**9
 MiB_UNITS = 1024
 


### PR DESCRIPTION
Adding validation for static IP's.
This will check the current IP  vs the static config and return validation error if one or more are not matching  

log example:
```console
2024-12-15 14:48:19,302  root INFO       - 140045960247104 - Static IP validation: host network {'02:00:00:ef:b6:0e': {'ipv4_addresses': ['192.168.128.33/24']}, '02:00:00:24:fd:ad': {'ipv4_addresses': ['192.168.146.33/24']}, '02:00:00:7e:21:90': {'ipv4_addresses': ['192.168.128.31/24']}, '02:00:00:cb:86:0d': {'ipv4_addresses': ['192.168.14
6.31/24']}, '02:00:00:8f:c7:71': {'ipv4_addresses': ['192.168.128.30/24']}, '02:00:00:9d:f2:fe': {'ipv4_addresses': ['192.168.146.30/24']}, '02:00:00:cc:82:6e': {'ipv4_addresses': ['192.168.128.32/24']}, '02:00:00:b8:82:49': {'ipv4_addresses': ['192.168.146.32/24']}, '02:00:00:d7:6e:1c': {'ipv4_addresses': ['192.168.128.34/24']}, '02:00:00
:f9:d3:5f': {'ipv4_addresses': ['192.168.146.34/24']}}, expected address [{'02:00:00:f9:d3:5f': ['192.168.146.34/24']}]         (/home/worktree/assisted-test-infra/static_networking/src/assisted_test_infra/test_infra/helper_classes/cluster.py:1366)->validate_static_ip                                                                         
2024-12-15 14:48:19,302  root INFO       - 140045960247104 - Static IP validation passed        (/home/worktree/assisted-test-infra/static_networking/src/assisted_test_infra/test_infra/helper_classes/cluster.py:1371)->validate_static_ip    
```
