### PR TITLE
Fix collect log raise exception when network does not exist

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/libvirt_controller.py
@@ -700,7 +700,10 @@ def collect_virsh_logs(nodes, log_dir_name):
 
     network_name = nodes.get_cluster_network()
     virsh_leases_path = os.path.join(virsh_log_path, "net_dhcp_leases")
-    utils.run_command(f"virsh net-dhcp-leases {network_name} >> {virsh_leases_path}", shell=True)
+    try:
+        utils.run_command(f"virsh net-dhcp-leases {network_name} >> {virsh_leases_path}", shell=True)
+    except RuntimeError:
+        log.warning(f"Failed to collect network {network_name}, network does not exists")
 
     messages_log_path = os.path.join(virsh_log_path, "messages.log")
     try:


### PR DESCRIPTION
In case we have a failure in a test before the concrete resource created, We may return another failure in teardown when network does not exist

Cached exception in case the libvirt network not created.