### PR TITLE
NO-ISSUE: Fix DNS setting in k8s API test

### DIFF
--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -184,7 +184,7 @@ class TestKubeAPI(BaseKubeAPI):
             agent_cluster_install.set_api_vip(api_vip)
             agent_cluster_install.set_ingress_vip(ingress_vip)
 
-        nodes.controller.set_dns(api_ip=api_vip, ingress_ip=[ingress_vip])
+        nodes.controller.set_dns(api_ip=api_vip, ingress_ip=ingress_vip)
 
         log.info("Waiting for install")
         self._wait_for_install(agent_cluster_install, agents, cluster_config.kubeconfig_path)


### PR DESCRIPTION
Fix DNS setting in kube api tests:

```
Trying to pull registry.build01.ci.openshift.org/ci-op-02vcdx9p/pipeline@sha256:cc3ce78e311b6d94bdaa9170212d1b901534ded6f61f81e3fa0c478c8c13ad94...
[2024-12-29 06:52:03] Error: initializing source docker://registry.build01.ci.openshift.org/ci-op-02vcdx9p/pipeline@sha256:cc3ce78e311b6d94bdaa9170212d1b901534ded6f61f81e3fa0c478c8c13ad94: pinging container registry registry.build01.ci.openshift.org: Get "https://registry.build01.ci.openshift.org/v2/": dial tcp: lookup registry.build01.ci.openshift.org on 127.0.0.1:53: read udp 127.0.0.1:57990->127.0.0.1:53: read: connection refused == *\f\a\i\l\e\d\ 
```