### PR TITLE
MGMT-19684: Enable automatic testing of user managed load balancer with hosts in the same subnet but load balancer outside this subnet on baremetal for k8s API flow

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -427,3 +427,9 @@ test_ctlplane_scaleup:
 
 install_k8s_api:
 	TEST_TEARDOWN=false TEST=./src/tests/test_kube_api.py TEST_FUNC=test_kubeapi $(MAKE) test
+
+destroy_crs:
+	oc delete cd --all-namespaces --all
+	oc delete aci --all-namespaces --all
+	oc delete infraenv --all-namespaces --all
+	oc delete agents --all-namespaces --all

--- a/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/agent_cluster_install.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/agent_cluster_install.py
@@ -90,16 +90,12 @@ class AgentClusterInstall(BaseCustomResource):
 
         log.info("patching agentclusterinstall %s: %s", self.ref, pformat(body))
 
-    def set_machinenetwork(self, machine_cidr):
-        self.patch(
-            networking={
-                "machineNetwork": [
-                    {
-                        "cidr": machine_cidr,
-                    }
-                ]
-            }
-        )
+    def set_machine_networks(self, machine_cidrs):
+        machine_networks: list[dict[str, str]] = []
+        for machine_cidr in machine_cidrs:
+            machine_networks.append({"cidr": machine_cidr})
+
+        self.patch(networking={"machineNetwork": machine_networks})
 
     def set_api_vip(self, vip):
         self.patch(apiVIPs=[vip])

--- a/src/tests/base_kubeapi_test.py
+++ b/src/tests/base_kubeapi_test.py
@@ -137,7 +137,7 @@ class BaseKubeAPI(BaseTest):
     @classmethod
     def _set_agent_cluster_install_machine_cidr(cls, agent_cluster_install: AgentClusterInstall, nodes: Nodes):
         machine_cidr = nodes.controller.get_primary_machine_cidr()
-        agent_cluster_install.set_machinenetwork(machine_cidr)
+        agent_cluster_install.set_machine_networks([machine_cidr])
 
     @classmethod
     def download_iso_from_infra_env(cls, infra_env: InfraEnv, iso_download_path: str):

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -175,8 +175,11 @@ class TestKubeAPI(BaseKubeAPI):
             api_vip = ingress_vip = load_balancer_ip
             agent_cluster_install.set_api_vip(api_vip)
             agent_cluster_install.set_ingress_vip(ingress_vip)
+            primary_machine_cidr = nodes.controller.get_primary_machine_cidr()
+            agent_cluster_install.set_machine_networks(
+                [primary_machine_cidr, consts.DEFAULT_LOAD_BALANCER_NETWORK_CIDR]
+            )
         else:
-            # patch the aci with the vips. The cidr will be derived from the range
             access_vips = nodes.controller.get_ingress_and_api_vips()
             api_vip = access_vips["api_vips"][0].get("ip", "") if len(access_vips["api_vips"]) > 0 else ""
             ingress_vip = access_vips["ingress_vips"][0].get("ip", "") if len(access_vips["ingress_vips"]) > 0 else ""
@@ -235,10 +238,7 @@ class TestKubeAPI(BaseKubeAPI):
     def configure_load_balancer(
         self, nodes: Nodes, infraenv: InfraEnv, aci: AgentClusterInstall, cluster_config: ClusterConfig
     ) -> str:
-        aci_resource = aci.get()
-        machine_cidr = get_field_from_resource(resource=aci_resource, path="spec.networking.machineNetwork[0].cidr")
-        log.info(f"Got cluster machine CIDR: {machine_cidr}")
-        load_balancer_ip = str(IPNetwork(machine_cidr).ip + 1)
+        load_balancer_ip = str(IPNetwork(consts.DEFAULT_LOAD_BALANCER_NETWORK_CIDR).ip + 1)
         log.info(f"Calculated load balancer IP: {load_balancer_ip}")
 
         agents = infraenv.list_agents()


### PR DESCRIPTION
This PR should enable automatic e2e testing of user-managed load balancer flow via k8s API such that the load balancer IP is outside the host's subnet. This is essentially the test for phase 2 of https://issues.redhat.com/browse/MGMT-18913 in k8s API.