### PR TITLE
MULTIARCH-5289: download_iso fix issue when downloading iso for s390x

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/zvm_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/zvm_controller.py
@@ -212,3 +212,13 @@ class ZVMController(NodeController, ABC):
 
     def get_day2_static_network_data(self):
         pass
+
+    # destroying network only for KVM (zVM and LPAR will be handled via HMC)
+    def destroy_network(self):
+        pass
+
+    def get_cluster_network(self):
+        pass
+
+    def set_per_device_boot_order(self):
+        pass


### PR DESCRIPTION
Fix following error:
      if platform == consts.CPUArchitecture.S390X:
>           return ZVMController(controller_configuration, cluster_configuration)
E           TypeError: Can't instantiate abstract class ZVMController without an implementation for abstract methods 'destroy_network', 'get_cluster_network', 'set_per_device_boot_order'

when running download_iso test case.