### PR TITLE
MGMT-19510: Enable automatic testing of user-managed load balancer using test-infra with hosts on different subnets

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/terraform_controller.py
@@ -207,6 +207,7 @@ class TerraformController(LibvirtController):
         tfvars["libvirt_worker_macs"] = self.generate_macs(self._params.worker_count)
         tfvars["master_boot_devices"] = self._params.master_boot_devices
         tfvars["worker_boot_devices"] = self._params.worker_boot_devices
+        tfvars["load_balancer_type"] = self._entity_config.load_balancer_type
         if self._entity_config.is_bonded:
             tfvars["slave_interfaces"] = True
             tfvars["network_interfaces_count"] = self._entity_config.num_bonded_slaves

--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -390,7 +390,7 @@ class Cluster(BaseCluster):
         elif self._config.load_balancer_type == consts.LoadBalancerType.USER_MANAGED.value:
             log.info("User managed load balancer. Setting the VIPs to the load balancer IP")
             api_vips = ingress_vips = [ApiVip(ip=self._get_load_balancer_ip()).to_dict()]
-            machine_networks = [self.get_machine_networks()[0], self.get_load_balancer_network_cidr()]
+            machine_networks = self.get_machine_networks() + [self.get_load_balancer_network_cidr()]
 
         else:
             log.info("Assigning VIPs statically")

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_cluster_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_cluster_config.py
@@ -35,7 +35,6 @@ class BaseClusterConfig(BaseEntityConfig, ABC):
     custom_manifests: List[Manifest] = None
     is_disconnected: bool = None
     registry_ca_path: str = None
-    load_balancer_type: str = None
 
     @property
     def cluster_name(self) -> BaseName:

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_entity_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_entity_config.py
@@ -34,3 +34,4 @@ class BaseEntityConfig(BaseConfig, ABC):
     is_bonded: bool = None
     num_bonded_slaves: int = None
     bonding_mode: str = None
+    load_balancer_type: str = None

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -176,8 +176,9 @@ class TestKubeAPI(BaseKubeAPI):
             agent_cluster_install.set_api_vip(api_vip)
             agent_cluster_install.set_ingress_vip(ingress_vip)
             primary_machine_cidr = nodes.controller.get_primary_machine_cidr()
+            provisioning_machine_cidr = nodes.controller.get_provisioning_cidr()
             agent_cluster_install.set_machine_networks(
-                [primary_machine_cidr, consts.DEFAULT_LOAD_BALANCER_NETWORK_CIDR]
+                [primary_machine_cidr, provisioning_machine_cidr, consts.DEFAULT_LOAD_BALANCER_NETWORK_CIDR]
             )
         else:
             access_vips = nodes.controller.get_ingress_and_api_vips()

--- a/terraform_files/baremetal/variables-libvirt.tf
+++ b/terraform_files/baremetal/variables-libvirt.tf
@@ -292,6 +292,12 @@ variable "load_balancer_ip" {
   default     = ""
 }
 
+variable "load_balancer_type" {
+  type        = string
+  description = "Set to `cluster-managed` if the load-balancer will be deployed by OpenShift, and `user-managed` if it will be deployed externally by the user."
+  default     = "cluster-managed"
+}
+
 variable "libvirt_load_balancer_net_name" {
   type        = string
   description = "The name of the load balancer network for user managed load balancer"


### PR DESCRIPTION
This PR enables testing of user-managed LB with hosts on different subnets for both RESTAPI and k8s API.
This PR essentially facilitates testing for - https://github.com/openshift/assisted-service/pull/7204 