### PR TITLE
IGNORE-DRAFT

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-debugpy==1.8.11
+debugpy==1.8.12
 dnspython==2.7.0
 filelock==3.16.1
 frozendict==2.4.6
@@ -8,19 +8,19 @@ jedi==0.19.2
 Jinja2===3.1.5
 junit-report==0.2.7
 kubernetes==31.0.0
-libvirt-python==10.10.0
+libvirt-python==11.0.0
 munch==4.0.0
 natsort==8.4.0 # natsort used in kni-assisted-installer-auto
 netaddr==1.3.0 ## from https://github.com/openshift/assisted-test-infra/pull/2398
 netifaces==0.11.0
 openshift-client==2.0.5
 paramiko==3.5.0
-pre-commit==4.0.1
+pre-commit==4.1.0
 pycharm-remote-debugger==0.1.18
 pytest-xdist==3.6.1
 pytest==8.3.4
 python-dateutil==2.9.0.post0
-python-hcl2==5.1.1
+python-hcl2==6.0.0
 python-terraform==0.10.1
 PyYAML==6.0.2
 requests==2.32.3
@@ -32,7 +32,7 @@ tqdm==4.67.1
 urllib3<3.0
 pyvmomi==8.0.3.0.1
 waiting>=1.4.1
-prompt-toolkit==3.0.48
+prompt-toolkit==3.0.50
 nutanix-api==0.0.20
 pytest-error-for-skips==2.0.2
 ansible==11.1.0 # Fix for issues with DNF and ansible core 2.17 on RHEL8 / RHEL9 systems
@@ -43,4 +43,4 @@ pydantic==2.10.5
 certifi>=2023.7.22 # not directly required, pinned by Snyk to avoid a vulnerability
 cryptography>=42.0.8 # not directly required, pinned by Snyk to avoid a vulnerability
 zipp>=3.19.1 # not directly required, pinned by Snyk to avoid a vulnerability
-kfish==99.0.202501101206
+kfish==99.0.202501201910

--- a/src/assisted_test_infra/test_infra/controllers/load_balancer_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/load_balancer_controller.py
@@ -18,6 +18,7 @@ class LoadBalancerController:
         self._tf.change_variables(
             {"load_balancer_ip": load_balancer_ip, "load_balancer_config_file": load_balancer_config_file}
         )
+        print("test")
         self._wait_for_load_balancer(load_balancer_ip)
 
     @staticmethod


### PR DESCRIPTION
Bumps the python-dependencies group with 6 updates:

| Package | From | To |
| --- | --- | --- |
| [debugpy](https://github.com/microsoft/debugpy) | `1.8.11` | `1.8.12` | | [libvirt-python](http://www.libvirt.org) | `10.10.0` | `11.0.0` | | [pre-commit](https://github.com/pre-commit/pre-commit) | `4.0.1` | `4.1.0` | | [python-hcl2](https://github.com/amplify-education/python-hcl2) | `5.1.1` | `6.0.0` | | [prompt-toolkit](https://github.com/prompt-toolkit/python-prompt-toolkit) | `3.0.48` | `3.0.50` | | [kfish](https://github.com/karmab/kcli) | `99.0.202501101206` | `99.0.202501201910` |

Updates `debugpy` from 1.8.11 to 1.8.12
- [Release notes](https://github.com/microsoft/debugpy/releases)
- [Commits](https://github.com/microsoft/debugpy/compare/v1.8.11...v1.8.12)

Updates `libvirt-python` from 10.10.0 to 11.0.0

Updates `pre-commit` from 4.0.1 to 4.1.0
- [Release notes](https://github.com/pre-commit/pre-commit/releases)
- [Changelog](https://github.com/pre-commit/pre-commit/blob/main/CHANGELOG.md)
- [Commits](https://github.com/pre-commit/pre-commit/compare/v4.0.1...v4.1.0)

Updates `python-hcl2` from 5.1.1 to 6.0.0
- [Release notes](https://github.com/amplify-education/python-hcl2/releases)
- [Changelog](https://github.com/amplify-education/python-hcl2/blob/main/CHANGELOG.md)
- [Commits](https://github.com/amplify-education/python-hcl2/compare/v5.1.1...v6.0.0)

Updates `prompt-toolkit` from 3.0.48 to 3.0.50
- [Release notes](https://github.com/prompt-toolkit/python-prompt-toolkit/releases)
- [Changelog](https://github.com/prompt-toolkit/python-prompt-toolkit/blob/master/CHANGELOG)
- [Commits](https://github.com/prompt-toolkit/python-prompt-toolkit/commits)

Updates `kfish` from 99.0.202501101206 to 99.0.202501201910
- [Commits](https://github.com/karmab/kcli/commits)

---
updated-dependencies:
- dependency-name: debugpy dependency-type: direct:production update-type: version-update:semver-patch dependency-group: python-dependencies
- dependency-name: libvirt-python dependency-type: direct:production update-type: version-update:semver-major dependency-group: python-dependencies
- dependency-name: pre-commit dependency-type: direct:production update-type: version-update:semver-minor dependency-group: python-dependencies
- dependency-name: python-hcl2 dependency-type: direct:production update-type: version-update:semver-major dependency-group: python-dependencies
- dependency-name: prompt-toolkit dependency-type: direct:production update-type: version-update:semver-patch dependency-group: python-dependencies
- dependency-name: kfish dependency-type: direct:production update-type: version-update:semver-patch dependency-group: python-dependencies ...