### PR TITLE
NO-ISSUE: Bump Terraform Libvirt provider to the latest version

### DIFF
--- a/terraform_files/baremetal/main.tf
+++ b/terraform_files/baremetal/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.6.14"
+      version = "0.8.1"
     }
   }
 }

--- a/terraform_files/baremetal_host/main.tf
+++ b/terraform_files/baremetal_host/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.6.14"
+      version = "0.8.1"
     }
   }
 }

--- a/terraform_files/baremetal_infra_env/main.tf
+++ b/terraform_files/baremetal_infra_env/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.6.14"
+      version = "0.8.1"
     }
   }
 }

--- a/terraform_files/none/main.tf
+++ b/terraform_files/none/main.tf
@@ -2,7 +2,7 @@ terraform {
   required_providers {
     libvirt = {
       source  = "dmacvicar/libvirt"
-      version = "0.6.14"
+      version = "0.8.1"
     }
   }
 }


### PR DESCRIPTION
Bump Terraform Libvirt provider to `0.8.1` mainly to include https://github.com/dmacvicar/terraform-provider-libvirt/pull/945