### PR TITLE
MGMT-19831: Let test-infra provide the machine network for vSphere umlb dynamically

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -399,7 +399,7 @@ class Cluster(BaseCluster):
                 access_vips = controller.get_ingress_and_api_vips()
                 api_vips = access_vips["api_vips"] if access_vips else None
                 ingress_vips = access_vips["ingress_vips"] if access_vips else None
-                machine_networks = self.get_machine_networks() + [self._config.load_balancer_cidr]
+                machine_networks = self.get_machine_networks()
             else:
                 raise NotImplementedError("user-managed LB is supported for 'baremetal' and 'vsphere' platforms only")
 


### PR DESCRIPTION
Let test-infra find the common network for all hosts in the cluster which should contain the load balancer IP as well in order to avoid providing additional configuration for the load balancer cidr