### PR TITLE
NO-ISSUE: Fix running two targets when running make deploy_nodes

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -282,10 +282,10 @@ deploy_nodes: start_load_balancer
 	TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_deploy_nodes $(MAKE) test
 
 deploy_nodes_oci: start_load_balancer
-	TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_deploy_nodes_oci $(MAKE) test
+	TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_oci_deploy_nodes $(MAKE) test
 
 destroy_nodes_oci: start_load_balancer
-	TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_destroy_nodes_oci $(MAKE) test
+	TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_oci_destroy_nodes $(MAKE) test
 
 deploy_nodes_with_networking: start_load_balancer
 	TEST_TEARDOWN=no TEST=./src/tests/test_targets.py TEST_FUNC=test_target_deploy_networking_with_nodes $(MAKE) test

--- a/src/tests/test_targets.py
+++ b/src/tests/test_targets.py
@@ -22,13 +22,13 @@ class TestMakefileTargets(BaseTest):
         cluster.prepare_nodes()
 
     @JunitTestSuite()
-    def test_target_deploy_nodes_oci(self, cluster):
+    def test_target_oci_deploy_nodes(self, cluster):
         cluster.generate_and_download_infra_env()
         cluster.nodes.prepare_nodes()
         cluster.create_custom_manifests()
 
     @JunitTestSuite()
-    def test_target_destroy_nodes_oci(self, cluster):
+    def test_target_oci_destroy_nodes(self, cluster):
         cluster.nodes.destroy_all_nodes()
 
     @JunitTestSuite()


### PR DESCRIPTION
When running `make deploy_nodes` all the test methods that starting with `test_deploy_nodes` are executed causing some targets to create 2 clusters instead on one.
This PR changes the `test_target_deploy_nodes_oci` and `test_target_destroy_nodes_oci` tests


/cc @eifrach 