### PR TITLE
Fix ip static validations.

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -1380,9 +1380,7 @@ class Cluster(BaseCluster):
                         for address_version in consts.IP_VERSIONS.keys():
                             if address_version not in current_interface.keys():
                                 continue
-                            address = current_interface[address_version]["address"]
-                            if len(address) == 0:
-                                continue
+                            address = current_interface[address_version].get("address", [])
                             host_network[expected_interface_mac] = {
                                 consts.IP_VERSIONS[address_version]: [
                                     f'{item["ip"]}/{item["prefix-length"]}' for item in address


### PR DESCRIPTION
static configuration should support case when no address assigned.

example:
interfaces:
- ipv4: auto-dns: false auto-gateway: false auto-routes: false dhcp: true  -----------> we can set it to false without ip for testing enabled: true

In case we dont have any address assigned format_host_from_config_mapping_file returns empty dictionary and validation fails.