### PR TITLE
MGMT-20256: fix 'wait_for_api_readiness' timeout error

### DIFF
--- a/src/assisted_test_infra/test_infra/__init__.py
+++ b/src/assisted_test_infra/test_infra/__init__.py
@@ -9,7 +9,6 @@ from assisted_test_infra.test_infra.helper_classes.config import (
     BaseTerraformConfig,
     BaseVSphereConfig,
 )
-from assisted_test_infra.test_infra.helper_classes.nodes import Nodes
 from assisted_test_infra.test_infra.utils.entity_name import ClusterName, InfraEnvName
 
 __all__ = [
@@ -22,7 +21,6 @@ __all__ = [
     "utils",
     "BaseEntityConfig",
     "BaseNutanixConfig",
-    "Nodes",
     "BaseVSphereConfig",
     "BaseRedfishConfig",
 ]

--- a/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/base_cluster.py
@@ -6,11 +6,12 @@ from assisted_service_client import models
 from junit_report import JunitTestCase
 
 import consts
-from assisted_test_infra.test_infra import BaseClusterConfig, BaseInfraEnvConfig, Nodes
+from assisted_test_infra.test_infra import BaseClusterConfig, BaseInfraEnvConfig
 from assisted_test_infra.test_infra.controllers.node_controllers import Node
 from assisted_test_infra.test_infra.helper_classes.cluster_host import ClusterHost
 from assisted_test_infra.test_infra.helper_classes.entity import Entity
 from assisted_test_infra.test_infra.helper_classes.infra_env import InfraEnv
+from assisted_test_infra.test_infra.helper_classes.nodes import Nodes
 from assisted_test_infra.test_infra.utils.waiting import wait_till_all_hosts_are_in_status
 from service_client import InventoryClient, log
 

--- a/src/tests/base_kubeapi_test.py
+++ b/src/tests/base_kubeapi_test.py
@@ -9,7 +9,7 @@ from kubernetes.client import ApiClient, CoreV1Api
 from kubernetes.client.exceptions import ApiException as K8sApiException
 from netaddr import IPNetwork
 
-from assisted_test_infra.test_infra import BaseEntityConfig, BaseInfraEnvConfig, Nodes, utils
+from assisted_test_infra.test_infra import BaseEntityConfig, BaseInfraEnvConfig, utils
 from assisted_test_infra.test_infra.controllers import Node
 from assisted_test_infra.test_infra.helper_classes.config import BaseNodesConfig
 from assisted_test_infra.test_infra.helper_classes.kube_helpers import (
@@ -22,6 +22,7 @@ from assisted_test_infra.test_infra.helper_classes.kube_helpers import (
     KubeAPIContext,
     NMStateConfig,
 )
+from assisted_test_infra.test_infra.helper_classes.nodes import Nodes
 from assisted_test_infra.test_infra.tools import static_network
 from assisted_test_infra.test_infra.utils.entity_name import SpokeClusterNamespace
 from consts.consts import MiB_UNITS

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -16,7 +16,7 @@ from paramiko import SSHException
 
 import consts
 from assisted_test_infra.download_logs.download_logs import download_logs
-from assisted_test_infra.test_infra import ClusterName, Nodes, utils
+from assisted_test_infra.test_infra import ClusterName, utils
 from assisted_test_infra.test_infra.controllers import (
     AssistedInstallerInfraController,
     IptableRule,
@@ -42,6 +42,7 @@ from assisted_test_infra.test_infra.helper_classes.config import BaseConfig, Bas
 from assisted_test_infra.test_infra.helper_classes.day2_cluster import Day2Cluster
 from assisted_test_infra.test_infra.helper_classes.events_handler import EventsHandler
 from assisted_test_infra.test_infra.helper_classes.infra_env import InfraEnv
+from assisted_test_infra.test_infra.helper_classes.nodes import Nodes
 from assisted_test_infra.test_infra.tools import LibvirtNetworkAssets
 from service_client import InventoryClient, SuppressAndLog, add_log_record, log
 from tests.config import ClusterConfig, InfraEnvConfig, TerraformConfig, global_variables

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -11,7 +11,7 @@ from junit_report import JunitFixtureTestCase, JunitTestCase, JunitTestSuite
 from netaddr import IPNetwork
 
 import consts
-from assisted_test_infra.test_infra import BaseInfraEnvConfig, Nodes, utils
+from assisted_test_infra.test_infra import BaseInfraEnvConfig, utils
 from assisted_test_infra.test_infra.controllers.load_balancer_controller import LoadBalancerController
 from assisted_test_infra.test_infra.helper_classes.config import BaseNodesConfig
 from assisted_test_infra.test_infra.helper_classes.hypershift import HyperShift
@@ -24,6 +24,7 @@ from assisted_test_infra.test_infra.helper_classes.kube_helpers import (
     Proxy,
     Secret,
 )
+from assisted_test_infra.test_infra.helper_classes.nodes import Nodes
 from assisted_test_infra.test_infra.utils.k8s_utils import get_field_from_resource
 from assisted_test_infra.test_infra.utils.kubeapi_utils import get_ip_for_single_node, get_platform_type
 from service_client import log


### PR DESCRIPTION
[MGMT-20256](https://issues.redhat.com//browse/MGMT-20256): removed importing the Nodes from test_infra module because it assumes that assisted-service is being deployed and test_infra module can be called before assisted-service deployment