### PR TITLE
MGMT-20168: Allow osImageVersion to be set on InfraEnv

### DIFF
--- a/README.md
+++ b/README.md
@@ -192,6 +192,7 @@ before you run start the deployment.
 | `REGISTRY_CA_PATH`           | Path to mirror registry CA bundle                                                            |
 | `HOST_INSTALLER_ARGS`        | JSON formatted string used to customize installer arguments on all the hosts. Example: `{"args": ["--append-karg", "console=ttyS0"]}`                      |
 | `LOAD_BALANCER_TYPE` | Set to `cluster-managed` if the load-balancer will be deployed by OpenShift, and `user-managed` if it will be deployed externally by the user. |
+| `SET_INFRAENV_VERSION` | If `true`, sets the `osImageVersion` field on the `InfraEnv` to the `OPENSHIFT_VERSION` to ensure the discovery ISO uses this OCP version for tests, default: `false` | 
 
 ## Vsphere parameters
 

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_infra_env_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_infra_env_config.py
@@ -19,3 +19,4 @@ class BaseInfraEnvConfig(BaseEntityConfig, ABC):
     is_static_ip: bool = None
     kernel_arguments: List[dict[str, str]] = None
     host_installer_args: List[dict[str, str]] = None
+    set_infraenv_version: bool = None

--- a/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/infraenv.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/infraenv.py
@@ -84,11 +84,13 @@ class InfraEnv(BaseCustomResource):
         self,
         cluster_deployment: Optional[ClusterDeployment],
         secret: Secret,
+        set_infraenv_version: bool = False,
         proxy: Optional[Proxy] = None,
         ignition_config_override: Optional[str] = None,
         nmstate_label: Optional[str] = None,
         ssh_pub_key: Optional[str] = None,
         additional_trust_bundle: Optional[str] = None,
+        openshift_version: Optional[str] = None,
         **kwargs,
     ) -> Dict:
         body = {
@@ -115,6 +117,9 @@ class InfraEnv(BaseCustomResource):
             spec["sshAuthorizedKey"] = ssh_pub_key
         if additional_trust_bundle:
             spec["additionalTrustBundle"] = additional_trust_bundle
+
+        if set_infraenv_version:
+            body["spec"]["osImageVersion"] = openshift_version
 
         spec.update(kwargs)
         infraenv = self.crd_api.create_namespaced_custom_object(

--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -69,6 +69,7 @@ class _EnvVariables(DataPool, ABC):
     )
     bonding_mode: EnvVar = EnvVar(["BONDING_MODE"], default=env_defaults.DEFAULT_BONDING_MODE)
     iso_image_type: EnvVar = EnvVar(["ISO_IMAGE_TYPE"], default=env_defaults.DEFAULT_IMAGE_TYPE)
+    set_infraenv_version: EnvVar = EnvVar(["SET_INFRAENV_VERSION"], loader=lambda x: bool(strtobool(x)), default=False)
     worker_vcpu: EnvVar = EnvVar(["WORKER_CPU"], loader=int, default=resources.DEFAULT_WORKER_CPU)
     master_vcpu: EnvVar = EnvVar(["MASTER_CPU"], loader=int, default=resources.DEFAULT_MASTER_CPU)
     test_teardown: EnvVar = EnvVar(

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -652,6 +652,8 @@ class TestLateBinding(BaseKubeAPI):
             secret=secret,
             proxy=None,
             ssh_pub_key=infraenv_config.ssh_public_key,
+            set_infraenv_version=infraenv_config.set_infraenv_version,
+            openshift_version=infraenv_config.openshift_version,
         )
 
         agents = self.start_nodes(nodes, infra_env, infraenv_config, infraenv_config.is_static_ip)


### PR DESCRIPTION
Adds new environment variable `SET_INFRAENV_VERSION` that allows the openshift version to be set on the InfraEnv for tests.