### PR TITLE
MGMT-14822: Add MetalLB operator

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -178,14 +178,7 @@ class Cluster(BaseCluster):
 
         olm_operators = []
         for operator_name in unique_operators:
-            operator_properties = consts.get_operator_properties(
-                operator_name,
-                api_ip=self._config.metallb_api_ip,
-                ingress_ip=self._config.metallb_ingress_ip,
-            )
             operator = {"name": operator_name}
-            if operator_properties:
-                operator["properties"] = operator_properties
             olm_operators.append(operator)
 
         return olm_operators
@@ -327,16 +320,6 @@ class Cluster(BaseCluster):
     def set_mce(self, properties: str = None, update: bool = False):
         self.set_olm_operator(consts.OperatorType.MCE, properties=properties, update=update)
 
-    def set_metallb(self, properties: str = None, update: bool = False):
-        if properties is None:
-            properties = consts.get_operator_properties(
-                consts.OperatorType.METALLB,
-                api_vip=self._config.api_vips[0].ip,
-                ingress_vip=self._config.ingress_vips[0].ip,
-            )
-
-        self.set_olm_operator(consts.OperatorType.METALLB, properties=properties, update=update)
-
     def unset_odf(self):
         self.unset_olm_operator(consts.OperatorType.ODF)
 
@@ -348,9 +331,6 @@ class Cluster(BaseCluster):
 
     def unset_mce(self):
         self.unset_olm_operator(consts.OperatorType.MCE)
-
-    def unset_metallb(self):
-        self.unset_olm_operator(consts.OperatorType.METALLB)
 
     def unset_olm_operator(self, operator_name):
         log.info(f"Unsetting {operator_name} for cluster: {self.id}")

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_cluster_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_cluster_config.py
@@ -27,8 +27,6 @@ class BaseClusterConfig(BaseEntityConfig, ABC):
     network_type: str = None
     api_vips: List[models.ApiVip] = None
     ingress_vips: List[models.IngressVip] = None
-    metallb_api_ip: str = None
-    metallb_ingress_ip: str = None
     disk_encryption_mode: str = None
     disk_encryption_roles: str = None
     tang_servers: str = None

--- a/src/consts/__init__.py
+++ b/src/consts/__init__.py
@@ -13,7 +13,7 @@ from .kube_api import (
     HIVE_API_GROUP,
     HIVE_API_VERSION,
 )
-from .olm_operators import OperatorResource, OperatorStatus, OperatorType, get_operator_properties
+from .olm_operators import OperatorResource, OperatorStatus, OperatorType
 
 __all__ = [
     "OperatorType",
@@ -36,6 +36,5 @@ __all__ = [
     "HIVE_API_VERSION",
     "DEFAULT_WAIT_FOR_ISO_URL_TIMEOUT",
     "NUMBER_OF_MASTERS",
-    "get_operator_properties",
     "IP_VERSIONS",
 ]

--- a/src/tests/global_variables/env_variables_defaults.py
+++ b/src/tests/global_variables/env_variables_defaults.py
@@ -142,9 +142,6 @@ class _EnvVariables(DataPool, ABC):
     ingress_vips: EnvVar = EnvVar(["INGRESS_VIPS"], loader=json.loads)
     load_balancer_cidr: EnvVar = EnvVar(["LOAD_BALANCER_CIDR"])
 
-    metallb_api_ip: EnvVar = EnvVar(["METALLB_API_IP"])
-    metallb_ingress_ip: EnvVar = EnvVar(["METALLB_INGRESS_IP"])
-
     ipxe_boot: EnvVar = EnvVar(["IPXE_BOOT"], loader=lambda x: bool(strtobool(x)))
 
     vsphere_parent_folder: str = EnvVar(["VSPHERE_PARENT_FOLDER"], default=env_defaults.DEFAULT_VSHPERE_PARENT_FOLDER)

--- a/src/triggers/default_triggers.py
+++ b/src/triggers/default_triggers.py
@@ -70,9 +70,6 @@ _default_triggers = frozendict(
             service_networks=consts.DEFAULT_SERVICE_NETWORKS_IPV4V6,
         ),
         "lso_operator": OlmOperatorsTrigger(conditions=[lambda config: "lso" in config.olm_operators], operator="lso"),
-        "metallb_operator": OlmOperatorsTrigger(
-            conditions=[lambda config: "metallb" in config.olm_operators], operator="metallb"
-        ),
         "cnv_operator": OlmOperatorsTrigger(conditions=[lambda config: "cnv" in config.olm_operators], operator="cnv"),
         "mtv_operator": OlmOperatorsTrigger(conditions=[lambda config: "mtv" in config.olm_operators], operator="mtv"),
         "odf_operator": OlmOperatorsTrigger(conditions=[lambda config: "odf" in config.olm_operators], operator="odf"),


### PR DESCRIPTION
Simplified MetalLB setup by removing the need to provide IPs (api_ip, ingress_ip) during installation.
Users can now enable MetalLB and configure IPs later, post-installation.

/cc @danmanor @eliorerz 