### PR TITLE
NO-ISSUE: Avoid deploying the UI in CI jobs

### DIFF
--- a/scripts/deploy_ui.sh
+++ b/scripts/deploy_ui.sh
@@ -13,6 +13,11 @@ if [[ "${NO_UI}" != "n" ]] || [[ "${DEPLOY_TARGET}" != @(minikube|kind) ]]; then
     exit 0
 fi
 
+if [[ "${OPENSHIFT_CI}" == "true" ]]; then
+    echo "Skipping UI deployment in CI"
+    exit 0
+fi
+
 mkdir -p build
 
 print_log "Starting ui"


### PR DESCRIPTION
The UI image is currently broken, and we don't have a use case for the UI in CI jobs