### PR TITLE
NO-ISSUE: Pass arbiter_count to AgentClusterInstall

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/agent_cluster_install.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/kube_helpers/agent_cluster_install.py
@@ -127,6 +127,7 @@ class AgentClusterInstall(BaseCustomResource):
             "provisionRequirements": {
                 "controlPlaneAgents": control_plane_agents,
                 "workerAgents": kwargs.pop("worker_agents", 0),
+                "arbiterAgents": kwargs.pop("arbiter_agents", 0),
             },
         }
 

--- a/src/tests/test_kube_api.py
+++ b/src/tests/test_kube_api.py
@@ -149,6 +149,7 @@ class TestKubeAPI(BaseKubeAPI):
             hyperthreading=cluster_config.hyperthreading,
             control_plane_agents=nodes.masters_count,
             worker_agents=nodes.workers_count,
+            arbiter_agents=nodes.arbiters_count,
             proxy=proxy.as_dict() if proxy else {},
             platform_type=get_platform_type(cluster_config.platform),
             load_balancer_type=load_balancer_type,


### PR DESCRIPTION
This is to allow installing TNA clusters with the kube-api