### PR TITLE
NO-ISSUE: fix container build failure

### DIFF
--- a/Dockerfile.assisted-test-infra
+++ b/Dockerfile.assisted-test-infra
@@ -54,8 +54,9 @@ COPY --from=quay.io/ocp-splat/govc:v0.29.0 /govc /usr/local/bin
 WORKDIR /home/assisted-test-infra
 
 COPY requirements.txt requirements-dev.txt ./
+
 RUN pip3 install --upgrade pip && \
-      pip3 install --no-cache-dir -I -r ./requirements.txt -r ./requirements-dev.txt
+       pip3 install --no-cache-dir -I -r ./requirements.txt -r ./requirements-dev.txt
 
 ENV GO_VERSION=1.18.1
 RUN curl --retry 5 --connect-timeout 30 -s "https://dl.google.com/go/go${GO_VERSION}.linux-amd64.tar.gz" | tar -C /usr/local -xz

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,7 +8,7 @@ jedi==0.19.1
 Jinja2===3.1.4
 junit-report==0.2.7
 kubernetes==30.1.0
-libvirt-python==10.4.0
+libvirt-python==11.8.0
 munch==4.0.0
 netaddr==1.3.0
 netifaces==0.11.0


### PR DESCRIPTION
podman/docker build failed likelly because libirt-python <= 11.1.0 is not supported any more
as a fix libvirt-python has to be bumped