### PR TITLE
Fix UnboundLocalError in update_etc_hosts 

### DIFF
--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -387,6 +387,9 @@ def update_etc_hosts(dns_map: dict[str, str]) -> None:
     lock_file = "/tmp/test_etc_hosts.lock"
 
     with file_lock_context(lock_file):
+        # Snapshot all entries for logging before dns_map gets mutated
+        all_entries = dict(dns_map)
+
         with open("/etc/hosts", "r") as f:
             hosts_lines = f.readlines()
 
@@ -403,6 +406,8 @@ def update_etc_hosts(dns_map: dict[str, str]) -> None:
 
         with open("/etc/hosts", "w") as f:
             f.writelines(hosts_lines)
+
+        for dns_name, ip in all_entries.items():
             log.info("Updated /etc/hosts with record: %s %s", ip, dns_name)
 
 


### PR DESCRIPTION
when all DNS entries already exist

The log.info referenced 'ip' and 'dns_name' variables that were only bound inside for-loops. When all entries in dns_map were already present in /etc/hosts, the second loop iterated over an empty dict, leaving the variables unbound and crashing with UnboundLocalError.

Snapshot dns_map before mutation and log all entries after writing.