### PR TITLE
MGMT-23476: fixing CVE-2026-32274

### DIFF
--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,4 +1,4 @@
-black==25.9.0
+black==26.3.1
 isort==7.0.0
 flake8==7.1.2
 flake8-bugbear==23.12.2             # Flake8 plugin that help identify likely bugs and design problems

--- a/scripts/override_images/override_release_images.py
+++ b/scripts/override_images/override_release_images.py
@@ -60,12 +60,10 @@ def main():
                 release_images=release_images, ocp_xy_version=ocp_xy_version, cpu_architecture=cpu_architecture
             )
         ) is None:
-            raise ValueError(
-                f"""
+            raise ValueError(f"""
                 No release image found with 'openshift_version':
                 {ocp_xy_version} and cpu_architecture: {cpu_architecture}"
-            """
-            )
+            """)
 
         release_image.default = True
 

--- a/src/assisted_test_infra/test_infra/utils/utils.py
+++ b/src/assisted_test_infra/test_infra/utils/utils.py
@@ -408,12 +408,10 @@ def update_etc_hosts(dns_map: dict[str, str]) -> None:
 
 def add_dns_record(cluster_name: str, base_dns_domain: str, api_ip: str = None, ingress_ip: str = None):
     fname = f"/etc/NetworkManager/dnsmasq.d/openshift-{cluster_name}.conf"
-    contents = dedent(
-        f"""
+    contents = dedent(f"""
                         address=/api.{cluster_name}.{base_dns_domain}/{api_ip}
                         address=/.apps.{cluster_name}.{base_dns_domain}/{ingress_ip}
-                        """
-    )
+                        """)
     with open(fname, "w") as f:
         f.write(contents)
         log.info(f"Added DNS records for {cluster_name}.{base_dns_domain}")

--- a/src/update_assisted_service_cm.py
+++ b/src/update_assisted_service_cm.py
@@ -12,6 +12,7 @@ configmap:
 
 Hence, in order to support unset env vars, avoid override in Makefile.
 """
+
 import json
 import os
 


### PR DESCRIPTION
to fix CVE-2026-32274 the python package black needs to be upgraded to 26.3.1