### PR TITLE
Run external baremetal and delegate idrac controll.

### DIFF
--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/adapter_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/adapter_controller.py
@@ -8,7 +8,7 @@ from assisted_test_infra.test_infra.controllers.node_controllers.disk import Dis
 from assisted_test_infra.test_infra.controllers.node_controllers.node import Node
 from assisted_test_infra.test_infra.controllers.node_controllers.node_controller import NodeController
 from assisted_test_infra.test_infra.helper_classes.config.base_nodes_config import BaseNodesConfig
-from service_client import log
+from service_client import InventoryClient, log
 
 
 class AdapterController(NodeController):
@@ -21,9 +21,10 @@ class AdapterController(NodeController):
 
     """
 
-    def __init__(self, cluster: dict, config: BaseNodesConfig, entity_config: BaseEntityConfig):
+    def __init__(self, inventory_client: InventoryClient, config: BaseNodesConfig, entity_config: BaseEntityConfig):
         super().__init__(config, entity_config)
-        self._cluster = cluster
+        self._inventory_client = inventory_client
+        self._cluster_id = entity_config.cluster_id
         self.private_ssh_key_path = config.private_ssh_key_path
 
     def log_configuration(self):
@@ -60,10 +61,8 @@ class AdapterController(NodeController):
     def list_nodes(self) -> List[Node]:
         nodes_list = []
         try:
-            for host in self._cluster.get_details().hosts:
-                nodes_list.append(
-                    Node(host.requested_hostname, self._cluster.nodes.controller, self.private_ssh_key_path)
-                )
+            for host in self._inventory_client.cluster_get(self._cluster_id).hosts:
+                nodes_list.append(Node(host.requested_hostname, self, self.private_ssh_key_path))
             return nodes_list
         except Exception as e:
             log.info(f"Unable to list nodes {str(e)}")
@@ -71,7 +70,7 @@ class AdapterController(NodeController):
 
     def list_disks(self, node_name: str) -> List[dict]:
         try:
-            for host in self._cluster.get_details().hosts:
+            for host in self._inventory_client.cluster_get(self._cluster_id).hosts:
                 if host.requested_hostname == node_name:
                     disks = json.loads(host.inventory)["disks"]
                     return disks
@@ -142,7 +141,7 @@ class AdapterController(NodeController):
 
     def is_active(self, node_name: str) -> bool:
         try:
-            for host in self._cluster.get_details().hosts:
+            for host in self._inventory_client.cluster_get(self._cluster_id).hosts:
                 if host.requested_hostname == node_name:
                     if host.status not in ["disconnected"]:
                         return True
@@ -167,7 +166,7 @@ class AdapterController(NodeController):
         ips = []
         macs = []
         try:
-            for host in self._cluster.get_details().hosts:
+            for host in self._inventory_client.cluster_get(self._cluster_id).hosts:
                 if host.requested_hostname == node_name:
                     interfaces = json.loads(host.inventory)["interfaces"]
                     for i in interfaces:

--- a/src/assisted_test_infra/test_infra/controllers/node_controllers/redfish_controller.py
+++ b/src/assisted_test_infra/test_infra/controllers/node_controllers/redfish_controller.py
@@ -1,9 +1,12 @@
+import threading
+import time
 from typing import Any, Callable, List, Optional, Tuple
 
 import kfish
 import libvirt
+import waiting
 
-from assisted_test_infra.test_infra import BaseClusterConfig
+from assisted_test_infra.test_infra import BaseClusterConfig, utils
 from assisted_test_infra.test_infra.controllers.node_controllers.adapter_controller import AdapterController
 from assisted_test_infra.test_infra.controllers.node_controllers.disk import Disk
 from assisted_test_infra.test_infra.controllers.node_controllers.node import Node
@@ -11,6 +14,7 @@ from assisted_test_infra.test_infra.controllers.node_controllers.node_controller
 from assisted_test_infra.test_infra.helper_classes.config import BaseNodesConfig
 from assisted_test_infra.test_infra.helper_classes.config.base_redfish_config import BaseRedfishConfig
 from service_client import log
+from src.service_client import InventoryClient
 
 SUCCESS = 204
 
@@ -51,7 +55,10 @@ class RedfishInsertIso:
     @classmethod
     def execute(cls, receiver: RedfishReceiver, nfs_iso):
         log.info(f"{cls.__name__} inserting iso {nfs_iso}")
-        receiver.redfish.insert_iso(nfs_iso)
+        try:
+            receiver.redfish.insert_iso(nfs_iso)
+        except Exception as e:
+            log.info(f"{cls.__name__}: insert iso fails {e}")
 
 
 class RedfishSetIsoOnce:
@@ -73,12 +80,24 @@ class RedfishRestart:
         receiver.redfish.restart()
 
 
+class RedfishReset:
+
+    @classmethod
+    def execute(cls, receiver: RedfishReceiver):
+        log.info(f"{cls.__name__}: {receiver.__dict__}")
+        receiver.redfish.reset()
+
+
 class RedfishController(NodeController):
     """Manage Dell's baremetal nodes.
 
     Allow to use baremetal machines directly by calling to racadm utils.
     It allows us to manage node - setting boot , reboot nodes and boot from iso.
     """
+
+    IDRAC_WAIT = 60 * 3
+    IDRAC_RETRY = 30
+    IDRAC_RESET_RECOVER = 60 * 4
 
     _config: BaseRedfishConfig
 
@@ -87,6 +106,71 @@ class RedfishController(NodeController):
         self.redfish_receivers = [RedfishReceiver(host, self._config) for host in self._config.redfish_machines]
         self.nfs_mount = None
         self._node_adapter = None
+
+    @staticmethod
+    def _nfs_server_local():
+        # Assume NFS server enabled on  /tmp/test_images/, return external interface address for nfs mount
+        command = """ip route get 1 | awk '{ printf  $7 }'"""
+        cmd_out, _, _ = utils.run_command(command, shell=True)
+        return cmd_out
+
+    @staticmethod
+    def _is_idrac_state(receiver: RedfishReceiver, states: list) -> bool:
+        try:
+            hostname = receiver.redfish.url.split("/")[2]
+            current_state = receiver.redfish.info()["BootProgress"]["LastState"]
+            log.info(f"Is idrac {hostname} status: {states}| current_state: {current_state}")
+            return current_state in states
+        except Exception as e:
+            log.info(e)
+            return False
+
+    def _stop_idrac_node(self, receiver: RedfishReceiver):
+        receiver.redfish.stop()
+        waiting.wait(
+            lambda: self._is_idrac_state(receiver, ["None", "Node already powered off"]),
+            timeout_seconds=self.IDRAC_WAIT,
+            sleep_seconds=self.IDRAC_RETRY,
+            waiting_for="Stopping IDRAC service",
+        )
+
+    def _start_idrac_node(self, receiver: RedfishReceiver):
+        receiver.redfish.start()
+        waiting.wait(
+            lambda: self._is_idrac_state(receiver, ["OSRunning"]),
+            timeout_seconds=self.IDRAC_WAIT,
+            sleep_seconds=self.IDRAC_RETRY,
+            waiting_for="Starting IDRAC service",
+        )
+
+    def _reset_idrac_node(self, receiver: RedfishReceiver):
+        receiver.redfish.reset()
+        # During reset no connectivity - ~3 minutes restart
+        time.sleep(self.IDRAC_RESET_RECOVER)
+
+        waiting.wait(
+            lambda: self._is_idrac_state(receiver, ["OSRunning"]),
+            timeout_seconds=self.IDRAC_WAIT,
+            sleep_seconds=self.IDRAC_RETRY,
+            waiting_for="Reset IDRAC service",
+        )
+
+    def stop_idrac(self, receivers: list[RedfishReceiver]):
+        for receiver in receivers:
+            self._stop_idrac_node(receiver)
+
+    def reset_idrac(self, receivers: list[RedfishReceiver]):
+        start_threads = []
+        for redfish in receivers:
+            t = threading.Thread(target=self._reset_idrac_node, args=(redfish,))
+            start_threads.append(t)
+            t.start()  # Start immediately so they all run at the same time
+        for t in start_threads:
+            t.join()
+
+    def start_idrac(self, receivers: list[RedfishReceiver]):
+        for receiver in receivers:
+            self._start_idrac_node(receiver)
 
     def list_nodes(self) -> List[Node]:
         if self._node_adapter:
@@ -159,15 +243,23 @@ class RedfishController(NodeController):
         log.info(f"{type(self).__name__} host {host} set mount path {image_path}")
         self.nfs_mount = f"{host}:{image_path}"
 
-    def set_adapter_controller(self, cluster):
-        self._node_adapter = AdapterController(cluster, self._config, self._entity_config)
+    def set_adapter_controller(self, inventory_client: InventoryClient):
+        self._node_adapter = AdapterController(inventory_client, self._config, self._entity_config)
 
     def prepare_nodes(self):
+        if not self.nfs_mount:
+            self.set_nfs_mount_path(self._nfs_server_local(), self._entity_config.iso_download_path)
+
+        # Reset idrac and start from  clean without leftovers - ~3.5 minutes
+        if not self._node_adapter:
+            self.set_adapter_controller(self.inventory_client)
+        self.reset_idrac(self.redfish_receivers)
         for receiver in self.redfish_receivers:
             RedfishEjectIso.execute(receiver)
             # ISO image shared by NFS by default
             RedfishSetIsoOnce.execute(receiver)
             RedfishInsertIso.execute(receiver, self.nfs_mount)
+
         for receiver_restart in self.redfish_receivers:
             RedfishRestart.execute(receiver_restart)
 

--- a/src/assisted_test_infra/test_infra/helper_classes/config/base_redfish_config.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/config/base_redfish_config.py
@@ -10,4 +10,4 @@ class BaseRedfishConfig(BaseNodesConfig, ABC):
     redfish_user: str = None
     redfish_password: str = None
     redfish_machines: List[str] = None
-    redfish_enabled: bool = False
+    redfish_enabled: bool = None

--- a/src/assisted_test_infra/test_infra/helper_classes/entity.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/entity.py
@@ -67,6 +67,7 @@ class Entity(ABC):
         )
 
         self.nodes.controller.log_configuration()
+        self.nodes.controller.inventory_client = self.api_client
 
         if self._config.download_image and not is_static_ip:
             self.download_image()


### PR DESCRIPTION
Current code support running on existing cluster created by UI.

The baremetal nodes are not created by the code , we use adapter wrapper getting info from inventoy client

Change the adpater to accept inventoy_client to support external clusters.

On prepare_network we pass to controller reference to inventoy_client When running commands on created cluster the adapter use inventoy_client to get info.

Added support to redfish controller reset actions and threads When the idrac reset run we clean all leftovers , the reset run in thread. Sometimes the management not stable.

The CI will be resposible to add NFS support for test_images directory and IDEA will use it to access to iso images.

Example:
export REDFISH_ENABLED=True
make deploy_nodes CLUSTER_ID=bb306e89-ebdf-4d59-9a18-db2da96d9b48