### PR TITLE
MGMT-21834: removing the get_cluster_supported_platforms api

### DIFF
--- a/src/assisted_test_infra/test_infra/helper_classes/cluster.py
+++ b/src/assisted_test_infra/test_infra/helper_classes/cluster.py
@@ -1,4 +1,5 @@
 import base64
+import enum
 import json
 import random
 import re
@@ -28,6 +29,32 @@ from assisted_test_infra.test_infra.utils.waiting import (
     wait_till_all_hosts_use_agent_image,
 )
 from service_client import InventoryClient, log
+
+
+def _cluster_is_sno(cluster: models.cluster.Cluster) -> bool:
+    ham = getattr(cluster, "high_availability_mode", None)
+    if ham is not None and isinstance(ham, enum.Enum):
+        ham = ham.value
+    if ham == consts.HighAvailabilityMode.NONE:
+        return True
+    cp = getattr(cluster, "control_plane_count", None)
+    if cp is not None and isinstance(cp, enum.Enum):
+        cp = cp.value
+    if cp is not None:
+        try:
+            if int(cp) == consts.ControlPlaneCount.ONE:
+                return True
+        except (TypeError, ValueError):
+            pass
+    return False
+
+
+def get_supported_cluster_platforms(client: InventoryClient, cluster_id: str) -> List[str]:
+    """Bare-metal CI topology: SNO uses none platform, HA uses baremetal."""
+    cluster = client.cluster_get(cluster_id)
+    if _cluster_is_sno(cluster):
+        return [consts.Platforms.NONE]
+    return [consts.Platforms.BARE_METAL, consts.Platforms.NONE]
 
 
 class Cluster(BaseCluster):
@@ -1001,7 +1028,7 @@ class Cluster(BaseCluster):
         log.debug(f"Nodes for architecture: {self._config.cpu_architecture}")
         super(Cluster, self).prepare_nodes(is_static_ip=self._infra_env_config.is_static_ip, **kwargs)
         platform = self.get_details().platform
-        assert platform.type in self.api_client.get_cluster_supported_platforms(self.id) or (
+        assert platform.type in get_supported_cluster_platforms(self.api_client, self.id) or (
             platform.type == consts.Platforms.EXTERNAL
             and platform.external.platform_name == consts.ExternalPlatformNames.OCI
         )  # required to test against stage/production  # Patch for SNO OCI - currently not supported in the service

--- a/src/service_client/assisted_service_api.py
+++ b/src/service_client/assisted_service_api.py
@@ -641,9 +641,6 @@ class InventoryClient(object):
 
         return dict(api_vips=cluster_info.api_vips, ingress_vips=cluster_info.ingress_vips)
 
-    def get_cluster_supported_platforms(self, cluster_id: str) -> List[str]:
-        return self.client.get_cluster_supported_platforms(cluster_id)
-
     def create_custom_manifest(self, cluster_id: str, folder: str, file_name: str, base64_content: str) -> Manifest:
         params = CreateManifestParams(file_name=file_name, folder=folder, content=base64_content)
         return self.manifest.v2_create_cluster_manifest(cluster_id=cluster_id, create_manifest_params=params)

--- a/src/tests/base_test.py
+++ b/src/tests/base_test.py
@@ -38,7 +38,7 @@ from assisted_test_infra.test_infra.controllers import (
 from assisted_test_infra.test_infra.controllers.node_controllers.kvm_s390x_controller import KVMs390xController
 from assisted_test_infra.test_infra.controllers.node_controllers.libvirt_controller import collect_virsh_logs
 from assisted_test_infra.test_infra.helper_classes import kube_helpers
-from assisted_test_infra.test_infra.helper_classes.cluster import Cluster
+from assisted_test_infra.test_infra.helper_classes.cluster import Cluster, get_supported_cluster_platforms
 from assisted_test_infra.test_infra.helper_classes.config import BaseConfig, BaseNodesConfig
 from assisted_test_infra.test_infra.helper_classes.day2_cluster import Day2Cluster
 from assisted_test_infra.test_infra.helper_classes.events_handler import EventsHandler
@@ -535,7 +535,7 @@ class BaseTest:
             nodes=prepare_nodes_network,
         )
 
-        assert consts.Platforms.NONE in api_client.get_cluster_supported_platforms(cluster.id)
+        assert consts.Platforms.NONE in get_supported_cluster_platforms(api_client, cluster.id)
 
         if self._does_need_proxy_server(prepare_nodes_network):
             self.__set_up_proxy_server(cluster, cluster_configuration, proxy_server)


### PR DESCRIPTION
The generated assisted-service installer client no longer exposes get_cluster_supported_platforms.
The test code now implements get_supported_cluster_platforms(client: InventoryClient, cluster_id: str) instead of the old api function.
The new function in case of HA returns ['baremetal', 'none'] and in case of SNO it returns ['none'].